### PR TITLE
feat(config): configurable bind address for HTTP and gRPC listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+- **config**: Both the HTTP and gRPC listeners now honor a configurable
+  bind address. `[service] bind` accepts any `IpAddr` (`0.0.0.0`,
+  `127.0.0.1`, `::1`, …) and defaults to `0.0.0.0` for backward
+  compatibility, so downstream services can finally expose a loopback-only
+  surface without hand-rolling their own listener. `[grpc] bind` overrides
+  the service-level bind for the separate-port gRPC listener and falls back
+  to it when unset (`GrpcConfig::effective_bind`). (#38)
+- **grpc**: Per-listener TLS for the separate-port gRPC surface via
+  `[grpc.tls]` (requires the `tls` feature). When the section is present it
+  is authoritative: `enabled = true` terminates TLS with its own
+  certificate/key independently of the HTTP listener, `enabled = false`
+  serves plaintext gRPC even when the shared `[tls]` is active (e.g. a
+  loopback-only sidecar surface). When the section is omitted the gRPC
+  listener falls back to the shared `[tls]` config, preserving prior
+  behavior. Bad gRPC certificates are reported at build time. (#38)
+
+### Notes
+
+- Adding `bind`/`tls` fields to the public `ServiceConfig`/`GrpcConfig`
+  structs is source-breaking for consumers that build them with a struct
+  literal (no `#[non_exhaustive]`); the next release should take the minor
+  (0.x breaking) slot. Config files and deserialization are unaffected —
+  every new field is optional or defaulted.
+
 ## [acton-service-v0.27.1] - 2026-07-11
 
 ### Fixes

--- a/acton-service/src/config.rs
+++ b/acton-service/src/config.rs
@@ -12,6 +12,7 @@ use figment::{
     Figment,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::net::{IpAddr, Ipv4Addr};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -160,6 +161,13 @@ where
 pub struct ServiceConfig {
     /// Service name
     pub name: String,
+
+    /// IP address to bind the listener to.
+    ///
+    /// Defaults to `0.0.0.0` (all interfaces) for backward compatibility.
+    /// Set to `127.0.0.1` or `::1` to expose a loopback-only surface.
+    #[serde(default = "default_bind")]
+    pub bind: IpAddr,
 
     /// Port to listen on
     #[serde(default = "default_port")]
@@ -663,6 +671,26 @@ pub struct GrpcConfig {
     #[serde(default = "default_false")]
     pub use_separate_port: bool,
 
+    /// IP address to bind the gRPC listener to.
+    ///
+    /// When `None` (default), falls back to the service-level `[service] bind`.
+    /// Only used when `use_separate_port` is true; the hybrid single-port mode
+    /// shares the HTTP listener and its bind address.
+    #[serde(default)]
+    pub bind: Option<IpAddr>,
+
+    /// Per-listener TLS configuration for the gRPC surface (requires `tls` feature).
+    ///
+    /// When present, this section is authoritative for the separate-port gRPC
+    /// listener: `enabled = true` terminates TLS using this certificate/key
+    /// independently of the HTTP listener, while `enabled = false` serves
+    /// plaintext gRPC even when the shared `[tls]` is active (useful for a
+    /// loopback-only gRPC surface). When `None`, the gRPC listener falls back
+    /// to the shared `[tls]` configuration.
+    #[cfg(feature = "tls")]
+    #[serde(default)]
+    pub tls: Option<TlsConfig>,
+
     /// gRPC port (only used if use_separate_port is true)
     #[serde(default = "default_grpc_port")]
     pub port: u16,
@@ -748,6 +776,14 @@ impl GrpcConfig {
         } else {
             http_port
         }
+    }
+
+    /// Resolve the effective bind address.
+    ///
+    /// Returns the gRPC-specific bind address when set, otherwise the supplied
+    /// service-level bind address.
+    pub fn effective_bind(&self, service_bind: IpAddr) -> IpAddr {
+        self.bind.unwrap_or(service_bind)
     }
 
     /// Get max message size in bytes
@@ -1179,6 +1215,10 @@ impl LocalRateLimitConfig {
 }
 
 // Default value functions
+fn default_bind() -> IpAddr {
+    IpAddr::V4(Ipv4Addr::UNSPECIFIED) // 0.0.0.0 (all interfaces)
+}
+
 fn default_port() -> u16 {
     8080
 }
@@ -1584,6 +1624,7 @@ where
         Self {
             service: ServiceConfig {
                 name: "acton-service".to_string(),
+                bind: default_bind(),
                 port: default_port(),
                 log_level: default_log_level(),
                 timeout_secs: default_timeout(),
@@ -1673,6 +1714,7 @@ mod tests {
         let config = Config {
             service: ServiceConfig {
                 name: "test-service".to_string(),
+                bind: default_bind(),
                 port: 9090,
                 log_level: "debug".to_string(),
                 timeout_secs: 30,
@@ -1747,6 +1789,7 @@ mod tests {
         let config = Config {
             service: ServiceConfig {
                 name: "test".to_string(),
+                bind: default_bind(),
                 port: 8080,
                 log_level: "info".to_string(),
                 timeout_secs: 30,
@@ -1923,5 +1966,130 @@ key_path = "./keys/paseto.key"
             config.token.is_none(),
             "token sections in config.example.toml must stay commented (JWT needs the `jwt` feature)"
         );
+    }
+
+    #[test]
+    fn test_default_bind_is_unspecified() {
+        // Default must remain 0.0.0.0 for backward compatibility.
+        let config = Config::<()>::default();
+        assert_eq!(config.service.bind, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    }
+
+    #[test]
+    fn test_service_bind_parses_from_toml() {
+        // Round-trip through Figment (the real load path) so a loopback bind
+        // documented in config.example.toml actually resolves to 127.0.0.1.
+        let toml = r#"
+[service]
+name = "loopback-service"
+bind = "127.0.0.1"
+"#;
+        let config: Config<()> = Figment::new()
+            .merge(Serialized::defaults(Config::<()>::default()))
+            .merge(Toml::string(toml))
+            .extract()
+            .expect("[service] bind = \"127.0.0.1\" must deserialize");
+        assert_eq!(config.service.bind, IpAddr::V4(Ipv4Addr::LOCALHOST));
+    }
+
+    #[test]
+    fn test_service_bind_accepts_ipv6() {
+        let toml = r#"
+[service]
+name = "v6-service"
+bind = "::1"
+"#;
+        let config: Config<()> = Figment::new()
+            .merge(Serialized::defaults(Config::<()>::default()))
+            .merge(Toml::string(toml))
+            .extract()
+            .expect("[service] bind = \"::1\" must deserialize");
+        assert_eq!(
+            config.service.bind,
+            IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)
+        );
+    }
+
+    #[test]
+    fn test_service_bind_rejects_garbage() {
+        // Validation is free: an unparseable address must fail extraction
+        // rather than silently falling back to a default.
+        let toml = r#"
+[service]
+name = "bad-service"
+bind = "not-an-ip"
+"#;
+        let result: std::result::Result<Config<()>, _> = Figment::new()
+            .merge(Serialized::defaults(Config::<()>::default()))
+            .merge(Toml::string(toml))
+            .extract();
+        assert!(result.is_err(), "an invalid bind address must be rejected");
+    }
+
+    #[test]
+    fn test_grpc_effective_bind_falls_back_to_service() {
+        let service_bind = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+        // No gRPC-specific bind: fall back to the service bind.
+        let unset: GrpcConfig =
+            serde_json::from_str("{}").expect("empty gRPC config must deserialize via defaults");
+        assert_eq!(unset.effective_bind(service_bind), service_bind);
+
+        // Explicit gRPC bind wins over the service bind.
+        let explicit: GrpcConfig = serde_json::from_str(r#"{ "bind": "0.0.0.0" }"#)
+            .expect("gRPC config with bind must deserialize");
+        assert_eq!(
+            explicit.effective_bind(service_bind),
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+        );
+    }
+
+    #[test]
+    fn test_grpc_bind_parses_from_toml() {
+        let toml = r#"
+[service]
+name = "svc"
+
+[grpc]
+use_separate_port = true
+bind = "127.0.0.1"
+port = 9090
+"#;
+        let config: Config<()> = Figment::new()
+            .merge(Serialized::defaults(Config::<()>::default()))
+            .merge(Toml::string(toml))
+            .extract()
+            .expect("[grpc] bind must deserialize");
+        let grpc = config.grpc.expect("grpc section present");
+        assert_eq!(grpc.bind, Some(IpAddr::V4(Ipv4Addr::LOCALHOST)));
+        assert_eq!(grpc.port, 9090);
+    }
+
+    #[cfg(feature = "tls")]
+    #[test]
+    fn test_grpc_tls_parses_from_toml() {
+        let toml = r#"
+[service]
+name = "svc"
+
+[grpc]
+use_separate_port = true
+port = 9090
+
+[grpc.tls]
+enabled = true
+cert_path = "./certs/grpc.pem"
+key_path = "./certs/grpc.key"
+"#;
+        let config: Config<()> = Figment::new()
+            .merge(Serialized::defaults(Config::<()>::default()))
+            .merge(Toml::string(toml))
+            .extract()
+            .expect("[grpc.tls] must deserialize");
+        let grpc = config.grpc.expect("grpc section present");
+        let tls = grpc.tls.expect("grpc tls present");
+        assert!(tls.enabled);
+        assert_eq!(tls.cert_path, PathBuf::from("./certs/grpc.pem"));
+        assert_eq!(tls.key_path, PathBuf::from("./certs/grpc.key"));
     }
 }

--- a/acton-service/src/grpc/server.rs
+++ b/acton-service/src/grpc/server.rs
@@ -3,7 +3,7 @@
 use crate::config::GrpcConfig;
 use crate::error::Result;
 use crate::state::AppState;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tonic::server::NamedService;
 use tonic::transport::Server;
 // Reflection types are not used directly, we use the Builder API
@@ -37,9 +37,16 @@ impl GrpcServer {
     }
 
     /// Get the socket address for the gRPC server
+    ///
+    /// A standalone [`GrpcServer`] has no service-level context, so the bind
+    /// address resolves to the gRPC-specific `bind` when set, otherwise
+    /// `0.0.0.0` (all interfaces).
     pub fn socket_addr(&self, http_port: u16) -> SocketAddr {
         let port = self.config.effective_port(http_port);
-        SocketAddr::from(([0, 0, 0, 0], port))
+        let bind = self
+            .config
+            .effective_bind(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        SocketAddr::new(bind, port)
     }
 }
 

--- a/acton-service/src/server.rs
+++ b/acton-service/src/server.rs
@@ -33,7 +33,7 @@ impl Server {
 
     /// Run the server with the given router
     pub async fn serve(self, app: Router) -> Result<()> {
-        let addr = SocketAddr::from(([0, 0, 0, 0], self.config.service.port));
+        let addr = SocketAddr::new(self.config.service.bind, self.config.service.port);
 
         tracing::info!("Starting {} on {}", self.config.service.name, addr);
 

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -1311,7 +1311,8 @@ where
             app = app.layer(axum::Extension(logger.clone()));
         }
 
-        let listener_addr = std::net::SocketAddr::from(([0, 0, 0, 0], config.service.port));
+        let listener_addr =
+            std::net::SocketAddr::new(config.service.bind, config.service.port);
 
         // Load TLS config once at build time (fail fast on bad certs)
         #[cfg(feature = "tls")]
@@ -1340,6 +1341,36 @@ where
             }
         };
 
+        // Resolve per-listener TLS for the separate-port gRPC listener.
+        // Mirrors the HTTP TLS handling above (log-and-degrade on load error).
+        // A present `[grpc.tls]` section is authoritative for the gRPC
+        // listener — `enabled = false` means plaintext gRPC even when the
+        // shared `[tls]` is active. Only an absent section inherits it.
+        #[cfg(all(feature = "grpc", feature = "tls"))]
+        let grpc_tls_config = match config.grpc.as_ref().and_then(|g| g.tls.as_ref()) {
+            Some(grpc_tls) if grpc_tls.enabled => match crate::tls::load_server_config(grpc_tls) {
+                Ok(sc) => {
+                    tracing::info!(
+                        "gRPC TLS configured (cert: {}, key: {})",
+                        grpc_tls.cert_path.display(),
+                        grpc_tls.key_path.display()
+                    );
+                    Some(sc)
+                }
+                Err(e) => {
+                    tracing::error!("Failed to load gRPC TLS configuration: {}", e);
+                    None
+                }
+            },
+            Some(_) => {
+                tracing::info!(
+                    "gRPC TLS explicitly disabled; separate-port gRPC listener serves plaintext"
+                );
+                None
+            }
+            None => tls_config.clone(),
+        };
+
         ActonService {
             config,
             state: state_clone,
@@ -1349,6 +1380,8 @@ where
             grpc_routes: self.grpc_services,
             #[cfg(feature = "tls")]
             tls_config,
+            #[cfg(all(feature = "grpc", feature = "tls"))]
+            grpc_tls_config,
             agent_runtime: self.agent_runtime,
         }
     }
@@ -1624,6 +1657,10 @@ where
     grpc_routes: Option<tonic::service::Routes>,
     #[cfg(feature = "tls")]
     tls_config: Option<std::sync::Arc<tokio_rustls::rustls::ServerConfig>>,
+    /// Per-listener TLS config for the separate-port gRPC listener. Falls back
+    /// to `tls_config` (the HTTP TLS) when `[grpc.tls]` is not configured.
+    #[cfg(all(feature = "grpc", feature = "tls"))]
+    grpc_tls_config: Option<std::sync::Arc<tokio_rustls::rustls::ServerConfig>>,
     agent_runtime: Option<acton_reactive::prelude::ActorRuntime>,
 }
 
@@ -1688,9 +1725,12 @@ where
                     let grpc_routes = self.grpc_routes.take().unwrap();
 
                     if grpc_config.use_separate_port {
-                        // Dual-port mode: HTTP and gRPC on separate ports
+                        // Dual-port mode: HTTP and gRPC on separate ports.
+                        // The gRPC listener uses its own bind when set, else the
+                        // service-level bind.
                         let grpc_port = grpc_config.port;
-                        let grpc_addr = std::net::SocketAddr::from(([0, 0, 0, 0], grpc_port));
+                        let grpc_bind = grpc_config.effective_bind(self.config.service.bind);
+                        let grpc_addr = std::net::SocketAddr::new(grpc_bind, grpc_port);
 
                         tracing::info!("Starting HTTP service on {}", self.listener_addr);
                         tracing::info!("Starting gRPC service on {}", grpc_addr);
@@ -1701,9 +1741,10 @@ where
                         // Convert Routes to axum router for the gRPC listener
                         let grpc_app = grpc_routes.into_axum_router();
 
-                        // Spawn gRPC server on separate task (with optional TLS)
+                        // Spawn gRPC server on separate task (with optional
+                        // per-listener TLS, falling back to the HTTP TLS config).
                         #[cfg(feature = "tls")]
-                        let grpc_tls_config = self.tls_config.clone();
+                        let grpc_tls_config = self.grpc_tls_config.clone();
 
                         let grpc_handle = tokio::spawn(async move {
                             #[cfg(feature = "tls")]

--- a/config.example.toml
+++ b/config.example.toml
@@ -3,10 +3,31 @@
 
 [service]
 name = "my-service"
+# bind = "0.0.0.0"  # IP to bind the listener to. Default 0.0.0.0 (all interfaces).
+                    # Set to "127.0.0.1" or "::1" for a loopback-only surface.
 port = 8080
 log_level = "info"  # trace, debug, info, warn, error
 timeout_secs = 30
 environment = "dev"  # dev, staging, production
+
+# ============================================================================
+# gRPC ([grpc] section, requires the `grpc` feature)
+# ============================================================================
+# [grpc]
+# enabled = true
+# use_separate_port = true   # serve gRPC on its own port (below); false = share the HTTP port
+# port = 9090
+# bind = "127.0.0.1"         # gRPC listener bind. Falls back to [service] bind when unset.
+                             # Only applied in separate-port mode.
+#
+# Per-listener TLS for the separate-port gRPC surface (requires the `tls` feature).
+# When present this section is authoritative: enabled = false serves plaintext gRPC
+# even when the shared [tls] is active (e.g. a loopback-only surface).
+# When omitted, the gRPC listener falls back to the shared [tls] config.
+# [grpc.tls]
+# enabled = true
+# cert_path = "./certs/grpc.pem"
+# key_path = "./certs/grpc.key"
 
 # ============================================================================
 # TOKEN AUTHENTICATION ([token] section with format = "paseto" or "jwt")


### PR DESCRIPTION
## Summary

Remediates #38: both listeners hardcoded `0.0.0.0` with no configurable bind address, so downstream services (axorum-serve, axorum-queryd, key-custody signing sidecars) could not get a loopback-only surface from the framework.

### Ask 1 — configurable bind
- `[service] bind` on `ServiceConfig` (`IpAddr`, default `0.0.0.0` for backward compatibility; accepts `127.0.0.1`, `::1`, etc. — garbage strings fail config extraction instead of silently defaulting).
- `[grpc] bind` on `GrpcConfig` as an optional override for the separate-port gRPC listener, falling back to the service-level bind via `GrpcConfig::effective_bind`.
- All hardcoded `SocketAddr::from(([0,0,0,0], …))` sites replaced: `server.rs`, `grpc/server.rs`, and both paths in `service_builder.rs`.

### Ask 2 — per-listener gRPC TLS
- New `[grpc.tls]` section (`tls` feature). When present it is **authoritative** for the separate-port gRPC listener: `enabled = true` terminates TLS with its own cert/key independently of HTTP; `enabled = false` serves plaintext gRPC even when the shared `[tls]` is active (the loopback-sidecar posture). When absent, the gRPC listener inherits the shared `[tls]` config — preserving prior behavior exactly.
- Single-port hybrid mode shares the HTTP listener and its TLS, documented on the config fields.

### Versioning note
Adding public fields to non-`#[non_exhaustive]` `ServiceConfig`/`GrpcConfig` is source-breaking for struct-literal consumers, so the next release should take the 0.x-breaking minor slot (noted in the CHANGELOG under Unreleased). Config files are unaffected — every new field is optional or defaulted. No version bump in this PR per the separate `chore(release)` convention.

## Testing
- `cargo clippy --workspace --all-targets -- -D warnings` clean (default and `grpc,tls` feature sets), zero suppressions
- `cargo nextest run`: 109/109 default, 108/108 with `grpc,tls`, including 8 new config tests (bind default, IPv4/IPv6 TOML parsing via the real Figment load path, invalid-address rejection, gRPC bind fallback, `[grpc.tls]` parsing)

Closes #38