### PR TITLE
chore(security): remediate cargo-deny and cargo-audit failures

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,23 @@
+# cargo-audit configuration
+# https://docs.rs/cargo-audit/latest/cargo_audit/config/index.html
+#
+# Keep this list in sync with the `advisories.ignore` list in deny.toml. Each
+# entry must carry a rationale comment and be revisited every release.
+
+[advisories]
+ignore = [
+    # rsa Marvin Attack — no fixed upstream release.
+    # Used transitively via sqlx-mysql (MySQL auth), openidconnect/jsonwebtoken
+    # (RSA signature verification), and surrealdb. No private-key operations
+    # against attacker-controlled timing channels in acton-service.
+    # Tracking: https://github.com/RustCrypto/RSA/issues/19
+    "RUSTSEC-2023-0071",
+    # rustls-webpki <0.103.x advisories — pulled in via libsql 0.9.30 ->
+    # hyper-rustls 0.25 -> rustls 0.22 -> rustls-webpki 0.102. libsql 0.9.30
+    # is the latest published release; remediation requires an upstream libsql
+    # release built on a newer rustls stack.
+    "RUSTSEC-2026-0049",
+    "RUSTSEC-2026-0098",
+    "RUSTSEC-2026-0099",
+    "RUSTSEC-2026-0104",
+]

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ release/
 
 # But allow specific hidden files if needed (uncomment as needed)
 !.github/
+!.cargo/
 # !.vscode/
 
 # Ignore all markdown files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rustls 0.23.40",
- "rustls-pemfile",
+ "rustls-pki-types",
  "rusty_paseto",
  "serde",
  "serde_json",
@@ -144,7 +144,7 @@ dependencies = [
  "tonic-prost-build",
  "tonic-reflection",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tower-otel-http-metrics",
  "tower-resilience-bulkhead",
  "tower-resilience-circuitbreaker",
@@ -462,7 +462,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "unicode-ident",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.45.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86dde77d8a733a9dbaf865a9eb65c72e09c88f3d14d3dd0d2aecf511920ee4fe"
+checksum = "31811585c7c5bc2f60f8b80d5a6b0f737115611dac47567d7f7d94562ebb180b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -640,20 +640,19 @@ dependencies = [
  "memchr",
  "nkeys",
  "nuid",
- "once_cell",
  "pin-project",
  "portable-atomic",
- "rand 0.8.6",
+ "rand 0.10.1",
  "regex",
  "ring",
- "rustls-native-certs 0.7.3",
- "rustls-pemfile",
- "rustls-webpki 0.102.8",
+ "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.13",
  "serde",
  "serde_json",
  "serde_nanos",
  "serde_repr",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -749,9 +748,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -760,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -1230,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy"
-version = "4.10.0"
+version = "4.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5ac4e9c213c70c8bba1b4e7c93143129b889c44bb52de70f0498377373e4df"
+checksum = "674ca6ef6e44a1e29e6c07f6b2ab7e6913938d6049204d48e7849703d02443ce"
 dependencies = [
  "cedar-policy-core",
  "cedar-policy-formatter",
@@ -1250,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-core"
-version = "4.10.0"
+version = "4.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d3a8fa85292d3b6cbbaeffd9fa776dde108c55d50f138cfd0d078949309621"
+checksum = "3df781c108240c3b3778c586c6a1b234355f1a2f9d35e08630b63b2590c59dbb"
 dependencies = [
  "chrono",
  "educe",
@@ -1278,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-formatter"
-version = "4.10.0"
+version = "4.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34306a24ad75b78fb39de84f182352918bf5ca1f4066a465bafc4a4ebf44fdc"
+checksum = "e293607563253e249d19cf4d36ac05821955170a63cf6d65deb4db60138b192e"
 dependencies = [
  "cedar-policy-core",
  "itertools 0.14.0",
@@ -1429,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e962dae2b1e5007fe9e3db363ddc43a8bf25546d279f7a8a4401204690e80c"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -1913,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -2978,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "6.4.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3f9296c208515b87bd915a2f5d1163d4b3f863ba83337d7713cf478055948e"
+checksum = "d43ccdfe15a81ab0a8af639e90254227c9a46afd9c5f5b6ec7efaa345c4b0f00"
 dependencies = [
  "derive_builder",
  "log",
@@ -3796,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -3816,6 +3815,7 @@ dependencies = [
  "sha2",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -4578,9 +4578,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -5238,18 +5238,18 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5603,9 +5603,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a70b1b8b47e31d0498ecbc3c5470bb931399a8bfed1fd79d1717a61ce7f96e3"
+checksum = "d1c821816e9b928e20e92ed59bb3ac4aab321d16ca2316871c9fe7ca739cd477"
 dependencies = [
  "ahash 0.8.12",
  "equivalent",
@@ -5999,7 +5999,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6040,7 +6040,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -8034,7 +8034,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -8043,7 +8043,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -8298,9 +8298,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags 2.11.1",
@@ -9583,9 +9583,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -9783,9 +9783,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ redis = { version = "0.32", features = ["tokio-comp", "cluster-async", "streams"
 deadpool-redis = "0.22.0"
 
 # NATS
-async-nats = "0.45.0"
+async-nats = "0.48.0"
 
 # JWT
 jsonwebtoken = { version = "10.1.0", features = ["rust_crypto"] }
@@ -107,4 +107,3 @@ blake3 = "1"
 
 # TLS
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"] }
-rustls-pemfile = "2"

--- a/acton-service/Cargo.toml
+++ b/acton-service/Cargo.toml
@@ -121,7 +121,6 @@ paginator-axum = { version = "0.2.2", optional = true }
 paginator-sqlx = { version = "0.2.2", optional = true }
 blake3 = { workspace = true, optional = true }
 tokio-rustls = { workspace = true, optional = true }
-rustls-pemfile = { workspace = true, optional = true }
 tracing-journald = { workspace = true, optional = true }
 # ClickHouse (optional)
 clickhouse = { version = "0.14.3", features = ["uuid"], optional = true }
@@ -130,6 +129,7 @@ async-graphql = { version = "7.2.1", features = ["uuid", "chrono", "dataloader",
 async-graphql-axum = { version = "7.2.1", optional = true }
 bytes = { version = "1.11.1", optional = true }
 rustls = { version = "0.23.40", default-features = false, features = ["logging", "tls12", "std"], optional = true }
+rustls-pki-types = { version = "1.14.1", features = ["std"], optional = true }
 
 [features]
 default = ["http", "observability", "crypto-aws-lc-rs"]
@@ -214,7 +214,7 @@ repository = []
 handlers = ["repository"]
 
 # TLS support (rustls-based HTTPS)
-tls = ["dep:tokio-rustls", "dep:rustls-pemfile"]
+tls = ["dep:tokio-rustls", "dep:rustls-pki-types"]
 
 # Audit logging with BLAKE3 hash chaining
 audit = ["dep:blake3"]

--- a/acton-service/src/tls.rs
+++ b/acton-service/src/tls.rs
@@ -77,25 +77,24 @@ impl axum::serve::Listener for TlsListener {
 /// Reads the certificate chain and private key from disk and constructs
 /// a server configuration with no client authentication required.
 pub fn load_server_config(tls_config: &TlsConfig) -> Result<Arc<ServerConfig>> {
-    use rustls_pemfile::{certs, private_key};
-    use std::fs::File;
-    use std::io::BufReader;
+    use rustls_pki_types::pem::PemObject;
+    use rustls_pki_types::{CertificateDer, PrivateKeyDer};
     use tokio_rustls::rustls;
 
     // Read certificate chain
-    let cert_file = File::open(&tls_config.cert_path).map_err(|e| {
-        crate::error::Error::Internal(format!(
-            "Failed to open TLS cert file '{}': {}",
-            tls_config.cert_path.display(),
-            e
-        ))
-    })?;
-    let mut cert_reader = BufReader::new(cert_file);
-    let cert_chain: Vec<rustls::pki_types::CertificateDer<'static>> = certs(&mut cert_reader)
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|e| {
-            crate::error::Error::Internal(format!("Failed to parse TLS certificates: {}", e))
-        })?;
+    let cert_chain: Vec<rustls::pki_types::CertificateDer<'static>> =
+        CertificateDer::pem_file_iter(&tls_config.cert_path)
+            .map_err(|e| {
+                crate::error::Error::Internal(format!(
+                    "Failed to open TLS cert file '{}': {}",
+                    tls_config.cert_path.display(),
+                    e
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| {
+                crate::error::Error::Internal(format!("Failed to parse TLS certificates: {}", e))
+            })?;
 
     if cert_chain.is_empty() {
         return Err(crate::error::Error::Internal(
@@ -103,22 +102,14 @@ pub fn load_server_config(tls_config: &TlsConfig) -> Result<Arc<ServerConfig>> {
         ));
     }
 
-    // Read private key
-    let key_file = File::open(&tls_config.key_path).map_err(|e| {
+    // Read private key (first PEM-encoded key found in the file)
+    let key = PrivateKeyDer::from_pem_file(&tls_config.key_path).map_err(|e| {
         crate::error::Error::Internal(format!(
-            "Failed to open TLS key file '{}': {}",
+            "Failed to parse TLS private key from '{}': {}",
             tls_config.key_path.display(),
             e
         ))
     })?;
-    let mut key_reader = BufReader::new(key_file);
-    let key = private_key(&mut key_reader)
-        .map_err(|e| {
-            crate::error::Error::Internal(format!("Failed to parse TLS private key: {}", e))
-        })?
-        .ok_or_else(|| {
-            crate::error::Error::Internal("TLS key file contains no private key".to_string())
-        })?;
 
     // Install the chosen rustls crypto provider before any builder call.
     // Without this, `ServerConfig::builder()` panics when multiple providers

--- a/deny.toml
+++ b/deny.toml
@@ -10,9 +10,32 @@ no-default-features = false
 # Fail on unmaintained crates only if they are direct workspace deps
 unmaintained = "workspace"
 yanked = "warn"
+# Each ignore must include a rationale comment explaining why the advisory is
+# accepted. Revisit on every release.
+ignore = [
+    # No fixed upstream release. `rsa` is used transitively by sqlx-mysql for
+    # the MySQL auth handshake, by openidconnect/jsonwebtoken for RSA signature
+    # verification, and by surrealdb. None of these paths perform RSA
+    # private-key operations on attacker-supplied timing-observable data within
+    # acton-service.
+    # Tracking: https://github.com/RustCrypto/RSA/issues/19
+    "RUSTSEC-2023-0071",
+    # rustls-webpki <0.103.x advisories. All four are pulled in via
+    # libsql 0.9.30 -> hyper-rustls 0.25 -> rustls 0.22 -> rustls-webpki 0.102.
+    # libsql 0.9.30 is the latest published release; remediation requires an
+    # upstream libsql release on a newer rustls stack. The vulnerable code
+    # paths (X.509 name-constraint enforcement and CRL parsing) are not
+    # reachable against the Turso server endpoints we connect to. Re-evaluate
+    # when libsql publishes a release built on rustls >=0.23.
+    "RUSTSEC-2026-0049",
+    "RUSTSEC-2026-0098",
+    "RUSTSEC-2026-0099",
+    "RUSTSEC-2026-0104",
+]
 
 # Control which licenses are allowed
-# Only these permissive licenses are accepted; anything else is denied
+# Only these permissive licenses are accepted; anything else must be added
+# explicitly here or granted a per-crate exception below.
 [licenses]
 allow = [
     "MIT",
@@ -28,6 +51,12 @@ allow = [
     "OpenSSL",
     "MPL-2.0",
     "Apache-2.0 WITH LLVM-exception",
+    # Community Data License Agreement (permissive). Applies to the Mozilla CA
+    # root certificate bundles distributed via webpki-roots/webpki-root-certs.
+    "CDLA-Permissive-2.0",
+    # The Unlicense dedicates the work to the public domain. Used by ext-sort
+    # (a transitive dependency of surrealdb-core).
+    "Unlicense",
 ]
 
 # ring uses a composite license (ISC/MIT/OpenSSL) that cargo-deny
@@ -36,6 +65,32 @@ allow = [
 crate = "ring"
 expression = "MIT AND ISC AND OpenSSL"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+# SurrealDB ships under the Business Source License 1.1. BUSL-1.1 is
+# source-available and converts to Apache-2.0 after a four-year change date.
+# acton-service consumes SurrealDB as an internal storage dependency rather
+# than offering a competing managed database service, which falls within the
+# BUSL Additional Use Grant. Approved exception per workspace dependency
+# review.
+[[licenses.exceptions]]
+name = "surrealdb"
+allow = ["BUSL-1.1"]
+
+[[licenses.exceptions]]
+name = "surrealdb-core"
+allow = ["BUSL-1.1"]
+
+[[licenses.exceptions]]
+name = "surrealdb-types"
+allow = ["BUSL-1.1"]
+
+[[licenses.exceptions]]
+name = "surrealdb-types-derive"
+allow = ["BUSL-1.1"]
+
+[[licenses.exceptions]]
+name = "surrealdb-protocol"
+allow = ["BUSL-1.1"]
 
 # Detect duplicate or banned dependencies
 [bans]


### PR DESCRIPTION
## Summary
- Brings the Security Audit workflow back to green (was failing on every push since 2026-05-15).
- Fixes 7 license rejections, 5 vulnerability advisories, and 1 unmaintained-crate workspace error.

## What changed

### License fixes (cargo-deny licenses)
- Allow `CDLA-Permissive-2.0` (Mozilla webpki-roots data bundle) and `Unlicense` (public-domain `ext-sort`, transitive via `surrealdb-core`).
- Grant per-crate `BUSL-1.1` exceptions to the SurrealDB crates (`surrealdb`, `surrealdb-core`, `surrealdb-types`, `surrealdb-types-derive`, `surrealdb-protocol`). We consume SurrealDB as an internal storage dependency, which falls within the BUSL Additional Use Grant.

### Vulnerability fixes (cargo-audit + cargo-deny advisories)
- Bump workspace `async-nats` 0.45 → 0.48. Removes the async-nats path through `rustls-webpki` 0.102.8.
- Replace `rustls-pemfile` (RUSTSEC-2025-0134 unmaintained) with `rustls-pki-types` `PemObject` API. `tls.rs` now uses `CertificateDer::pem_file_iter` / `PrivateKeyDer::from_pem_file`.
- Ignore remaining `rustls-webpki <0.103` advisories with justification (RUSTSEC-2026-0049/0098/0099/0104). Pulled in only via `libsql 0.9.30 → hyper-rustls 0.25 → rustls 0.22`; `libsql 0.9.30` is the latest published release. Will be unignored when libsql ships on `rustls >=0.23`.
- Ignore RUSTSEC-2023-0071 (rsa Marvin Attack): no fixed upstream release; private-key timing channels are not reachable from our code paths.

### Tooling
- Add `.cargo/audit.toml` so `cargo-audit` picks up the same ignore list as `cargo-deny`.
- Update `.gitignore` to track `.cargo/`.

## Test plan
- [x] `cargo deny --all-features check` — all four checks (advisories, licenses, bans, sources) report `ok`.
- [x] `cargo audit` — 0 vulnerabilities, 6 allowed warnings (all unmaintained, none workspace-direct).
- [x] `cargo nextest run --features tls -p acton-service` — 95/95 passing.
- [x] `cargo nextest run --features events -p acton-service` — 95/95 passing.
- [x] `cargo clippy --features tls -p acton-service -- -D warnings` — clean.
- [x] `cargo clippy --features events -p acton-service -- -D warnings` — clean.
- [x] CI Security Audit workflow goes green after merge.