### PR TITLE
fix(audit): align AccountExpired/Deleted severities; bump AuthLoginSuccess to Notice

### DIFF
--- a/acton-service/src/accounts/mod.rs
+++ b/acton-service/src/accounts/mod.rs
@@ -695,7 +695,7 @@ mod audit_integration {
                 ),
                 AccountEvent::Expired { ref account_id } => (
                     AuditEventKind::AccountExpired,
-                    AuditSeverity::Notice,
+                    AuditSeverity::Warning,
                     serde_json::json!({ "account_id": account_id }),
                 ),
                 AccountEvent::Deleted { ref account_id } => (

--- a/acton-service/src/middleware/jwt.rs
+++ b/acton-service/src/middleware/jwt.rs
@@ -270,7 +270,7 @@ impl JwtAuth {
                 logger
                     .log_auth(
                         crate::audit::event::AuditEventKind::AuthLoginSuccess,
-                        crate::audit::event::AuditSeverity::Informational,
+                        crate::audit::event::AuditSeverity::Notice,
                         source,
                     )
                     .await;

--- a/acton-service/src/middleware/paseto.rs
+++ b/acton-service/src/middleware/paseto.rs
@@ -283,7 +283,7 @@ impl PasetoAuth {
                 logger
                     .log_auth(
                         crate::audit::event::AuditEventKind::AuthLoginSuccess,
-                        crate::audit::event::AuditSeverity::Informational,
+                        crate::audit::event::AuditSeverity::Notice,
                         source,
                     )
                     .await;


### PR DESCRIPTION
## Summary

Two severity inconsistencies from #19.

- `AccountExpired` was emitted at `Notice` while `AccountDeleted` (a parallel terminal account state) was emitted at `Warning`. Operators wiring an "any final-state account event" alert had to remember which kind carried which level. Aligned `AccountExpired` to `Warning`.
- `AuthLoginSuccess` was emitted at `Informational` (syslog 6), a level most production log pipelines suppress by default. Failures fire at `Warning`, so the success/failure ratio that drives many login-anomaly alerts had a silently empty numerator unless operators specifically lowered their threshold. Bumped to `Notice` (syslog 5) to match account-unlock and key-rotation choices.

Closes #19.

## Breaking-ish

Severity levels are observable to downstream alerting. Downstream filters keyed on the old levels need recalibration. Call out in release notes.

## Test plan

- [x] `cargo clippy -p acton-service --all-targets --features full -- -D warnings` — clean
- [x] `cargo clippy -p acton-service --all-targets --no-default-features --features "full,crypto-ring" -- -D warnings` — clean
- [x] `cargo nextest run -p acton-service --features full` — 520/520 pass