### PR TITLE
fix(audit): attach jti to AuthTokenRevoked event metadata

### DIFF
--- a/acton-service/src/middleware/jwt.rs
+++ b/acton-service/src/middleware/jwt.rs
@@ -243,13 +243,14 @@ impl JwtAuth {
                         if logger.config().audit_auth_events {
                             let mut source = audit_source.clone();
                             source.subject = Some(claims.sub.clone());
-                            logger
-                                .log_auth(
-                                    crate::audit::event::AuditEventKind::AuthTokenRevoked,
-                                    crate::audit::event::AuditSeverity::Warning,
-                                    source,
-                                )
-                                .await;
+                            let event = crate::audit::event::AuditEvent::new(
+                                crate::audit::event::AuditEventKind::AuthTokenRevoked,
+                                crate::audit::event::AuditSeverity::Warning,
+                                logger.service_name().to_string(),
+                            )
+                            .with_source(source)
+                            .with_metadata(serde_json::json!({ "jti": jti }));
+                            logger.log(event).await;
                         }
                     }
                     return Err(Error::Unauthorized("Token has been revoked".to_string()));

--- a/acton-service/src/middleware/paseto.rs
+++ b/acton-service/src/middleware/paseto.rs
@@ -256,13 +256,14 @@ impl PasetoAuth {
                         if logger.config().audit_auth_events {
                             let mut source = audit_source.clone();
                             source.subject = Some(claims.sub.clone());
-                            logger
-                                .log_auth(
-                                    crate::audit::event::AuditEventKind::AuthTokenRevoked,
-                                    crate::audit::event::AuditSeverity::Warning,
-                                    source,
-                                )
-                                .await;
+                            let event = crate::audit::event::AuditEvent::new(
+                                crate::audit::event::AuditEventKind::AuthTokenRevoked,
+                                crate::audit::event::AuditSeverity::Warning,
+                                logger.service_name().to_string(),
+                            )
+                            .with_source(source)
+                            .with_metadata(serde_json::json!({ "jti": jti }));
+                            logger.log(event).await;
                         }
                     }
                     return Err(Error::Unauthorized("Token has been revoked".to_string()));


### PR DESCRIPTION
## Summary

The PASETO and JWT auth middlewares emit `AuthTokenRevoked` when a revoked token is presented, but only attach `source.subject`. The JTI of the revoked token — the natural correlation key for SIEM rules, retroactive search ("show every request that presented this token"), and revocation-list audit — was in scope at the emission site but dropped before the event was constructed.

The convenience wrapper `logger.log_auth(kind, severity, source)` doesn't accept metadata. Switch the two emission sites to build the `AuditEvent` explicitly with `with_source(source).with_metadata(json!({"jti": jti}))` and call `logger.log(event)` directly. No API widening — matches the pattern `AuditAccountNotification` already uses (`accounts/mod.rs:744`).

Closes #18.

## Out of scope

The issue noted that `AuthTokenInvalid` has similar enrichment value — when validation fails, `kid` / `iss` / sometimes `sub` are available in the decode error but none ship. That's a more invasive change (the decode-error type isn't currently exposed at the middleware emission point) and is tracked under #16 / future follow-up.

## Test plan

- [x] `cargo clippy -p acton-service --all-targets --features full -- -D warnings` — clean
- [x] `cargo clippy -p acton-service --all-targets --no-default-features --features "full,crypto-ring" -- -D warnings` — clean
- [x] `cargo nextest run -p acton-service --features full` — 520/520 pass
- [ ] Verify downstream sees `metadata.jti` populated on `auth.token.revoked` events after upgrade.