### PR TITLE
fix(audit): emit AuthPermissionDenied, HttpRequestDenied, AuthPasswordChanged

### DIFF
--- a/acton-service/src/accounts/mod.rs
+++ b/acton-service/src/accounts/mod.rs
@@ -712,11 +712,10 @@ mod audit_integration {
                     }),
                 ),
                 AccountEvent::PasswordChanged { ref account_id } => (
-                    AuditEventKind::AccountUpdated,
-                    AuditSeverity::Informational,
+                    AuditEventKind::AuthPasswordChanged,
+                    AuditSeverity::Notice,
                     serde_json::json!({
                         "account_id": account_id,
-                        "action": "password_changed",
                     }),
                 ),
                 AccountEvent::RolesUpdated {

--- a/acton-service/src/middleware/cedar.rs
+++ b/acton-service/src/middleware/cedar.rs
@@ -332,6 +332,35 @@ impl CedarAuthz {
             })?
             .clone();
 
+        #[cfg(feature = "audit")]
+        let audit_logger = request
+            .extensions()
+            .get::<crate::audit::AuditLogger>()
+            .cloned();
+        #[cfg(feature = "audit")]
+        let audit_source = {
+            use crate::audit::event::AuditSource;
+            AuditSource {
+                ip: request
+                    .headers()
+                    .get("x-forwarded-for")
+                    .or_else(|| request.headers().get("x-real-ip"))
+                    .and_then(|v| v.to_str().ok())
+                    .map(|s| s.split(',').next().unwrap_or(s).trim().to_string()),
+                user_agent: request
+                    .headers()
+                    .get("user-agent")
+                    .and_then(|v| v.to_str().ok())
+                    .map(String::from),
+                subject: Some(claims.sub.clone()),
+                request_id: request
+                    .headers()
+                    .get("x-request-id")
+                    .and_then(|v| v.to_str().ok())
+                    .map(String::from),
+            }
+        };
+
         // Extract request information
         let method = request.method().clone();
 
@@ -346,7 +375,21 @@ impl CedarAuthz {
             .await?
         {
             Decision::Allow => Ok(next.run(request).await),
-            Decision::Deny => Err(Error::Forbidden("Access denied by policy".to_string())),
+            Decision::Deny => {
+                #[cfg(feature = "audit")]
+                if let Some(ref logger) = audit_logger {
+                    if logger.config().audit_auth_events {
+                        logger
+                            .log_auth(
+                                crate::audit::event::AuditEventKind::AuthPermissionDenied,
+                                crate::audit::event::AuditSeverity::Warning,
+                                audit_source,
+                            )
+                            .await;
+                    }
+                }
+                Err(Error::Forbidden("Access denied by policy".to_string()))
+            }
         }
     }
 
@@ -751,6 +794,12 @@ where
                 })?
                 .clone();
 
+            #[cfg(feature = "audit")]
+            let audit_logger = req
+                .extensions()
+                .get::<crate::audit::AuditLogger>()
+                .cloned();
+
             // Extract gRPC method path from metadata
             let method_path = req
                 .metadata()
@@ -786,6 +835,33 @@ where
                         method = %method_path,
                         "Cedar policy denied gRPC request"
                     );
+                    #[cfg(feature = "audit")]
+                    if let Some(ref logger) = audit_logger {
+                        if logger.config().audit_auth_events {
+                            use crate::audit::event::AuditSource;
+                            let source = AuditSource {
+                                ip: None,
+                                user_agent: req
+                                    .metadata()
+                                    .get("user-agent")
+                                    .and_then(|v| v.to_str().ok())
+                                    .map(String::from),
+                                subject: Some(claims.sub.clone()),
+                                request_id: req
+                                    .metadata()
+                                    .get("x-request-id")
+                                    .and_then(|v| v.to_str().ok())
+                                    .map(String::from),
+                            };
+                            logger
+                                .log_auth(
+                                    crate::audit::event::AuditEventKind::AuthPermissionDenied,
+                                    crate::audit::event::AuditSeverity::Warning,
+                                    source,
+                                )
+                                .await;
+                        }
+                    }
                     Err(Status::permission_denied("Access denied by policy"))
                 }
             }

--- a/acton-service/src/middleware/rate_limit.rs
+++ b/acton-service/src/middleware/rate_limit.rs
@@ -94,14 +94,63 @@ impl RateLimit {
     ) -> Result<Response, Error> {
         #[cfg(feature = "cache")]
         {
-            let method = request.method().as_str();
-            let path = request.uri().path();
+            let method = request.method().as_str().to_string();
+            let path = request.uri().path().to_string();
             let claims = request.extensions().get::<Claims>().cloned();
 
+            #[cfg(feature = "audit")]
+            let audit_logger = request
+                .extensions()
+                .get::<crate::audit::AuditLogger>()
+                .cloned();
+            #[cfg(feature = "audit")]
+            let audit_source = {
+                use crate::audit::event::AuditSource;
+                AuditSource {
+                    ip: request
+                        .headers()
+                        .get("x-forwarded-for")
+                        .or_else(|| request.headers().get("x-real-ip"))
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.split(',').next().unwrap_or(s).trim().to_string()),
+                    user_agent: request
+                        .headers()
+                        .get("user-agent")
+                        .and_then(|v| v.to_str().ok())
+                        .map(String::from),
+                    subject: claims.as_ref().map(|c| c.sub.clone()),
+                    request_id: request
+                        .headers()
+                        .get("x-request-id")
+                        .and_then(|v| v.to_str().ok())
+                        .map(String::from),
+                }
+            };
+
             // Check rate limit and get result for headers
-            let result = rate_limit
-                .check_rate_limit_with_route(method, path, claims.as_ref())
-                .await?;
+            let result = match rate_limit
+                .check_rate_limit_with_route(&method, &path, claims.as_ref())
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    #[cfg(feature = "audit")]
+                    if matches!(e, Error::RateLimitExceeded) {
+                        if let Some(ref logger) = audit_logger {
+                            if logger.config().audit_auth_events {
+                                logger
+                                    .log_auth(
+                                        crate::audit::event::AuditEventKind::HttpRequestDenied,
+                                        crate::audit::event::AuditSeverity::Warning,
+                                        audit_source,
+                                    )
+                                    .await;
+                            }
+                        }
+                    }
+                    return Err(e);
+                }
+            };
 
             // Run the request
             let mut response = next.run(request).await;


### PR DESCRIPTION
## Summary

Closes Tier 1 of #16. Three `AuditEventKind` variants were declared as public API and listed in every storage parser but had no emission site in the framework. Downstream apps that rely on the framework for an audit trail got silent gaps for Cedar policy denials, rate-limit rejections, and password changes. This PR fills them in at the places where the framework already owns the code and has the `AuditLogger` in scope.

## Changes

### `AuthPermissionDenied`

- **HTTP** (`middleware/cedar.rs`) — emit on `Decision::Deny` with a populated `AuditSource` (IP from X-Forwarded-For / X-Real-IP, user-agent, subject from JWT claims, request-id). Severity: `Warning`.
- **gRPC** (`middleware/cedar.rs`) — emit on `Decision::Deny` with subject + UA + request-id from gRPC metadata. gRPC has no peer IP at this layer; `ip` stays `None`. Severity: `Warning`.

### `HttpRequestDenied`

- `middleware/rate_limit.rs` — emit when `check_rate_limit_with_route` returns `Error::RateLimitExceeded`. Other error variants (Redis down, etc.) are not audit-worthy and don't emit. Severity: `Warning`.

### `AuthPasswordChanged`

- `accounts/mod.rs` — `AuditAccountNotification` was coarsely mapping `AccountEvent::PasswordChanged` to `AuditEventKind::AccountUpdated` with `action: "password_changed"` metadata. Remapped to the dedicated `AuthPasswordChanged` kind at `Notice` severity. Downstream consumers parsing the kind now get a distinct, security-relevant event instead of having to inspect metadata.

## Breaking change

The `AccountUpdated` event with `action: "password_changed"` no longer fires. Downstream SIEM rules keyed on that combination need to switch to `auth.password.changed`. Justifies a minor-version bump.

## Out of scope (tracked under #16)

- **Tier 2** — `AuthApiKeyCreated`, `AuthApiKeyRevoked`, `AuthTokenRefresh` — these live behind storage traits (`ApiKeyStorage`, `RefreshTokenStorage`) that don't carry an `AuditLogger`. Needs a notification-handler pattern like `AuditAccountNotification` for each, wired through all four backends.
- **Tier 3** — `AuthLogout`, `AuthOAuthCallback` — `AuthSession::logout()` is sync and has no path to the `AuditLogger`; the OAuth callback path isn't owned by the framework. Both need design decisions before implementation.

## Test plan

- [x] `cargo clippy -p acton-service --all-targets --features full -- -D warnings` — clean
- [x] `cargo clippy -p acton-service --all-targets --no-default-features --features "full,crypto-ring" -- -D warnings` — clean
- [x] `cargo nextest run -p acton-service --features full` — 520/520 pass
- [ ] Verify downstream (schemaforge) sees the three new event kinds reach storage and roll up correctly in SIEM dashboards.