### PR TITLE
feat(observability): Prometheus scrape endpoint — align the OTel stack at 0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,11 +112,14 @@ dependencies = [
  "once_cell",
  "openidconnect",
  "opentelemetry",
+ "opentelemetry-instrumentation-tower",
  "opentelemetry-otlp",
+ "opentelemetry-prometheus",
  "opentelemetry_sdk",
  "paginator-axum",
  "paginator-rs",
  "paginator-sqlx",
+ "prometheus",
  "prost 0.14.3",
  "prost-build",
  "rand 0.10.1",
@@ -145,7 +148,6 @@ dependencies = [
  "tonic-reflection",
  "tower 0.5.3",
  "tower-http 0.6.11",
- "tower-otel-http-metrics",
  "tower-resilience-bulkhead",
  "tower-resilience-circuitbreaker",
  "tower-sessions",
@@ -4735,9 +4737,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4749,9 +4751,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4761,41 +4763,78 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-otlp"
-version = "0.30.0"
+name = "opentelemetry-instrumentation-tower"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+checksum = "5fa342b7ded339a38c6df9a3aef833298bca24a7aeec098397b4b3ec741b0e52"
+dependencies = [
+ "axum 0.8.9",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http 1.4.0",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.13.5",
+ "prost 0.14.3",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
- "tonic 0.13.1",
+ "tonic 0.14.6",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14095eb06b569eb5d538fa4555969f7e8a410ed7910c903bfd295f9e1a50d7ea"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prometheus",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.13.5",
- "tonic 0.13.1",
+ "prost 0.14.3",
+ "tonic 0.14.6",
+ "tonic-prost",
 ]
 
 [[package]]
-name = "opentelemetry_sdk"
-version = "0.30.0"
+name = "opentelemetry-semantic-conventions"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
 dependencies = [
  "futures-channel",
  "futures-executor",
@@ -4803,7 +4842,6 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.4",
- "serde_json",
  "thiserror 2.0.18",
 ]
 
@@ -5389,6 +5427,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5396,16 +5449,6 @@ checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
  "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -5454,19 +5497,6 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "prost-derive"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
@@ -5485,6 +5515,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost 0.14.3",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8057,32 +8107,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-timeout 0.5.2",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost 0.13.5",
- "tokio",
- "tokio-stream",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
@@ -8305,21 +8329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
-name = "tower-otel-http-metrics"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1dde2214d51e31911933b312d69dd1dcc30cc9d5e1a77734191fffb23d248e"
-dependencies = [
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "opentelemetry",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-resilience-bulkhead"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8508,14 +8517,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "once_cell",
  "opentelemetry",
- "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ tower-http = { version = "0.6.6", features = [
     "sensitive-headers",
     "set-header",
 ] }
-tower-otel-http-metrics = "0.16.0"
 
 # gRPC framework
 tonic = { version = "0.14.2", default-features = false, features = ["transport", "codegen", "router", "server", "channel"] }
@@ -73,10 +72,13 @@ figment = { version = "0.10.19", features = ["toml", "env", "json"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }
 tracing-journald = "0.3.2"
-opentelemetry = "0.30.0"
-opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic"] }
-opentelemetry_sdk = "0.30.0"
-tracing-opentelemetry = "0.31.0"
+opentelemetry = "0.31"
+opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
+opentelemetry_sdk = "0.31"
+tracing-opentelemetry = "0.32"
+opentelemetry-instrumentation-tower = { version = "0.17", features = ["axum"] }
+opentelemetry-prometheus = "0.31"
+prometheus = "0.14"
 
 # Resilience
 tower-resilience-circuitbreaker = "0.4.7"

--- a/acton-cli/src/commands/service/add/middleware.rs
+++ b/acton-cli/src/commands/service/add/middleware.rs
@@ -82,7 +82,10 @@ fn show_all_middleware() {
     println!("{}", "3. Metrics (OpenTelemetry)".green().bold());
     println!("   {}: metrics, otel, opentelemetry", "Aliases".yellow());
     println!("   HTTP request metrics and tracing");
-    println!("   {}: otel-metrics", "Feature".cyan());
+    println!(
+        "   {}: otel-metrics (OTLP push), prometheus-metrics (/metrics pull)",
+        "Feature".cyan()
+    );
     println!();
 
     println!("{}", "4. Rate Limiting (Governor)".green().bold());
@@ -218,31 +221,37 @@ fn show_metrics_middleware() {
     println!();
     println!(
         "{}",
-        "HTTP metrics are enabled via the 'otel-metrics' feature.".bold()
+        "HTTP metrics support two export models, selected by feature:".bold()
     );
+    println!("  - otel-metrics:       OTLP push to a collector");
+    println!("  - prometheus-metrics: pull-based GET /metrics endpoint");
     println!();
 
     println!("{}", "1. Enable in Cargo.toml:".green().bold());
     println!();
     println!("   [dependencies]");
+    println!("   # OTLP push:");
     println!(r#"   acton-service = {{ version = "0.2", features = ["otel-metrics"] }}"#);
+    println!("   # Prometheus pull (/metrics endpoint):");
+    println!(r#"   acton-service = {{ version = "0.2", features = ["prometheus-metrics"] }}"#);
     println!();
 
     println!("{}", "2. Configure in config.toml:".green().bold());
     println!();
     println!("   [middleware.metrics]");
     println!("   enabled = true");
-    println!("   endpoint_path = \"/metrics\"  # Prometheus endpoint");
     println!();
-    println!("   # Optional OTLP export");
+    println!("   # Optional OTLP export (otel-metrics feature)");
     println!("   [otlp]");
     println!(r#"   endpoint = "http://localhost:4317""#);
     println!("   service_name = \"my-service\"");
+    println!("   enabled = true");
     println!();
 
     println!("{}", "Automatic integration:".cyan().bold());
-    println!("  Metrics middleware is automatically added when configured.");
-    println!("  Exposes /metrics endpoint for Prometheus scraping.");
+    println!("  Metrics middleware is added automatically when configured.");
+    println!("  With prometheus-metrics, GET /metrics is mounted alongside");
+    println!("  /health and /ready for Prometheus scraping.");
     println!();
 
     println!("{}", "Available metrics:".cyan().bold());

--- a/acton-docs/src/app/docs/api-versioning/page.md
+++ b/acton-docs/src/app/docs/api-versioning/page.md
@@ -609,8 +609,8 @@ This logging happens automatically - no additional code required!
 
 ### Automatic OpenTelemetry Metrics
 
-{% callout type="note" title="Automatic Metrics (otel-metrics feature)" %}
-When the `otel-metrics` feature is enabled, the framework **automatically tracks OpenTelemetry metrics** for all API version usage. Every request is recorded with detailed attributes for monitoring and alerting.
+{% callout type="note" title="Automatic Metrics (otel-metrics / prometheus-metrics features)" %}
+When the `otel-metrics` or `prometheus-metrics` feature is enabled, the framework **automatically tracks OpenTelemetry metrics** for all API version usage. Every request is recorded with detailed attributes for monitoring and alerting.
 {% /callout %}
 
 The framework automatically records the `api.version.requests` counter metric with the following attributes:

--- a/acton-docs/src/app/docs/examples/page.md
+++ b/acton-docs/src/app/docs/examples/page.md
@@ -203,13 +203,22 @@ HTTP Client → REST API → Event Bus → gRPC Service → Business Logic
 
 Metrics, tracing, and monitoring integration.
 
-#### **test-metrics.rs** - Prometheus Metrics
+#### **test-prometheus-metrics.rs** - Prometheus Scrape Endpoint
 
-Prometheus metrics collection and custom metric definitions.
+Pull-based `/metrics` endpoint via the `prometheus-metrics` feature, mounted automatically by `ServiceBuilder`.
+
+```bash
+cargo run --manifest-path=acton-service/Cargo.toml --example test-prometheus-metrics --features prometheus-metrics
+curl http://localhost:8080/api/v1/hello
+curl http://localhost:8080/metrics
+```
+
+#### **test-metrics.rs** - HTTP Metrics Layer
+
+Constructing the OpenTelemetry HTTP metrics layer manually and applying it to a hand-built router.
 
 ```bash
 cargo run --manifest-path=acton-service/Cargo.toml --example test-metrics --features otel-metrics
-curl http://localhost:8080/metrics
 ```
 
 #### **test-observability.rs** - OpenTelemetry Tracing
@@ -443,7 +452,8 @@ Some examples require specific feature flags:
 | `cedar-authz` | cedar-authz | AWS Cedar policy authorization |
 | `cache` | cedar-authz | Redis caching for policy decisions |
 | `grpc` | ping-pong, single-port, event-driven | tonic gRPC server support |
-| `otel-metrics` | test-metrics | OpenTelemetry metrics collection |
+| `otel-metrics` | test-metrics | OpenTelemetry metrics collection (OTLP push) |
+| `prometheus-metrics` | test-prometheus-metrics | Pull-based Prometheus `/metrics` endpoint |
 | `observability` | test-observability | OpenTelemetry tracing |
 | `database` | database-api | PostgreSQL via SQLx |
 | `websocket` | chat-server | WebSocket support |

--- a/acton-docs/src/app/docs/feature-flags/page.md
+++ b/acton-docs/src/app/docs/feature-flags/page.md
@@ -98,7 +98,8 @@ acton-service uses feature flags to keep compile times fast and binary sizes sma
         ├─── Brute force protection ─────▶ Add "login-lockout"
         ├─── Rate limiting ───────────────▶ Add "governor"
         ├─── Resilience ──────────────────▶ Add "resilience"
-        ├─── Metrics ─────────────────────▶ Add "otel-metrics"
+        ├─── Metrics (OTLP push) ─────────▶ Add "otel-metrics"
+        ├─── Metrics (Prometheus pull) ───▶ Add "prometheus-metrics"
         └─── OpenAPI ─────────────────────▶ Add "openapi"
 ```
 
@@ -647,19 +648,39 @@ Advanced rate limiting with per-user limits via token claims.
 
 ### `otel-metrics`
 
-HTTP metrics collection via OpenTelemetry for detailed monitoring.
+HTTP metrics collection via OpenTelemetry, pushed to a collector over OTLP.
 
-**When to use**: Need detailed request metrics for monitoring
+**When to use**: Need detailed request metrics and you run an OpenTelemetry collector
 
-**Dependencies**: tower-otel-http-metrics
+**Dependencies**: opentelemetry-instrumentation-tower, opentelemetry-otlp
 
 **Provides**:
 - Request count, duration, size metrics
 - Active request tracking
 - HTTP status code distribution
+- OTLP push export (15s interval) to the configured `[otlp]` endpoint
 
 ```toml
 {% $dep.otelMetrics %}
+```
+
+### `prometheus-metrics`
+
+The same OpenTelemetry HTTP metrics, exposed for a direct Prometheus scrape — no collector required.
+
+**When to use**: Operators point Prometheus straight at the service, or running a collector is not worth it
+
+**Dependencies**: opentelemetry-instrumentation-tower, opentelemetry-prometheus
+
+**Provides**:
+- `GET /metrics` in Prometheus text-exposition format, mounted alongside `/health` and `/ready`
+- The same request metrics as `otel-metrics`, plus any application metrics registered through `get_meter()`
+- Independent of `otel-metrics`: enable either or both; with both, one meter provider feeds both exporters
+
+The endpoint is unauthenticated like `/health` — it exposes route names and traffic statistics, so restrict access at the network layer if that matters in your deployment. `/metrics` is excluded from audit-logged routes by default.
+
+```toml
+{% $dep.prometheusMetrics %}
 ```
 
 ### `tls`
@@ -1008,6 +1029,7 @@ Some features work better together:
 | `cedar-authz` | `cache` | Policy decision caching dramatically improves performance (10-50ms → 1-5ms) |
 | `cache` | `governor` | Distributed rate limiting needs Redis |
 | `otel-metrics` | `observability` | Metrics require tracing foundation |
+| `prometheus-metrics` | `http` | The `/metrics` scrape endpoint is served by the HTTP router |
 | `journald` | `observability` | Journald layer works alongside OTLP tracing |
 | `resilience` | `http` or `grpc` | Resilience patterns apply to HTTP/gRPC calls |
 | `openapi` | `http` | OpenAPI docs are for HTTP endpoints |

--- a/acton-docs/src/app/docs/observability/page.md
+++ b/acton-docs/src/app/docs/observability/page.md
@@ -150,7 +150,12 @@ enabled = true
 
 ## Metrics
 
-acton-service automatically collects comprehensive HTTP request metrics using OpenTelemetry. All metrics are exported via the OTLP exporter and can be visualized in Prometheus, Grafana, or any OpenTelemetry-compatible metrics backend.
+acton-service automatically collects comprehensive HTTP request metrics using OpenTelemetry. Two export models are available, selected by feature flag:
+
+- **`otel-metrics`** — push: metrics are exported over OTLP to an OpenTelemetry collector every 15 seconds
+- **`prometheus-metrics`** — pull: metrics are exposed at `GET /metrics` in Prometheus text-exposition format for direct scraping, no collector required
+
+The features are independent: enable either or both. With both enabled, a single meter provider feeds the OTLP exporter and the Prometheus registry simultaneously, so transport metrics and any application metrics you record through `get_meter()` appear in both.
 
 ### Automatic HTTP Metrics
 
@@ -226,6 +231,31 @@ The metrics layer is automatically applied to all routes and includes:
 - HTTP method and path
 - Response status codes
 - Request duration calculation
+
+### Prometheus Scrape Endpoint
+
+With the `prometheus-metrics` feature, `ServiceBuilder` mounts `GET /metrics` alongside `/health` and `/ready` — no wiring required:
+
+```bash
+curl http://localhost:8080/metrics
+# HELP http_server_request_duration_seconds Duration of HTTP server requests.
+# TYPE http_server_request_duration_seconds histogram
+http_server_request_duration_seconds_bucket{http_request_method="GET",http_route="/api/v1/hello",...} 2
+```
+
+The response uses `Content-Type: text/plain; version=0.0.4` as Prometheus expects. Point a scrape job directly at the service:
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: 'my-service'
+    static_configs:
+      - targets: ['my-service:8080']
+```
+
+{% callout type="note" title="Endpoint exposure" %}
+`/metrics` is unauthenticated, like `/health`. It exposes route names, traffic volumes, and latency distributions — no request payloads or secrets — but if that surface matters in your deployment, restrict access at the network layer. The route is excluded from audit logging by default.
+{% /callout %}
 
 ---
 
@@ -495,7 +525,9 @@ cargo run
 
 ### Prometheus (Metrics)
 
-Export metrics to Prometheus using an OpenTelemetry collector:
+The simplest integration is the `prometheus-metrics` feature: Prometheus scrapes the service's `/metrics` endpoint directly (see [Prometheus Scrape Endpoint](#prometheus-scrape-endpoint) above), and no collector is involved.
+
+Alternatively, with the `otel-metrics` feature, export metrics through an OpenTelemetry collector:
 
 ```yaml
 # otel-collector-config.yaml

--- a/acton-docs/src/markdoc/config.js
+++ b/acton-docs/src/markdoc/config.js
@@ -29,6 +29,7 @@ const DEP_FEATURES = {
   resilience: ['resilience'],
   governor: ['governor'],
   otelMetrics: ['otel-metrics'],
+  prometheusMetrics: ['prometheus-metrics'],
   openapiOnly: ['openapi'],
   databaseCache: ['database', 'cache'],
   jwtOnly: ['jwt'],

--- a/acton-docs/src/markdoc/functions.js
+++ b/acton-docs/src/markdoc/functions.js
@@ -36,6 +36,7 @@ export const dep = {
       resilience: `acton-service = { version = "${ACTON_VERSION}", features = ["resilience"] }`,
       governor: `acton-service = { version = "${ACTON_VERSION}", features = ["governor"] }`,
       otelMetrics: `acton-service = { version = "${ACTON_VERSION}", features = ["otel-metrics"] }`,
+      prometheusMetrics: `acton-service = { version = "${ACTON_VERSION}", features = ["prometheus-metrics"] }`,
       openapiOnly: `acton-service = { version = "${ACTON_VERSION}", features = ["openapi"] }`,
 
       // Multi-feature combinations

--- a/acton-service/Cargo.toml
+++ b/acton-service/Cargo.toml
@@ -25,7 +25,7 @@ tokio-stream = { workspace = true, optional = true }
 axum = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
-tower-otel-http-metrics = { workspace = true, optional = true }
+opentelemetry-instrumentation-tower = { workspace = true, optional = true }
 
 # gRPC framework (optional)
 tonic = { workspace = true, optional = true }
@@ -66,6 +66,8 @@ opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry-prometheus = { workspace = true, optional = true }
+prometheus = { workspace = true, optional = true }
 
 # Error handling
 thiserror = { workspace = true }
@@ -164,7 +166,14 @@ cache = ["dep:redis", "dep:deadpool-redis"]
 events = ["dep:async-nats"]
 observability = ["dep:opentelemetry", "dep:opentelemetry-otlp", "dep:opentelemetry_sdk", "dep:tracing-opentelemetry"]
 resilience = [ "dep:tower-resilience-circuitbreaker", "dep:tower-resilience-bulkhead"]
-otel-metrics = ["dep:tower-otel-http-metrics", "observability"]
+# Internal umbrella: shared metrics machinery (meter provider + HTTP metrics
+# tower layer). Enabled transitively by otel-metrics and prometheus-metrics;
+# not intended to be enabled directly by downstream crates.
+_metrics = ["dep:opentelemetry-instrumentation-tower", "observability"]
+# OpenTelemetry HTTP metrics with OTLP push export to a collector.
+otel-metrics = ["_metrics"]
+# Pull-based Prometheus metrics exposed at the /metrics endpoint.
+prometheus-metrics = ["_metrics", "dep:opentelemetry-prometheus", "dep:prometheus"]
 governor = ["dep:governor"]
 websocket = []
 openapi = ["dep:utoipa", "dep:utoipa-swagger-ui"]
@@ -176,7 +185,7 @@ auth = ["dep:argon2", "dep:rand", "dep:blake3", "dep:base64"] # Core: password h
 oauth = ["auth", "dep:oauth2", "dep:openidconnect", "dep:base64"]  # OAuth/OIDC providers (requires auth)
 auth-full = ["auth", "oauth", "jwt", "cache", "database", "login-lockout", "accounts"]  # All auth features (excludes turso - mutually exclusive with database)
 
-full = ["http", "grpc", "websocket", "database", "cache", "events", "observability", "resilience", "otel-metrics", "governor", "openapi", "cedar-authz", "jwt", "auth", "session-memory", "session-redis", "htmx", "askama", "sse", "pagination-full", "handlers", "login-lockout", "tls", "accounts", "account-handlers", "journald", "graphql", "graphql-cedar"]
+full = ["http", "grpc", "websocket", "database", "cache", "events", "observability", "resilience", "otel-metrics", "prometheus-metrics", "governor", "openapi", "cedar-authz", "jwt", "auth", "session-memory", "session-redis", "htmx", "askama", "sse", "pagination-full", "handlers", "login-lockout", "tls", "accounts", "account-handlers", "journald", "graphql", "graphql-cedar"]
 tonic-health = ["dep:tonic-health"]
 tonic-reflection = ["dep:tonic-reflection"]
 tower-resilience-circuitbreaker = ["dep:tower-resilience-circuitbreaker"]
@@ -285,6 +294,11 @@ required-features = ["otel-metrics"]
 name = "test-observability"
 path = "examples/observability/test-observability.rs"
 required-features = ["observability"]
+
+[[example]]
+name = "test-prometheus-metrics"
+path = "examples/observability/test-prometheus-metrics.rs"
+required-features = ["prometheus-metrics"]
 
 # Database examples
 [[example]]

--- a/acton-service/examples/observability/README.md
+++ b/acton-service/examples/observability/README.md
@@ -4,24 +4,39 @@ Examples demonstrating metrics, tracing, and monitoring integration with acton-s
 
 ## Examples
 
+### test-prometheus-metrics.rs
+
+**Pull-based Prometheus `/metrics` endpoint**
+
+Demonstrates the `prometheus-metrics` feature:
+- A `/metrics` endpoint in Prometheus text-exposition format
+- The OpenTelemetry HTTP metrics tower layer feeding the same meter provider
+- Batteries-included wiring: `ServiceBuilder` initializes the meter provider,
+  applies the metrics layer, and mounts `/metrics` automatically
+
+Run with:
+```bash
+cargo run --manifest-path=../../Cargo.toml --example test-prometheus-metrics --features prometheus-metrics
+```
+
+Generate traffic and scrape metrics:
+```bash
+curl http://localhost:8080/api/v1/hello
+curl http://localhost:8080/metrics
+```
+
 ### test-metrics.rs
 
-**Prometheus Metrics Integration**
+**HTTP metrics tower layer (manual wiring)**
 
-Demonstrates:
-- Prometheus metrics collection
-- Custom metric definitions
-- Automatic metric endpoints
-- Performance monitoring
+Demonstrates constructing the OpenTelemetry HTTP metrics layer directly and
+applying it to a hand-built router. Metrics are collected into a meter provider;
+for OTLP push export enable a collector via the `[otlp]` config and the
+`otel-metrics` feature.
 
 Run with:
 ```bash
 cargo run --manifest-path=../../Cargo.toml --example test-metrics --features otel-metrics
-```
-
-View metrics:
-```bash
-curl http://localhost:8080/metrics
 ```
 
 ### test-observability.rs
@@ -50,7 +65,9 @@ Requires the `observability` feature flag:
 
 ### Metrics
 
-Metrics are automatically exposed at `/metrics` endpoint in Prometheus format.
+With the `prometheus-metrics` feature, metrics are automatically exposed at the
+`/metrics` endpoint in Prometheus text-exposition format (mounted by
+`ServiceBuilder` alongside `/health` and `/ready`).
 
 Common metrics include:
 - Request counts

--- a/acton-service/examples/observability/test-prometheus-metrics.rs
+++ b/acton-service/examples/observability/test-prometheus-metrics.rs
@@ -1,0 +1,67 @@
+//! Prometheus Metrics Example - Pull-based `/metrics` endpoint
+//!
+//! This example demonstrates the `prometheus-metrics` feature:
+//! - A pull-based `/metrics` endpoint in Prometheus text-exposition format
+//! - The OpenTelemetry HTTP metrics tower layer (via
+//!   `opentelemetry-instrumentation-tower`) feeding the same meter provider
+//! - Zero manual wiring: `ServiceBuilder` initializes the meter provider,
+//!   applies the metrics layer, and mounts `/metrics` automatically
+//!
+//! Run with:
+//!   cargo run --example test-prometheus-metrics --features prometheus-metrics
+//!
+//! Then, in another terminal, generate some traffic and scrape metrics:
+//!   curl http://localhost:8080/api/v1/hello
+//!   curl http://localhost:8080/metrics
+//!
+//! The `/metrics` output includes HTTP server metrics (request counts and
+//! latencies) plus the per-version `api.version.requests` counter.
+
+use acton_service::prelude::*;
+
+#[derive(Serialize)]
+struct Message {
+    message: String,
+}
+
+async fn hello() -> Json<Message> {
+    Json(Message {
+        message: "Hello - this request is counted in /metrics!".to_string(),
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // HTTP metrics are enabled via the [middleware.metrics] config section.
+    // With default config they are on; here we set it explicitly so the example
+    // is self-contained regardless of any config.toml on disk.
+    let mut config = Config::<()>::default();
+    config.service.name = "prometheus-metrics-example".to_string();
+    config.middleware.metrics = Some(acton_service::config::MetricsConfig {
+        enabled: true,
+        include_path: true,
+        include_method: true,
+        include_status: true,
+        latency_buckets_ms: vec![5.0, 25.0, 100.0, 500.0, 1000.0],
+    });
+
+    let routes = VersionedApiBuilder::new()
+        .with_base_path("/api")
+        .add_version(ApiVersion::V1, |router| {
+            router.route("/hello", get(hello))
+        })
+        .build_routes();
+
+    // ServiceBuilder automatically:
+    // - initializes the Prometheus meter provider (pull reader + registry)
+    // - applies the OpenTelemetry HTTP metrics tower layer
+    // - mounts GET /metrics alongside /health and /ready
+    ServiceBuilder::new()
+        .with_config(config)
+        .with_routes(routes)
+        .build()
+        .serve()
+        .await?;
+
+    Ok(())
+}

--- a/acton-service/src/audit/config_audit.rs
+++ b/acton-service/src/audit/config_audit.rs
@@ -100,6 +100,8 @@ pub fn enabled_features() -> Vec<&'static str> {
     features.push("resilience");
     #[cfg(feature = "otel-metrics")]
     features.push("otel-metrics");
+    #[cfg(feature = "prometheus-metrics")]
+    features.push("prometheus-metrics");
     #[cfg(feature = "governor")]
     features.push("governor");
     #[cfg(feature = "websocket")]

--- a/acton-service/src/lib.rs
+++ b/acton-service/src/lib.rs
@@ -245,7 +245,7 @@ pub mod prelude {
     #[cfg(feature = "resilience")]
     pub use crate::middleware::ResilienceConfig;
 
-    #[cfg(feature = "otel-metrics")]
+    #[cfg(feature = "_metrics")]
     pub use crate::middleware::{metric_labels, metric_names, MetricsConfig};
 
     #[cfg(feature = "governor")]

--- a/acton-service/src/middleware/metrics.rs
+++ b/acton-service/src/middleware/metrics.rs
@@ -5,8 +5,8 @@
 
 use std::time::Duration;
 
-#[cfg(feature = "otel-metrics")]
-use tower_otel_http_metrics::HTTPMetricsLayerBuilder;
+#[cfg(feature = "_metrics")]
+use opentelemetry_instrumentation_tower::HTTPMetricsLayerBuilder;
 
 /// Configuration for HTTP metrics
 #[derive(Debug, Clone)]
@@ -151,13 +151,13 @@ pub mod metric_labels {
 ///     .service(my_service);
 /// # */
 /// ```
-#[cfg(feature = "otel-metrics")]
+#[cfg(feature = "_metrics")]
 pub fn create_metrics_layer(
     config: &MetricsConfig,
 ) -> Option<
-    tower_otel_http_metrics::HTTPMetricsLayer<
-        tower_otel_http_metrics::NoOpExtractor,
-        tower_otel_http_metrics::NoOpExtractor,
+    opentelemetry_instrumentation_tower::HTTPMetricsLayer<
+        opentelemetry_instrumentation_tower::NoOpExtractor,
+        opentelemetry_instrumentation_tower::NoOpExtractor,
     >,
 > {
     if !config.enabled {
@@ -188,9 +188,9 @@ pub fn create_metrics_layer(
 }
 
 /// Create the HTTP metrics layer (no-op when feature is disabled)
-#[cfg(not(feature = "otel-metrics"))]
+#[cfg(not(feature = "_metrics"))]
 pub fn create_metrics_layer(_config: &MetricsConfig) -> Option<()> {
-    tracing::info!("HTTP metrics not available (otel-metrics feature disabled)");
+    tracing::info!("HTTP metrics not available (otel-metrics/prometheus-metrics feature disabled)");
     None
 }
 
@@ -262,7 +262,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "otel-metrics")]
+    #[cfg(feature = "_metrics")]
     fn test_create_metrics_layer_without_meter_provider() {
         // Without initializing the meter provider, should return None
         let config = MetricsConfig::new().with_enabled(true);

--- a/acton-service/src/middleware/mod.rs
+++ b/acton-service/src/middleware/mod.rs
@@ -21,7 +21,7 @@ pub mod route_matcher;
 #[cfg(feature = "resilience")]
 pub mod resilience;
 
-#[cfg(feature = "otel-metrics")]
+#[cfg(feature = "_metrics")]
 pub mod metrics;
 
 #[cfg(feature = "governor")]
@@ -60,7 +60,7 @@ pub use route_matcher::{normalize_path, CompiledRoutePatterns};
 #[cfg(feature = "resilience")]
 pub use resilience::ResilienceConfig;
 
-#[cfg(feature = "otel-metrics")]
+#[cfg(feature = "_metrics")]
 pub use metrics::{metric_labels, metric_names, MetricsConfig};
 
 #[cfg(feature = "governor")]

--- a/acton-service/src/observability.rs
+++ b/acton-service/src/observability.rs
@@ -24,11 +24,14 @@ use {
     tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer},
 };
 
+#[cfg(feature = "_metrics")]
+use {
+    opentelemetry::metrics::MeterProvider as _, opentelemetry_sdk::metrics::SdkMeterProvider,
+};
+
 #[cfg(feature = "otel-metrics")]
 use {
-    opentelemetry::metrics::MeterProvider as _,
-    opentelemetry_otlp::MetricExporter,
-    opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider},
+    opentelemetry_otlp::MetricExporter, opentelemetry_sdk::metrics::PeriodicReader,
     std::time::Duration as StdDuration,
 };
 
@@ -38,8 +41,16 @@ static TRACER_PROVIDER: once_cell::sync::OnceCell<SdkTracerProvider> =
     once_cell::sync::OnceCell::new();
 
 /// Global meter provider for graceful shutdown
-#[cfg(feature = "otel-metrics")]
+#[cfg(feature = "_metrics")]
 pub static METER_PROVIDER: once_cell::sync::OnceCell<SdkMeterProvider> =
+    once_cell::sync::OnceCell::new();
+
+/// Global Prometheus registry backing the pull-based `/metrics` endpoint.
+///
+/// Populated by [`init_meter_provider`] when the `prometheus-metrics` feature is
+/// enabled and a reader is successfully created.
+#[cfg(feature = "prometheus-metrics")]
+pub static PROMETHEUS_REGISTRY: once_cell::sync::OnceCell<prometheus::Registry> =
     once_cell::sync::OnceCell::new();
 
 /// Initialize tracing with OpenTelemetry and structured logging
@@ -187,24 +198,12 @@ pub(crate) fn init_otlp_tracer(
     Ok(provider)
 }
 
-/// Initialize OpenTelemetry OTLP meter provider for metrics collection
+/// Build an OTLP push metric reader (Tonic gRPC transport).
+///
+/// Extracted so it can be composed as one reader among several on a single
+/// [`SdkMeterProvider`] in [`init_meter_provider`].
 #[cfg(feature = "otel-metrics")]
-pub(crate) fn init_otlp_meter(
-    otlp_config: &crate::config::OtlpConfig,
-    service_name: &str,
-) -> Result<SdkMeterProvider> {
-    // Use service name from OTLP config or fall back to main service name
-    let metrics_service_name = otlp_config
-        .service_name
-        .as_ref()
-        .unwrap_or(&service_name.to_string())
-        .clone();
-
-    // Create resource with service metadata
-    let resource = Resource::builder()
-        .with_service_name(metrics_service_name)
-        .build();
-
+fn otlp_metric_reader(otlp_config: &crate::config::OtlpConfig) -> Result<PeriodicReader<MetricExporter>> {
     // Build OTLP metric exporter with Tonic gRPC transport
     let mut exporter_builder = MetricExporter::builder().with_tonic();
 
@@ -218,17 +217,79 @@ pub(crate) fn init_otlp_meter(
     })?;
 
     // Create periodic reader with appropriate export interval (15s for Prometheus compatibility)
-    let reader = PeriodicReader::builder(exporter)
+    Ok(PeriodicReader::builder(exporter)
         .with_interval(StdDuration::from_secs(15))
-        .build();
+        .build())
+}
 
-    // Build meter provider with production-ready configuration
-    let provider = SdkMeterProvider::builder()
-        .with_resource(resource)
-        .with_reader(reader)
-        .build();
+/// Build the Prometheus pull exporter (a metric reader) and its backing registry.
+#[cfg(feature = "prometheus-metrics")]
+fn prometheus_metric_reader() -> Result<(opentelemetry_prometheus::PrometheusExporter, prometheus::Registry)>
+{
+    let registry = prometheus::Registry::new();
+    let exporter = opentelemetry_prometheus::exporter()
+        .with_registry(registry.clone())
+        .build()
+        .map_err(|e| {
+            crate::error::Error::Internal(format!("Failed to build Prometheus exporter: {}", e))
+        })?;
+    Ok((exporter, registry))
+}
 
-    Ok(provider)
+/// Encode a Prometheus registry's current metric families into the text
+/// exposition format.
+///
+/// Pure with respect to its input: the same registry state always yields the
+/// same bytes, and it performs no I/O beyond in-memory encoding.
+#[cfg(feature = "prometheus-metrics")]
+fn encode_registry(registry: &prometheus::Registry) -> Result<Vec<u8>> {
+    use prometheus::Encoder;
+
+    let encoder = prometheus::TextEncoder::new();
+    let metric_families = registry.gather();
+    let mut buffer = Vec::new();
+    encoder.encode(&metric_families, &mut buffer).map_err(|e| {
+        crate::error::Error::Internal(format!("Failed to encode Prometheus metrics: {}", e))
+    })?;
+    Ok(buffer)
+}
+
+/// Axum handler exposing metrics at `/metrics` in Prometheus text format.
+///
+/// Returns `503 Service Unavailable` if the meter provider has not been
+/// initialized, `500 Internal Server Error` if encoding fails, and `200 OK`
+/// with `Content-Type: text/plain; version=0.0.4` otherwise.
+#[cfg(feature = "prometheus-metrics")]
+pub async fn metrics_handler() -> axum::response::Response {
+    use axum::response::IntoResponse;
+    use prometheus::Encoder;
+
+    let Some(registry) = PROMETHEUS_REGISTRY.get() else {
+        return (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "metrics not initialized",
+        )
+            .into_response();
+    };
+
+    match encode_registry(registry) {
+        Ok(buffer) => (
+            [(
+                axum::http::header::CONTENT_TYPE,
+                prometheus::TextEncoder::new().format_type(),
+            )],
+            buffer,
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to encode Prometheus metrics");
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to encode metrics",
+            )
+                .into_response()
+        }
+    }
 }
 
 /// Initialize journald tracing layer for native systemd journal integration
@@ -267,7 +328,7 @@ fn init_journald_layer(
 ///
 /// This function returns a meter from the global meter provider if metrics are enabled.
 /// Returns None if no meter provider has been initialized (neither local nor global).
-#[cfg(feature = "otel-metrics")]
+#[cfg(feature = "_metrics")]
 pub fn get_meter() -> Option<opentelemetry::metrics::Meter> {
     // Try local provider first
     if let Some(provider) = METER_PROVIDER.get() {
@@ -281,41 +342,78 @@ pub fn get_meter() -> Option<opentelemetry::metrics::Meter> {
     None
 }
 
-/// Initialize the meter provider and set it globally
+/// Initialize the meter provider and set it globally.
 ///
-/// This should be called during service initialization if metrics are enabled.
-#[cfg(feature = "otel-metrics")]
-pub fn init_meter_provider(config: &Config) -> Result<()> {
+/// Assembles a single [`SdkMeterProvider`] with one reader per enabled export
+/// feature: an OTLP push reader (`otel-metrics`, when `[otlp]` is enabled) and a
+/// Prometheus pull reader (`prometheus-metrics`). If both features are enabled,
+/// both readers feed the same provider. Individual reader failures are logged
+/// and skipped so the service still starts; the provider is only installed when
+/// at least one reader was created.
+///
+/// This should be called once during service initialization.
+#[cfg(feature = "_metrics")]
+pub fn init_meter_provider<T>(config: &Config<T>) -> Result<()>
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + Clone + Default + Send + Sync + 'static,
+{
+    let resource = Resource::builder()
+        .with_service_name(config.service.name.clone())
+        .build();
+
+    let mut builder = SdkMeterProvider::builder().with_resource(resource);
+    let mut reader_count: usize = 0;
+
+    #[cfg(feature = "otel-metrics")]
     if let Some(otlp_config) = &config.otlp {
         if otlp_config.enabled {
-            match init_otlp_meter(otlp_config, &config.service.name) {
-                Ok(meter_provider) => {
-                    // Store provider for later access and shutdown
-                    let _ = METER_PROVIDER.set(meter_provider.clone());
-
-                    // Set global meter provider
-                    global::set_meter_provider(meter_provider);
-
+            match otlp_metric_reader(otlp_config) {
+                Ok(reader) => {
+                    builder = builder.with_reader(reader);
+                    reader_count += 1;
                     tracing::info!(
                         service = %config.service.name,
                         otlp_endpoint = %otlp_config.endpoint,
-                        "OpenTelemetry metrics initialized with OTLP export"
+                        "OpenTelemetry metrics OTLP push reader initialized"
                     );
-
-                    return Ok(());
                 }
                 Err(e) => {
-                    // Log error but continue without metrics
                     tracing::warn!(
                         error = %e,
-                        "Failed to initialize OTLP metric exporter (metrics disabled)"
+                        "Failed to initialize OTLP metric exporter (skipping OTLP reader)"
                     );
                 }
             }
         }
     }
 
-    tracing::info!("Metrics not configured or disabled");
+    #[cfg(feature = "prometheus-metrics")]
+    match prometheus_metric_reader() {
+        Ok((reader, registry)) => {
+            builder = builder.with_reader(reader);
+            let _ = PROMETHEUS_REGISTRY.set(registry);
+            reader_count += 1;
+            tracing::info!(
+                service = %config.service.name,
+                "Prometheus metrics pull reader initialized (/metrics)"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "Failed to initialize Prometheus exporter (skipping Prometheus reader)"
+            );
+        }
+    }
+
+    if reader_count == 0 {
+        tracing::info!("Metrics not configured or disabled");
+        return Ok(());
+    }
+
+    let provider = builder.build();
+    let _ = METER_PROVIDER.set(provider.clone());
+    global::set_meter_provider(provider);
     Ok(())
 }
 
@@ -414,7 +512,7 @@ pub fn shutdown_tracing() {
     }
 
     // Shutdown the meter provider if initialized
-    #[cfg(feature = "otel-metrics")]
+    #[cfg(feature = "_metrics")]
     if let Some(provider) = METER_PROVIDER.get() {
         if let Err(e) = provider.shutdown() {
             eprintln!("Error during meter provider shutdown: {}", e);
@@ -488,7 +586,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg(feature = "otel-metrics")]
-    async fn test_init_otlp_meter() {
+    async fn test_otlp_metric_reader() {
         let otlp_config = crate::config::OtlpConfig {
             endpoint: "http://localhost:4317".to_string(),
             service_name: Some("test-metrics-service".to_string()),
@@ -497,22 +595,73 @@ mod tests {
 
         // The OTLP metric exporter should build successfully even with potentially invalid endpoint
         // It will only fail when trying to actually send metrics (lazy connection)
-        let result = init_otlp_meter(&otlp_config, "test-service");
+        let result = otlp_metric_reader(&otlp_config);
 
         assert!(
             result.is_ok(),
-            "OTLP meter should build even with potentially invalid endpoint (connection is lazy)"
+            "OTLP metric reader should build even with potentially invalid endpoint (connection is lazy)"
         );
     }
 
     #[test]
-    #[cfg(feature = "otel-metrics")]
+    #[cfg(feature = "_metrics")]
     fn test_get_meter_without_init() {
         // Before initialization, get_meter should return None
         let meter = get_meter();
         assert!(
             meter.is_none(),
             "get_meter should return None before initialization"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "prometheus-metrics")]
+    fn test_prometheus_metric_reader_builds() {
+        let result = prometheus_metric_reader();
+        assert!(
+            result.is_ok(),
+            "Prometheus exporter/registry should build successfully"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "prometheus-metrics")]
+    fn test_encode_registry_empty_is_ok() {
+        // Encoding an empty registry must not error and yields valid (possibly
+        // empty) output.
+        let registry = prometheus::Registry::new();
+        let bytes = encode_registry(&registry).expect("encoding an empty registry should succeed");
+        // Empty registry produces no metric families, hence no bytes.
+        assert!(bytes.is_empty(), "empty registry should encode to no output");
+    }
+
+    #[test]
+    #[cfg(feature = "prometheus-metrics")]
+    fn test_encode_registry_with_counter_contains_metric() {
+        use prometheus::core::Collector;
+
+        let registry = prometheus::Registry::new();
+        let counter =
+            prometheus::IntCounter::new("acton_test_total", "A test counter").expect("counter");
+        registry
+            .register(Box::new(counter.clone()) as Box<dyn Collector>)
+            .expect("register counter");
+        counter.inc_by(3);
+
+        let bytes = encode_registry(&registry).expect("encoding should succeed");
+        let text = String::from_utf8(bytes).expect("encoder emits UTF-8");
+
+        assert!(
+            text.contains("acton_test_total"),
+            "encoded output should contain the metric name, got: {text}"
+        );
+        assert!(
+            text.contains("# TYPE acton_test_total counter"),
+            "encoded output should contain the TYPE line, got: {text}"
+        );
+        assert!(
+            text.contains("acton_test_total 3"),
+            "encoded output should contain the counter value, got: {text}"
         );
     }
 

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -414,6 +414,13 @@ where
             eprintln!("Warning: Failed to initialize tracing: {}", e);
         }
 
+        // Initialize the meter provider (OTLP push and/or Prometheus pull readers)
+        // before middleware is layered, so the HTTP metrics layer can obtain a meter.
+        #[cfg(feature = "_metrics")]
+        if let Err(e) = crate::observability::init_meter_provider(&config) {
+            eprintln!("Warning: Failed to initialize metrics: {}", e);
+        }
+
         // Determine if we need to spawn pool agents
         #[cfg(feature = "database")]
         let needs_db_agent = config.database.is_some();
@@ -1027,6 +1034,11 @@ where
                     "/admin/config/drift",
                     axum::routing::get(crate::audit::config_audit::drift_check_handler::<T>),
                 );
+                #[cfg(feature = "prometheus-metrics")]
+                let router = router.route(
+                    "/metrics",
+                    axum::routing::get(crate::observability::metrics_handler),
+                );
                 router.with_state(state)
             }
             VersionedRoutes::WithoutState(router) => {
@@ -1040,6 +1052,12 @@ where
                 let health_router = health_router.route(
                     "/admin/config/drift",
                     get(crate::audit::config_audit::drift_check_handler::<T>),
+                );
+
+                #[cfg(feature = "prometheus-metrics")]
+                let health_router = health_router.route(
+                    "/metrics",
+                    get(crate::observability::metrics_handler),
                 );
 
                 // Use fallback_service to include the versioned routes
@@ -1606,6 +1624,24 @@ where
                 .make_span_with(DefaultMakeSpan::new().include_headers(true))
                 .on_response(DefaultOnResponse::new().include_headers(true)),
         );
+
+        // HTTP metrics layer (OpenTelemetry) - records into the global meter that
+        // feeds the OTLP push and/or Prometheus pull readers. Requires the meter
+        // provider to have been initialized in `build()` beforehand.
+        #[cfg(feature = "_metrics")]
+        if let Some(metrics_cfg) = &config.middleware.metrics {
+            if metrics_cfg.enabled {
+                let mw_config = crate::middleware::metrics::MetricsConfig::new()
+                    .with_service_name(config.service.name.clone())
+                    .with_include_path(metrics_cfg.include_path)
+                    .with_include_method(metrics_cfg.include_method)
+                    .with_include_status(metrics_cfg.include_status)
+                    .with_latency_buckets(metrics_cfg.latency_buckets_ms.clone());
+                if let Some(layer) = crate::middleware::metrics::create_metrics_layer(&mw_config) {
+                    app = app.layer(layer);
+                }
+            }
+        }
 
         // Request tracking layers - based on config
         if config.middleware.request_tracking.mask_sensitive_headers {

--- a/acton-service/src/versioning.rs
+++ b/acton-service/src/versioning.rs
@@ -49,7 +49,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt;
 use tracing::warn;
 
-#[cfg(feature = "otel-metrics")]
+#[cfg(feature = "_metrics")]
 use opentelemetry::KeyValue;
 
 /// API version identifier
@@ -230,14 +230,14 @@ impl VersionedRouter {
 
     /// Convert to a regular Axum router with deprecation middleware applied
     pub fn into_router(self) -> Router {
-        #[cfg(feature = "otel-metrics")]
+        #[cfg(feature = "_metrics")]
         let version = self.version;
         let deprecation = self.deprecation.clone();
 
         // Always apply middleware for metrics tracking and optional deprecation headers
         self.router.layer(middleware::from_fn(move |req: Request, next: Next| {
             let deprecation = deprecation.clone();
-            #[cfg(feature = "otel-metrics")]
+            #[cfg(feature = "_metrics")]
             let version = version;
             async move {
                 // If deprecated, log the usage
@@ -264,7 +264,7 @@ impl VersionedRouter {
                 }
 
                 // Record metrics for all API version usage (deprecated or not)
-                #[cfg(feature = "otel-metrics")]
+                #[cfg(feature = "_metrics")]
                 if let Some(meter) = crate::observability::get_meter() {
                     let counter = meter
                         .u64_counter("api.version.requests")

--- a/config.example.toml
+++ b/config.example.toml
@@ -112,7 +112,10 @@ bulkhead_max_queued = 200           # Max queued requests
 
 # ----------------------------------------------------------------------------
 # HTTP Metrics (OpenTelemetry)
-# Requires feature: otel-metrics
+# Requires feature: otel-metrics (OTLP push to a collector) and/or
+#                   prometheus-metrics (pull-based /metrics endpoint).
+# When prometheus-metrics is enabled, metrics are scraped from GET /metrics
+# in Prometheus text-exposition format.
 # ----------------------------------------------------------------------------
 [middleware.metrics]
 enabled = true


### PR DESCRIPTION
Closes #42.

## What

- **OTel stack 0.30 → 0.31**: `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp` to 0.31; `tracing-opentelemetry` to 0.32. These are mutually version-locked; 0.31 is the alignment point (not latest — see #42 for why 0.32 is blocked on `opentelemetry-instrumentation-tower`).
- **Swap archived dependency**: `tower-otel-http-metrics` 0.16 (archived, read-only) → official `opentelemetry-instrumentation-tower` 0.17 from opentelemetry-rust-contrib. Near drop-in (same `HTTPMetricsLayerBuilder` API). Side benefit: removes the duplicate tonic in the tree (otlp 0.30 pulled tonic 0.13; the workspace is on 0.14).
- **New `prometheus-metrics` feature**: `opentelemetry-prometheus` 0.31 registered as a pull reader on the shared `SdkMeterProvider`; `GET /metrics` (Prometheus text-exposition format) mounted by `ServiceBuilder` alongside `/health` and `/ready`.
- Push and scrape are independently selectable: `otel-metrics` (OTLP push) and `prometheus-metrics` (pull) both sit on an internal `_metrics` umbrella; enabling both feeds two readers from one meter provider.
- `ServiceBuilder` now initializes the meter provider and applies the HTTP metrics tower layer automatically from `[middleware.metrics]` config.

## Endpoint placement

`/metrics` is mounted on the main listener, unauthenticated, like `/health`: default transport metrics expose route names, traffic volumes, and latencies — an API-surface map but no secrets or payload data. Documented in the observability example README; network-level protection is the operator's call. It was already excluded from audit-logged routes by default.

## Verification

- `cargo clippy -p acton-service --all-targets --features full -- -D warnings`: clean
- `cargo clippy --no-default-features --features full,crypto-ring`: clean; `acton-cli` clippy clean
- `cargo nextest run --features full` and `full,crypto-ring`: 533/533 passed each
- Isolated combos compile: `otel-metrics` only, `prometheus-metrics` only, both
- Live smoke test via the new `test-prometheus-metrics` example: scraped `/metrics` returns `200` with `Content-Type: text/plain; version=0.0.4`, per-route counters and latency histograms populated from real traffic

## Notes

- `prometheus-metrics` is included in `full` (kitchen-sink feature); it is not in default features. `opentelemetry-prometheus` has historically lagged core OTel releases — flagging in case you'd rather keep it out of `full`.
- Consumers pinned to OTel 0.30 must move to 0.31 together with this bump (versions are mutually locked).