### PR TITLE
chore(release): bump workspace to 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [acton-service-v0.27.0] - 2026-05-28
+
+### Breaking changes
+
+- **audit**: The PASETO and JWT auth middleware no longer emit
+  `AuthLoginFailed` (`auth.login.failed`) for unauthenticated or
+  malformed-token requests on protected routes. That event is now
+  reserved for application-level credential-submission failures (e.g.
+  a `POST /auth/login` handler). The middleware emits two new kinds
+  instead — `AuthTokenMissing` (`auth.token.missing`, Informational)
+  when no bearer token is presented, and `AuthTokenInvalid`
+  (`auth.token.invalid`, Warning) when a token fails validation.
+  Downstream SIEM rules keyed on `auth.login.failed` from the middleware
+  will go quiet for the unauthenticated-request case (the goal) and
+  must switch to the new kinds. Fixes #13.
+
+- **audit**: `AuditAccountNotification` now maps
+  `AccountEvent::PasswordChanged` to the dedicated
+  `AuthPasswordChanged` (`auth.password.changed`) kind at Notice
+  severity. Previously it emitted `AccountUpdated` with
+  `action: "password_changed"` metadata. SIEM rules that inspected the
+  metadata to detect password changes must switch to the new kind.
+
+- **audit**: `AuthLoginSuccess` now emits at Notice severity (was
+  Informational). Many production log pipelines suppress
+  Informational-level events by default, which silently dropped the
+  success counterpart of every failure-driven login alert. Closes #19.
+
+- **audit**: `AccountExpired` now emits at Warning severity (was
+  Notice), aligning with `AccountDeleted` and other terminal account
+  states. Closes #19.
+
+### New emissions
+
+- **audit/cedar**: The Cedar middleware now emits `AuthPermissionDenied`
+  (`auth.permission.denied`, Warning) whenever a policy returns
+  `Decision::Deny`. Both the HTTP middleware and the gRPC tower service
+  emit. Closes part of #16.
+
+- **audit/rate-limit**: The rate-limit middleware now emits
+  `HttpRequestDenied` (`http.request.denied`, Warning) when
+  `Error::RateLimitExceeded` fires. Other error variants (Redis
+  connection failures, etc.) do not emit. Closes part of #16.
+
+### Fixes
+
+- **audit/storage**: All four storage backends (Postgres, ClickHouse,
+  Turso, SurrealDB) now correctly round-trip every emitted event kind.
+  Previously, `config.loaded`, `config.drift_detected`, every
+  `account.*` kind (under the `accounts` feature), and the
+  `login-lockout` `auth.account.locked` / `auth.account.unlocked`
+  variants were silently downgraded to `AuditEventKind::Custom(...)` on
+  query. Rust consumers matching on the typed variant missed the
+  events; SIEM queries keyed on the stored string were unaffected.
+  Closes #15.
+
+- **audit**: `AuthTokenRevoked` events now carry `jti` in the event
+  metadata. SIEM correlation by JTI and forensic queries against
+  "every request that presented this revoked token" can anchor on the
+  audit event directly. Closes #18.
+
+- **audit/storage**: Storage parsers now emit a `tracing::warn!` when
+  the catch-all wraps an unknown framework-owned event-kind string
+  (`auth.*`, `http.*`, `account.*`, `config.*`) in `Custom`. Previously
+  the catch-all was silent, which masked version skew between a newer
+  emitter and an older reader — pattern matches on the typed variant
+  would miss without any operator-facing signal. Closes #20.
+
+### Documentation
+
+- Updated `audit/page.md` to reflect the new emission set,
+  severities, and `jti` metadata.
+- Added "Audit Integration" sections to `cedar-auth/page.md` and
+  `rate-limiting/page.md` describing the new automatic emissions.
+- Added "Audit Emission" section to `token-auth/page.md` covering
+  the middleware-emitted kinds and the `AuthLoginFailed` migration.
+
 ## [acton-service-v0.26.1] - 2026-05-18
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "acton-cli"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "acton-service",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["acton-service", "acton-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.26.1"
+version = "0.27.0"
 edition = "2021"
 authors = ["roland@govcraft.ai"]
 license = "MIT"

--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-acton-service = { path = "../acton-service", version = "0.26.1" }
+acton-service = { path = "../acton-service", version = "0.27.0" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/acton-docs/src/lib/version.ts
+++ b/acton-docs/src/lib/version.ts
@@ -2,4 +2,4 @@
  * Version information for acton-service
  * This should match the version in the root Cargo.toml workspace.package.version
  */
-export const VERSION = '0.26.1'
+export const VERSION = '0.27.0'

--- a/acton-docs/src/markdoc/config.js
+++ b/acton-docs/src/markdoc/config.js
@@ -4,7 +4,7 @@ import { siteConfig } from '../lib/config'
 
 // Extract version from workspace Cargo.toml
 // This should be kept in sync with the workspace version
-const ACTON_VERSION = '0.26.1'
+const ACTON_VERSION = '0.27.0'
 
 // Helper function to build dependency string
 function buildDep(features) {

--- a/acton-docs/src/markdoc/functions.js
+++ b/acton-docs/src/markdoc/functions.js
@@ -1,5 +1,5 @@
 // Markdoc functions for version management
-const ACTON_VERSION = '0.26.1'
+const ACTON_VERSION = '0.27.0'
 
 export const version = {
   transform() {


### PR DESCRIPTION
## Summary

Workspace version bump for the 0.27.0 release. This PR is the precondition to running `cargo release tag --execute && cargo release publish --execute` against `main` after merge.

## Changes

- `Cargo.toml` workspace version: `0.26.1` → `0.27.0`
- `Cargo.lock` regenerated by `cargo release version minor -p acton-service --execute --no-confirm`
- `acton-docs/src/lib/version.ts` — `VERSION` constant bumped (per CLAUDE.md release checklist)
- `acton-docs/src/markdoc/config.js` — `ACTON_VERSION` constant bumped
- `acton-docs/src/markdoc/functions.js` — `ACTON_VERSION` constant bumped
- `CHANGELOG.md` — populated the `[Unreleased]` section with the 0.27.0 entry, covering all breaking changes, new emissions, fixes, and documentation work from #14, #21, #22, #23, #24, #25, #27.

## Why minor, not patch

Six PRs in this cycle introduce observable behavior changes to the audit-event surface that downstream SIEM rules can key on:

- `AuthLoginFailed` no longer middleware-emitted (#14)
- `AccountUpdated`+`action:password_changed` replaced by `AuthPasswordChanged` (#22)
- `AuthLoginSuccess` severity Informational → Notice (#23)
- `AccountExpired` severity Notice → Warning (#23)

Per SemVer, observable-behavior changes that aren't bug fixes warrant a minor bump.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] Pre-bump CI on all the constituent PRs was green
- [ ] CI on this PR runs the workspace once at the new version before merge

## Follow-up (after merge)

\`\`\`
git pull --ff-only
cargo release tag --execute --no-confirm
cargo release publish --execute --no-confirm
git push origin acton-service-v0.27.0
\`\`\`

Closes #13 #15 #18 #19 #20 #19 (refs partial #16)