### PR TITLE
fix(audit): stop emitting auth.login.failed for unauthenticated requests

### DIFF
--- a/acton-service/src/audit/event.rs
+++ b/acton-service/src/audit/event.rs
@@ -101,7 +101,17 @@ pub enum AuditEventKind {
     /// Successful authentication
     AuthLoginSuccess,
     /// Failed authentication attempt
+    ///
+    /// Reserved for credential-submission failures from application login
+    /// handlers (e.g. `/auth/login`). The auth middleware no longer emits
+    /// this kind for missing or invalid bearer tokens on protected routes —
+    /// see [`Self::AuthTokenMissing`] and [`Self::AuthTokenInvalid`].
     AuthLoginFailed,
+    /// Protected route reached without a bearer token, or with one that was
+    /// malformed at extraction time
+    AuthTokenMissing,
+    /// Bearer token failed validation (bad signature, expired, malformed claims)
+    AuthTokenInvalid,
     /// User logout
     AuthLogout,
     /// Token refresh
@@ -171,6 +181,8 @@ impl std::fmt::Display for AuditEventKind {
         match self {
             Self::AuthLoginSuccess => write!(f, "auth.login.success"),
             Self::AuthLoginFailed => write!(f, "auth.login.failed"),
+            Self::AuthTokenMissing => write!(f, "auth.token.missing"),
+            Self::AuthTokenInvalid => write!(f, "auth.token.invalid"),
             Self::AuthLogout => write!(f, "auth.logout"),
             Self::AuthTokenRefresh => write!(f, "auth.token.refresh"),
             Self::AuthTokenRevoked => write!(f, "auth.token.revoked"),

--- a/acton-service/src/audit/storage/clickhouse_impl.rs
+++ b/acton-service/src/audit/storage/clickhouse_impl.rs
@@ -139,6 +139,8 @@ impl From<AuditQueryRow> for AuditEvent {
         let kind = match row.kind.as_str() {
             "auth.login.success" => AuditEventKind::AuthLoginSuccess,
             "auth.login.failed" => AuditEventKind::AuthLoginFailed,
+            "auth.token.missing" => AuditEventKind::AuthTokenMissing,
+            "auth.token.invalid" => AuditEventKind::AuthTokenInvalid,
             "auth.logout" => AuditEventKind::AuthLogout,
             "auth.token.refresh" => AuditEventKind::AuthTokenRefresh,
             "auth.token.revoked" => AuditEventKind::AuthTokenRevoked,

--- a/acton-service/src/audit/storage/pg.rs
+++ b/acton-service/src/audit/storage/pg.rs
@@ -268,6 +268,8 @@ impl From<AuditEventRow> for AuditEvent {
         let kind = match row.kind.as_str() {
             "auth.login.success" => AuditEventKind::AuthLoginSuccess,
             "auth.login.failed" => AuditEventKind::AuthLoginFailed,
+            "auth.token.missing" => AuditEventKind::AuthTokenMissing,
+            "auth.token.invalid" => AuditEventKind::AuthTokenInvalid,
             "auth.logout" => AuditEventKind::AuthLogout,
             "auth.token.refresh" => AuditEventKind::AuthTokenRefresh,
             "auth.token.revoked" => AuditEventKind::AuthTokenRevoked,

--- a/acton-service/src/audit/storage/surrealdb_impl.rs
+++ b/acton-service/src/audit/storage/surrealdb_impl.rs
@@ -369,6 +369,8 @@ fn parse_event_kind(s: &str) -> AuditEventKind {
     match s {
         "auth.login.success" => AuditEventKind::AuthLoginSuccess,
         "auth.login.failed" => AuditEventKind::AuthLoginFailed,
+        "auth.token.missing" => AuditEventKind::AuthTokenMissing,
+        "auth.token.invalid" => AuditEventKind::AuthTokenInvalid,
         "auth.logout" => AuditEventKind::AuthLogout,
         "auth.token.refresh" => AuditEventKind::AuthTokenRefresh,
         "auth.token.revoked" => AuditEventKind::AuthTokenRevoked,

--- a/acton-service/src/audit/storage/turso.rs
+++ b/acton-service/src/audit/storage/turso.rs
@@ -361,6 +361,8 @@ fn parse_event_kind(s: &str) -> AuditEventKind {
     match s {
         "auth.login.success" => AuditEventKind::AuthLoginSuccess,
         "auth.login.failed" => AuditEventKind::AuthLoginFailed,
+        "auth.token.missing" => AuditEventKind::AuthTokenMissing,
+        "auth.token.invalid" => AuditEventKind::AuthTokenInvalid,
         "auth.logout" => AuditEventKind::AuthLogout,
         "auth.token.refresh" => AuditEventKind::AuthTokenRefresh,
         "auth.token.revoked" => AuditEventKind::AuthTokenRevoked,

--- a/acton-service/src/middleware/jwt.rs
+++ b/acton-service/src/middleware/jwt.rs
@@ -202,8 +202,8 @@ impl JwtAuth {
                     if logger.config().audit_auth_events {
                         logger
                             .log_auth(
-                                crate::audit::event::AuditEventKind::AuthLoginFailed,
-                                crate::audit::event::AuditSeverity::Warning,
+                                crate::audit::event::AuditEventKind::AuthTokenMissing,
+                                crate::audit::event::AuditSeverity::Informational,
                                 audit_source,
                             )
                             .await;
@@ -222,7 +222,7 @@ impl JwtAuth {
                     if logger.config().audit_auth_events {
                         logger
                             .log_auth(
-                                crate::audit::event::AuditEventKind::AuthLoginFailed,
+                                crate::audit::event::AuditEventKind::AuthTokenInvalid,
                                 crate::audit::event::AuditSeverity::Warning,
                                 audit_source,
                             )

--- a/acton-service/src/middleware/paseto.rs
+++ b/acton-service/src/middleware/paseto.rs
@@ -215,8 +215,8 @@ impl PasetoAuth {
                     if logger.config().audit_auth_events {
                         logger
                             .log_auth(
-                                crate::audit::event::AuditEventKind::AuthLoginFailed,
-                                crate::audit::event::AuditSeverity::Warning,
+                                crate::audit::event::AuditEventKind::AuthTokenMissing,
+                                crate::audit::event::AuditSeverity::Informational,
                                 audit_source,
                             )
                             .await;
@@ -235,7 +235,7 @@ impl PasetoAuth {
                     if logger.config().audit_auth_events {
                         logger
                             .log_auth(
-                                crate::audit::event::AuditEventKind::AuthLoginFailed,
+                                crate::audit::event::AuditEventKind::AuthTokenInvalid,
                                 crate::audit::event::AuditSeverity::Warning,
                                 audit_source,
                             )


### PR DESCRIPTION
## Summary

- Adds `AuthTokenMissing` (Informational) and `AuthTokenInvalid` (Warning) variants to `AuditEventKind`.
- Repoints the four middleware emission sites in `paseto.rs` and `jwt.rs` to use them instead of `AuthLoginFailed`.
- Reserves `AuthLoginFailed` for application credential-submission failures (e.g. `/auth/login` handlers); doc comment updated.
- Teaches the Postgres, ClickHouse, Turso, and SurrealDB storage backends to round-trip the new event-kind strings.

Closes #13.

## Why

The middleware fired `auth.login.failed` for every request that arrived without a valid bearer token — including unauthenticated health checks. A downstream report showed ~5,758 false-positive `auth.login.failed` events per day from ALB health checks (vs. 4 real logins), drowning out real signal for SIEM rules and security monitoring.

The new variants let operators filter health-check-shaped noise (`auth.token.missing`) separately from credential failures (`auth.login.failed`) and presented-but-bad tokens (`auth.token.invalid`).

## Breaking change

Removes `auth.login.failed` from the middleware's emission set. Downstream SIEM rules keyed on `auth.login.failed` from acton-service alone will go quiet for the unauthenticated-request case (the goal). App-level login handlers continue to emit it correctly. Worth a minor-version bump (0.27.0) given the observable behavior change.

## Out of scope

- Reordering middleware so `AuditSource` is populated before auth runs (so `ip`/`request_id` are no longer blank in token-failure events). Bigger refactor; deferred — see issue #13 item (3).
- A config knob like `audit_token_failures: bool` to silence token-missing entirely. Easy follow-up if the new `Informational` level isn't filtered enough.

## Test plan

- [x] `cargo clippy -p acton-service --all-targets --features full -- -D warnings` — clean
- [x] `cargo clippy -p acton-service --all-targets --no-default-features --features "full,crypto-ring" -- -D warnings` — clean
- [x] `cargo nextest run -p acton-service --features full` — 520/520 pass
- [ ] Downstream verify in schemaforge (Govcraft/schemaforge-dev#66) after bump