### PR TITLE
ci: install protoc in Build & Test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -30,6 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy


### PR DESCRIPTION
## Summary
- Both Build & Test matrix jobs fail because `protoc` isn't installed on `ubuntu-latest`. The `acton-service` build script invokes `tonic-prost-build` (gRPC feature), which shells out to `protoc` to compile the bundled `.proto` files.
- Adds `arduino/setup-protoc@v3` right after checkout in both jobs.

## Test plan
- [ ] CI green on this PR