### PR TITLE
chore(release): prepare 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [acton-service-v0.28.0] - 2026-07-17
+
 ### Features
 
 - **config**: Both the HTTP and gRPC listeners now honor a configurable
@@ -29,9 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adding `bind`/`tls` fields to the public `ServiceConfig`/`GrpcConfig`
   structs is source-breaking for consumers that build them with a struct
-  literal (no `#[non_exhaustive]`); the next release should take the minor
-  (0.x breaking) slot. Config files and deserialization are unaffected —
-  every new field is optional or defaulted.
+  literal (no `#[non_exhaustive]`); hence the minor (0.x breaking) bump.
+  Config files and deserialization are unaffected — every new field is
+  optional or defaulted.
 
 ## [acton-service-v0.27.1] - 2026-07-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "acton-cli"
-version = "0.27.1"
+version = "0.28.0"
 dependencies = [
  "acton-service",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.27.1"
+version = "0.28.0"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["acton-service", "acton-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.27.1"
+version = "0.28.0"
 edition = "2021"
 authors = ["roland@govcraft.ai"]
 license = "MIT"

--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-acton-service = { path = "../acton-service", version = "0.27.1" }
+acton-service = { path = "../acton-service", version = "0.28.0" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/acton-docs/src/lib/version.ts
+++ b/acton-docs/src/lib/version.ts
@@ -2,4 +2,4 @@
  * Version information for acton-service
  * This should match the version in the root Cargo.toml workspace.package.version
  */
-export const VERSION = '0.27.1'
+export const VERSION = '0.28.0'

--- a/acton-docs/src/markdoc/config.js
+++ b/acton-docs/src/markdoc/config.js
@@ -4,7 +4,7 @@ import { siteConfig } from '../lib/config'
 
 // Extract version from workspace Cargo.toml
 // This should be kept in sync with the workspace version
-const ACTON_VERSION = '0.27.1'
+const ACTON_VERSION = '0.28.0'
 
 // Single source of truth mapping camelCase aliases to the real Cargo feature
 // lists. Used by both the `dep()` function and the `$dep.*` variables so a

--- a/acton-docs/src/markdoc/functions.js
+++ b/acton-docs/src/markdoc/functions.js
@@ -1,5 +1,5 @@
 // Markdoc functions for version management
-const ACTON_VERSION = '0.27.1'
+const ACTON_VERSION = '0.28.0'
 
 export const version = {
   transform() {


### PR DESCRIPTION
Minor (0.x breaking) release for the configurable bind address and per-listener gRPC TLS shipped in #39 (closes #38). The new public fields on `ServiceConfig`/`GrpcConfig` are source-breaking for struct-literal consumers, so this takes the 0.x-breaking minor slot.

- Bump workspace version 0.27.1 → 0.28.0 (`cargo release version minor`)
- Sync acton-docs version files (`src/lib/version.ts`, `src/markdoc/config.js`, `src/markdoc/functions.js`)
- Move the Unreleased CHANGELOG entries under `acton-service-v0.28.0`

Publish to crates.io (acton-service, then acton-cli) and signed tags follow after merge.