### PR TITLE
fix(surrealdb): derive SurrealValue on auth/audit/accounts storage types

### DIFF
--- a/acton-service/src/accounts/storage/surrealdb_impl.rs
+++ b/acton-service/src/accounts/storage/surrealdb_impl.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use surrealdb::types::SurrealValue;
 
 use super::AccountStorage;
 use crate::accounts::types::{Account, AccountId, AccountStatus};
@@ -57,7 +58,7 @@ impl SurrealDbAccountStorage {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, SurrealValue)]
 struct AccountRecord {
     email: String,
     username: Option<String>,
@@ -79,7 +80,7 @@ struct AccountRecord {
     updated_at: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, SurrealValue)]
 struct AccountRow {
     id: serde_json::Value,
     email: String,
@@ -118,7 +119,7 @@ fn extract_id(val: &serde_json::Value) -> String {
     match val {
         serde_json::Value::String(s) => {
             // "accounts:acct_xxx" -> "acct_xxx"
-            s.split(':').last().unwrap_or(s).to_string()
+            s.split(':').next_back().unwrap_or(s).to_string()
         }
         serde_json::Value::Object(obj) => obj
             .get("id")
@@ -350,7 +351,7 @@ impl AccountStorage for SurrealDbAccountStorage {
     }
 
     async fn count(&self, status_filter: Option<AccountStatus>) -> Result<u64, Error> {
-        #[derive(Deserialize)]
+        #[derive(Deserialize, SurrealValue)]
         struct CountRow {
             count: i64,
         }

--- a/acton-service/src/audit/storage/surrealdb_impl.rs
+++ b/acton-service/src/audit/storage/surrealdb_impl.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use surrealdb::types::SurrealValue;
 
 use super::AuditStorage;
 use crate::audit::event::{AuditEvent, AuditEventKind, AuditSeverity, AuditSource};
@@ -65,7 +66,7 @@ impl SurrealAuditStorage {
 }
 
 /// Serializable record for SurrealDB insert
-#[derive(Serialize)]
+#[derive(Serialize, SurrealValue)]
 struct AuditRecord {
     id: String,
     timestamp: String,
@@ -87,7 +88,7 @@ struct AuditRecord {
 }
 
 /// Deserializable record from SurrealDB queries
-#[derive(Deserialize)]
+#[derive(Deserialize, SurrealValue)]
 struct AuditRow {
     id: serde_json::Value,
     timestamp: String,
@@ -114,7 +115,7 @@ impl From<AuditRow> for AuditEvent {
         let id_str = match &row.id {
             serde_json::Value::String(s) => {
                 // Handle "audit_events:uuid" format
-                s.split(':').last().unwrap_or(s).to_string()
+                s.split(':').next_back().unwrap_or(s).to_string()
             }
             serde_json::Value::Object(obj) => {
                 // Handle { "tb": "audit_events", "id": { "String": "uuid" } } format
@@ -298,7 +299,7 @@ impl AuditStorage for SurrealAuditStorage {
                 Error::Internal(format!("Failed to count audit events for purge: {}", e))
             })?;
 
-        #[derive(Deserialize)]
+        #[derive(Deserialize, SurrealValue)]
         struct CountRow {
             total: i64,
         }

--- a/acton-service/src/auth/api_keys/mod.rs
+++ b/acton-service/src/auth/api_keys/mod.rs
@@ -21,50 +21,64 @@
 //! }
 //! ```
 
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use chrono::Utc;
+#[cfg(any(feature = "database", feature = "turso"))]
+use chrono::DateTime;
 
 use crate::auth::password::PasswordHasher;
 use crate::error::Error;
 
-/// API key structure
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ApiKey {
-    /// Database ID
-    pub id: String,
+// Inner module isolates the `SurrealValue` trait import the derive needs.
+// Keeping it out of the parent scope prevents `into_value` ambiguity with
+// `libsql::params::IntoValue` in the Turso storage submodule below.
+mod model {
+    use chrono::{DateTime, Utc};
+    use serde::{Deserialize, Serialize};
+    #[cfg(feature = "surrealdb")]
+    use surrealdb::types::SurrealValue;
 
-    /// User/owner ID
-    pub user_id: String,
+    /// API key structure
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[cfg_attr(feature = "surrealdb", derive(SurrealValue))]
+    pub struct ApiKey {
+        /// Database ID
+        pub id: String,
 
-    /// User-provided name for the key
-    pub name: String,
+        /// User/owner ID
+        pub user_id: String,
 
-    /// Key prefix (e.g., "sk_live")
-    pub prefix: String,
+        /// User-provided name for the key
+        pub name: String,
 
-    /// Hashed key value (stored, not the actual key)
-    pub key_hash: String,
+        /// Key prefix (e.g., "sk_live")
+        pub prefix: String,
 
-    /// Allowed scopes/permissions
-    #[serde(default)]
-    pub scopes: Vec<String>,
+        /// Hashed key value (stored, not the actual key)
+        pub key_hash: String,
 
-    /// Rate limit (requests per minute, None = default)
-    pub rate_limit: Option<u32>,
+        /// Allowed scopes/permissions
+        #[serde(default)]
+        pub scopes: Vec<String>,
 
-    /// Whether this key has been revoked
-    #[serde(default)]
-    pub is_revoked: bool,
+        /// Rate limit (requests per minute, None = default)
+        pub rate_limit: Option<u32>,
 
-    /// When this key was last used
-    pub last_used_at: Option<DateTime<Utc>>,
+        /// Whether this key has been revoked
+        #[serde(default)]
+        pub is_revoked: bool,
 
-    /// When this key expires (None = never)
-    pub expires_at: Option<DateTime<Utc>>,
+        /// When this key was last used
+        pub last_used_at: Option<DateTime<Utc>>,
 
-    /// When this key was created
-    pub created_at: DateTime<Utc>,
+        /// When this key expires (None = never)
+        pub expires_at: Option<DateTime<Utc>>,
+
+        /// When this key was created
+        pub created_at: DateTime<Utc>,
+    }
 }
+
+pub use model::ApiKey;
 
 impl ApiKey {
     /// Check if the key is currently valid (not revoked, not expired)

--- a/acton-service/src/auth/key_rotation/storage/surrealdb_impl.rs
+++ b/acton-service/src/auth/key_rotation/storage/surrealdb_impl.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use surrealdb::types::SurrealValue;
 
 use super::KeyRotationStorage;
 use crate::auth::key_rotation::key_metadata::{KeyFormat, KeyStatus, SigningKeyMetadata};
@@ -28,7 +29,7 @@ impl SurrealKeyRotationStorage {
 }
 
 /// Serializable record for SurrealDB inserts
-#[derive(Serialize)]
+#[derive(Serialize, SurrealValue)]
 struct SigningKeyRecord {
     kid: String,
     format: String,
@@ -44,7 +45,7 @@ struct SigningKeyRecord {
 }
 
 /// Deserializable record from SurrealDB queries
-#[derive(Deserialize)]
+#[derive(Deserialize, SurrealValue)]
 struct SigningKeyRow {
     // SurrealDB may return `id` as a Thing or string; we ignore it and use `kid`
     #[allow(dead_code)]
@@ -313,7 +314,7 @@ impl KeyRotationStorage for SurrealKeyRotationStorage {
                 Error::Internal(format!("Failed to count expired draining keys: {}", e))
             })?;
 
-        #[derive(Deserialize)]
+        #[derive(Deserialize, SurrealValue)]
         struct CountRow {
             total: i64,
         }

--- a/acton-service/src/auth/tokens/refresh.rs
+++ b/acton-service/src/auth/tokens/refresh.rs
@@ -5,58 +5,71 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 
-/// Refresh token metadata
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RefreshTokenMetadata {
-    /// User agent string from the request
-    pub user_agent: Option<String>,
+// Inner module isolates the `SurrealValue` trait import the derive needs.
+// Keeping it out of the parent scope prevents `into_value` ambiguity with
+// `libsql::params::IntoValue` in the Turso storage submodule.
+mod model {
+    use chrono::{DateTime, Utc};
+    use serde::{Deserialize, Serialize};
+    #[cfg(feature = "surrealdb")]
+    use surrealdb::types::SurrealValue;
 
-    /// Client IP address
-    pub ip_address: Option<String>,
+    /// Refresh token metadata
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[cfg_attr(feature = "surrealdb", derive(SurrealValue))]
+    pub struct RefreshTokenMetadata {
+        /// User agent string from the request
+        pub user_agent: Option<String>,
 
-    /// Device identifier (for mobile apps)
-    pub device_id: Option<String>,
+        /// Client IP address
+        pub ip_address: Option<String>,
 
-    /// When the token was created
-    pub created_at: DateTime<Utc>,
-}
+        /// Device identifier (for mobile apps)
+        pub device_id: Option<String>,
 
-impl Default for RefreshTokenMetadata {
-    fn default() -> Self {
-        Self {
-            user_agent: None,
-            ip_address: None,
-            device_id: None,
-            created_at: Utc::now(),
+        /// When the token was created
+        pub created_at: DateTime<Utc>,
+    }
+
+    impl Default for RefreshTokenMetadata {
+        fn default() -> Self {
+            Self {
+                user_agent: None,
+                ip_address: None,
+                device_id: None,
+                created_at: Utc::now(),
+            }
         }
+    }
+
+    /// Refresh token data stored in the backend
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[cfg_attr(feature = "surrealdb", derive(SurrealValue))]
+    pub struct RefreshTokenData {
+        /// Token ID (jti)
+        pub token_id: String,
+
+        /// User ID this token belongs to
+        pub user_id: String,
+
+        /// Token family ID for rotation tracking
+        pub family_id: String,
+
+        /// Whether this token has been revoked
+        pub is_revoked: bool,
+
+        /// When this token expires
+        pub expires_at: DateTime<Utc>,
+
+        /// Token metadata
+        pub metadata: RefreshTokenMetadata,
     }
 }
 
-/// Refresh token data stored in the backend
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RefreshTokenData {
-    /// Token ID (jti)
-    pub token_id: String,
-
-    /// User ID this token belongs to
-    pub user_id: String,
-
-    /// Token family ID for rotation tracking
-    pub family_id: String,
-
-    /// Whether this token has been revoked
-    pub is_revoked: bool,
-
-    /// When this token expires
-    pub expires_at: DateTime<Utc>,
-
-    /// Token metadata
-    pub metadata: RefreshTokenMetadata,
-}
+pub use model::{RefreshTokenData, RefreshTokenMetadata};
 
 /// Refresh token storage trait
 ///


### PR DESCRIPTION
## Summary
- Adds `SurrealValue` derive to every struct passed to `IndexedResults::take` or `.bind(("data", record))` in the SurrealDB backends. surrealdb 3.0 requires this trait, so 0.26 fails to build with `audit`/`auth`/`accounts` + `surrealdb`.
- Wraps `ApiKey`, `RefreshTokenData`, and `RefreshTokenMetadata` in private inner modules so the `SurrealValue` import doesn't leak into the Turso (libsql) submodules and collide with `libsql::params::IntoValue::into_value` inside `libsql::params!`.
- Fixes two pre-existing `clippy::double_ended_iterator_last` lints in `audit/storage/surrealdb_impl.rs` and `accounts/storage/surrealdb_impl.rs` that became visible once the surrealdb feature compiled cleanly.

Fixes #9

## Test plan
- [x] `cargo check --no-default-features --features "http,auth,audit,surrealdb,crypto-aws-lc-rs"` (the issue's repro)
- [x] `cargo clippy --features "http,auth,audit,surrealdb,accounts" -- -D warnings`
- [x] `cargo clippy --no-default-features --features "http,auth,database,crypto-aws-lc-rs" -- -D warnings`
- [x] `cargo clippy --no-default-features --features "http,auth,turso,crypto-aws-lc-rs" -- -D warnings`
- [x] `cargo nextest run --features "http,auth,surrealdb,accounts"` → 208 passed
- [x] `cargo nextest run --workspace` (default features) → 100 passed