### PR TITLE
fix(resilience): make circuit breaker and bulkhead usable on axum routers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8330,9 +8330,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-resilience-bulkhead"
-version = "0.4.7"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c9b15e771d70a9b12318549faa7e2bb2ebe519904157d4f273112685286749"
+checksum = "321c1d703c62ee1545f5f304b592779948bebfe4c69ace74ae88b05c294f89d0"
 dependencies = [
  "futures",
  "thiserror 2.0.18",
@@ -8345,9 +8345,9 @@ dependencies = [
 
 [[package]]
 name = "tower-resilience-circuitbreaker"
-version = "0.4.7"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff16e1f78dfac712d37e9332d23a4066d3fa8ccd82e8ba131a49018e594751f8"
+checksum = "f1c89ebacecf47734e7a562f615997bd54e1867ca26fb596f309d63ca5f6f42a"
 dependencies = [
  "futures",
  "thiserror 2.0.18",
@@ -8358,9 +8358,9 @@ dependencies = [
 
 [[package]]
 name = "tower-resilience-core"
-version = "0.4.7"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd405f5badae6282b44de3278f5c1f9098865cc348fbc9218babd777721cf16b"
+checksum = "13d51ef3353f58a987373162f9f68d6c9e555d1e09a215c224bf4e1f9e135138"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,8 @@ opentelemetry-prometheus = "0.31"
 prometheus = "0.14"
 
 # Resilience
-tower-resilience-circuitbreaker = "0.4.7"
-tower-resilience-bulkhead = "0.4.7"
+tower-resilience-circuitbreaker = "0.10.0"
+tower-resilience-bulkhead = "0.10.0"
 
 # Error handling
 thiserror = "2.0.17"

--- a/acton-docs/src/app/docs/resilience/page.md
+++ b/acton-docs/src/app/docs/resilience/page.md
@@ -31,7 +31,6 @@ Current surface (`resilience` feature):
 
 ```rust
 use acton_service::middleware::ResilienceConfig;
-use http::Request;
 
 let config = ResilienceConfig::new()
     .with_circuit_breaker(true)
@@ -40,8 +39,8 @@ let config = ResilienceConfig::new()
     .with_bulkhead_max_concurrent(100);    // max 100 concurrent calls
 
 // Each constructor returns `None` when that pattern is disabled
-if let Some(layer) = config.circuit_breaker_layer::<Request<()>, String>() {
-    // Attach to your tower service stack
+if let Some(layer) = config.circuit_breaker_layer() {
+    // Attach to your outbound tower client stack
 }
 
 if let Some(layer) = config.bulkhead_layer() {
@@ -50,6 +49,24 @@ if let Some(layer) = config.bulkhead_layer() {
 ```
 
 Both constructors return `Option`, so a disabled pattern costs you nothing at runtime.
+
+### Protecting an Inbound Router
+
+For an inbound axum router, use `apply_resilience` rather than attaching the layers by hand:
+
+```rust
+use acton_service::middleware::resilience::{apply_resilience, ResilienceConfig};
+use axum::{routing::get, Router};
+
+let app = Router::new().route("/", get(handler));
+let app = apply_resilience(app, &ResilienceConfig::default());
+```
+
+This wires up three things that are easy to get wrong individually:
+
+1. **A 5xx-aware failure classifier.** An inbound axum route is infallible — a handler that fails returns `Ok(Response)` with a 500 status, never `Err`. The default classifier counts only `Err` as a failure, so a hand-attached breaker would compile, look correct, and never open. `apply_resilience` classifies any 5xx response as a failure. A 4xx is the caller's fault and never trips the circuit.
+2. **An error handler.** Both layers change the service error type, but `Router::layer` requires `Infallible`. Rejections are converted to `503 Service Unavailable` and logged.
+3. **Ordering.** The bulkhead sits inside the breaker, so a concurrency rejection becomes a 503 that the breaker observes — sustained overload can open the circuit.
 
 ## Circuit Breaker
 
@@ -153,20 +170,21 @@ There is no `with_circuit_breaker_min_requests()`, `with_circuit_breaker_timeout
 
 ### Building the Layer
 
-`circuit_breaker_layer()` is generic over the request and error types of the service you're wrapping, and returns `None` when the circuit breaker is disabled:
+`circuit_breaker_layer()` takes no type parameters and returns `None` when the circuit breaker is disabled:
 
 ```rust
 use acton_service::middleware::resilience::ResilienceConfig;
-use http::Request;
 
 let config = ResilienceConfig::default();
 
-if let Some(layer) = config.circuit_breaker_layer::<Request<()>, String>() {
-    // Apply the layer to your service
+if let Some(layer) = config.circuit_breaker_layer() {
+    // Apply the layer to your outbound service stack
 }
 ```
 
-The request type must be `Clone` (the breaker may need to inspect a request more than once), so the circuit breaker is most useful around **outbound** tower stacks — the clients you use to call databases and downstream services — rather than around the inbound axum router, whose `Request<Body>` is not cloneable.
+This layer counts `Err` results as failures, which suits **outbound** tower stacks — the clients you use to call databases and downstream services, where a transport failure surfaces as `Err`.
+
+For an **inbound** axum router, reach for `apply_resilience` instead. If you need the pieces separately, `http_circuit_breaker_layer()` returns a breaker that classifies 5xx responses as failures; you must still pair it with an error handler before calling `Router::layer`.
 
 ### Configuration Reference
 

--- a/acton-service/src/middleware/resilience.rs
+++ b/acton-service/src/middleware/resilience.rs
@@ -3,9 +3,40 @@
 //! This module provides production-ready circuit breaker, retry, and bulkhead patterns
 //! using tower-resilience to ensure service stability and graceful degradation.
 
+use std::convert::Infallible;
 use std::time::Duration;
+
+use axum::http::StatusCode;
+use axum::response::Response;
+use axum::error_handling::HandleErrorLayer;
+use axum::Router;
+
+use tower::{BoxError, ServiceBuilder};
+
 pub use tower_resilience_bulkhead::BulkheadLayer;
-pub use tower_resilience_circuitbreaker::CircuitBreakerLayer;
+pub use tower_resilience_circuitbreaker::{
+    CircuitBreakerConfigBuilder, CircuitBreakerLayer, CircuitState,
+};
+use tower_resilience_circuitbreaker::classifier::FnClassifier;
+
+/// Failure classification used by [`ResilienceConfig::http_circuit_breaker_layer`].
+///
+/// A plain `fn` pointer (rather than a closure) keeps this type nameable in
+/// public signatures.
+pub type HttpFailureClassifier = FnClassifier<HttpClassifierFn>;
+
+/// Signature of the inbound-HTTP failure classifier.
+pub type HttpClassifierFn = fn(&Result<Response, Infallible>) -> bool;
+
+/// Treat any 5xx response as a circuit-breaker failure.
+///
+/// Inbound axum routes are infallible, so a failing handler produces
+/// `Ok(Response)` with a server-error status rather than `Err`.
+fn is_server_error(result: &Result<Response, Infallible>) -> bool {
+    result
+        .as_ref()
+        .is_ok_and(|response| response.status().is_server_error())
+}
 
 /// Configuration for resilience patterns
 #[derive(Debug, Clone)]
@@ -100,47 +131,96 @@ impl ResilienceConfig {
 
     /// Create circuit breaker layer from configuration
     ///
-    /// Returns a configured circuit breaker layer that can be applied to services.
-    /// The layer monitors request failures and opens when the failure rate exceeds
-    /// the configured threshold.
+    /// Returns a configured circuit breaker layer that can be applied to outbound
+    /// (client) service stacks, where transport failures surface as `Err`.
+    ///
+    /// The layer counts `Err` results as failures and opens once the failure rate
+    /// exceeds the configured threshold. For **inbound** axum stacks use
+    /// [`Self::http_circuit_breaker_layer`] instead — an inbound `Route` is
+    /// infallible, so a 5xx arrives as `Ok(Response)` and this layer would never
+    /// trip. See [`apply_resilience`] for the full router-ready stack.
     ///
     /// # Example
     /// ```
     /// use acton_service::middleware::resilience::ResilienceConfig;
-    /// use http::Request;
     ///
     /// let config = ResilienceConfig::default();
-    /// // Specify types when creating the layer
-    /// if let Some(layer) = config.circuit_breaker_layer::<Request<()>, String>() {
-    ///     // Apply layer to your service
+    /// if let Some(layer) = config.circuit_breaker_layer() {
+    ///     // Apply layer to your outbound service stack
+    ///     let _ = layer;
     /// }
     /// ```
-    pub fn circuit_breaker_layer<Req, Err>(&self) -> Option<CircuitBreakerLayer<Req, Err>>
-    where
-        Req: Clone,
-    {
+    pub fn circuit_breaker_layer(&self) -> Option<CircuitBreakerLayer> {
         if !self.circuit_breaker_enabled {
             return None;
         }
 
         Some(
-            CircuitBreakerLayer::builder()
-                .name("acton-circuit-breaker")
-                .failure_rate_threshold(self.circuit_breaker_threshold)
-                .sliding_window_size(self.circuit_breaker_min_requests as usize)
-                .wait_duration_in_open(self.circuit_breaker_wait_duration)
-                .on_state_transition(|from, to| {
-                    tracing::warn!(
-                        from = ?from,
-                        to = ?to,
-                        "Circuit breaker state transition"
-                    );
-                })
-                .build(),
+            self.circuit_breaker_builder()
+                .on_state_transition(Self::log_state_transition)
+                .build_with_handle()
+                .0,
         )
     }
 
+    /// Create a circuit breaker layer that classifies HTTP 5xx responses as failures
+    ///
+    /// Inbound axum routes are infallible: a handler returning 500 yields
+    /// `Ok(Response)`, not `Err`. The default classifier only counts `Err` as a
+    /// failure, so a breaker built by [`Self::circuit_breaker_layer`] would never
+    /// open on an inbound router. This layer classifies any response with a
+    /// server-error status as a failure instead.
+    ///
+    /// The resulting layer changes the service error type, so it must be paired
+    /// with an error handler before attaching to a [`Router`]. Prefer
+    /// [`apply_resilience`], which wires that up for you.
+    ///
+    /// [`Router`]: axum::Router
+    pub fn http_circuit_breaker_layer(
+        &self,
+    ) -> Option<CircuitBreakerLayer<HttpFailureClassifier>> {
+        if !self.circuit_breaker_enabled {
+            return None;
+        }
+
+        Some(
+            self.circuit_breaker_builder()
+                .on_state_transition(Self::log_state_transition)
+                .failure_classifier(is_server_error as HttpClassifierFn)
+                .build_with_handle()
+                .0,
+        )
+    }
+
+    /// Shared circuit breaker builder settings, independent of failure classification.
+    ///
+    /// Callers must finish with `build_with_handle()` rather than `build()`.
+    /// axum re-invokes `Layer::layer` on every request, and `build()` mints a
+    /// fresh circuit on each application -- the failure window would reset
+    /// between requests and the breaker could never open.
+    fn circuit_breaker_builder(&self) -> CircuitBreakerConfigBuilder {
+        CircuitBreakerLayer::builder()
+            .name("acton-circuit-breaker")
+            .failure_rate_threshold(self.circuit_breaker_threshold)
+            .sliding_window_size(self.circuit_breaker_min_requests as usize)
+            .wait_duration_in_open(self.circuit_breaker_wait_duration)
+    }
+
+    fn log_state_transition(from: CircuitState, to: CircuitState) {
+        tracing::warn!(
+            from = ?from,
+            to = ?to,
+            "Circuit breaker state transition"
+        );
+    }
+
     /// Create bulkhead layer from configuration
+    ///
+    /// The returned layer carries a **shared** semaphore. This matters: axum
+    /// re-invokes `Layer::layer` on every request, and a layer built with the
+    /// plain `build()` mints fresh state each time -- giving every request its
+    /// own full set of permits, so the concurrency cap would silently never
+    /// apply. See [`apply_resilience`].
     pub fn bulkhead_layer(&self) -> Option<BulkheadLayer> {
         if !self.bulkhead_enabled {
             return None;
@@ -150,7 +230,7 @@ impl ResilienceConfig {
             BulkheadLayer::builder()
                 .name("acton-bulkhead")
                 .max_concurrent_calls(self.bulkhead_max_concurrent)
-                .max_wait_duration(Some(self.bulkhead_max_wait))
+                .max_wait_duration(self.bulkhead_max_wait)
                 .on_call_permitted(|concurrent| {
                     tracing::debug!(
                         concurrent_requests = concurrent,
@@ -163,8 +243,71 @@ impl ResilienceConfig {
                         "Request rejected by bulkhead - max concurrent limit reached"
                     );
                 })
-                .build(),
+                .build_with_handle()
+                .0,
         )
+    }
+}
+
+/// Map a resilience rejection onto an HTTP status code.
+///
+/// The circuit breaker and bulkhead each introduce their own error type, so this
+/// is generic over anything boxable. Both rejections mean "the service is
+/// shedding load right now", which is a 503; the distinction between them is
+/// carried in the log, not the status line.
+async fn handle_resilience_error<E: Into<BoxError>>(error: E) -> (StatusCode, &'static str) {
+    let error: BoxError = error.into();
+    tracing::warn!(error = %error, "Request rejected by resilience middleware");
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Service temporarily unavailable",
+    )
+}
+
+/// Apply resilience middleware (circuit breaker + bulkhead) to an axum router.
+///
+/// This is the supported way to use these patterns on **inbound** HTTP. It
+/// wires three things that are easy to get wrong by hand:
+///
+/// 1. A 5xx-aware failure classifier, so the breaker actually trips. An inbound
+///    route is infallible, so the default `Err`-only classifier would never open
+///    the circuit.
+/// 2. An error handler converting the layers' error types back to `Infallible`,
+///    which axum's [`Router::layer`] requires.
+/// 3. Ordering: the bulkhead is applied first so it sits *inside* the breaker.
+///    A concurrency rejection therefore becomes a 503 that the breaker observes
+///    as a server error, letting sustained overload open the circuit.
+///
+/// Layers disabled in the config are omitted entirely. If both are disabled the
+/// router is returned untouched.
+///
+/// # Example
+/// ```
+/// use acton_service::middleware::resilience::{apply_resilience, ResilienceConfig};
+/// use axum::{routing::get, Router};
+///
+/// let app = Router::new().route("/", get(|| async { "ok" }));
+/// let app = apply_resilience(app, &ResilienceConfig::default());
+/// ```
+pub fn apply_resilience(app: Router, config: &ResilienceConfig) -> Router {
+    // Applied first => innermost. A bulkhead rejection is converted to a 503
+    // here, which the circuit breaker below then counts as a failure.
+    let app = match config.bulkhead_layer() {
+        Some(bulkhead) => app.layer(
+            ServiceBuilder::new()
+                .layer(HandleErrorLayer::new(handle_resilience_error))
+                .layer(bulkhead),
+        ),
+        None => app,
+    };
+
+    match config.http_circuit_breaker_layer() {
+        Some(circuit_breaker) => app.layer(
+            ServiceBuilder::new()
+                .layer(HandleErrorLayer::new(handle_resilience_error))
+                .layer(circuit_breaker),
+        ),
+        None => app,
     }
 }
 
@@ -206,12 +349,12 @@ mod tests {
     #[test]
     fn test_circuit_breaker_layer_creation() {
         let config = ResilienceConfig::new().with_circuit_breaker(true);
-        let layer: Option<CircuitBreakerLayer<(), ()>> = config.circuit_breaker_layer();
-        assert!(layer.is_some());
+        assert!(config.circuit_breaker_layer().is_some());
+        assert!(config.http_circuit_breaker_layer().is_some());
 
         let config = ResilienceConfig::new().with_circuit_breaker(false);
-        let layer: Option<CircuitBreakerLayer<(), ()>> = config.circuit_breaker_layer();
-        assert!(layer.is_none());
+        assert!(config.circuit_breaker_layer().is_none());
+        assert!(config.http_circuit_breaker_layer().is_none());
     }
 
     #[test]
@@ -221,5 +364,20 @@ mod tests {
 
         let config = ResilienceConfig::new().with_bulkhead(false);
         assert!(config.bulkhead_layer().is_none());
+    }
+
+    #[test]
+    fn classifier_counts_5xx_as_failure_not_2xx() {
+        let ok = Ok(Response::new(axum::body::Body::empty()));
+        assert!(!is_server_error(&ok));
+
+        let mut server_error = Response::new(axum::body::Body::empty());
+        *server_error.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+        assert!(is_server_error(&Ok(server_error)));
+
+        // A 4xx is the caller's fault, not the service's -- it must not trip.
+        let mut bad_request = Response::new(axum::body::Body::empty());
+        *bad_request.status_mut() = StatusCode::BAD_REQUEST;
+        assert!(!is_server_error(&Ok(bad_request)));
     }
 }

--- a/acton-service/tests/resilience_router.rs
+++ b/acton-service/tests/resilience_router.rs
@@ -1,0 +1,131 @@
+//! Integration tests for attaching resilience middleware to an axum `Router`.
+//!
+//! These cover the gap reported in issue #33: the circuit breaker and bulkhead
+//! layers could not be attached to a `Router` at all. Beyond compiling, we assert
+//! the breaker actually *opens*, since an inbound axum route is infallible and a
+//! default (`Err`-only) failure classifier would silently never trip.
+//!
+//! Following the convention in `governor_integration.rs`, routers are driven with
+//! `ServiceExt::oneshot` rather than a full server bind.
+
+#![cfg(feature = "resilience")]
+
+use std::time::Duration;
+
+use acton_service::middleware::resilience::{apply_resilience, ResilienceConfig};
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::get,
+    Router,
+};
+use tower::ServiceExt;
+
+/// Config with a tiny sliding window so a couple of requests can trip the breaker.
+fn trip_fast_config() -> ResilienceConfig {
+    let mut config = ResilienceConfig::new()
+        .with_circuit_breaker(true)
+        .with_circuit_breaker_threshold(0.5)
+        // Bulkhead off: this suite isolates circuit-breaker behavior.
+        .with_bulkhead(false);
+    config.circuit_breaker_min_requests = 2;
+    config.circuit_breaker_wait_duration = Duration::from_secs(60);
+    config
+}
+
+async fn status_of(app: &Router, path: &str) -> StatusCode {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .uri(path)
+                .body(Body::empty())
+                .expect("request builds"),
+        )
+        .await
+        .expect("router is infallible after apply_resilience")
+        .status()
+}
+
+#[tokio::test]
+async fn healthy_router_passes_requests_through() {
+    let app = apply_resilience(
+        Router::new().route("/", get(|| async { "ok" })),
+        &ResilienceConfig::default(),
+    );
+
+    for _ in 0..5 {
+        assert_eq!(status_of(&app, "/").await, StatusCode::OK);
+    }
+}
+
+#[tokio::test]
+async fn breaker_opens_after_sustained_5xx() {
+    let app = apply_resilience(
+        Router::new().route(
+            "/boom",
+            get(|| async { StatusCode::INTERNAL_SERVER_ERROR }),
+        ),
+        &trip_fast_config(),
+    );
+
+    // Fill the window with failures. These are the handler's own 500s.
+    for _ in 0..2 {
+        assert_eq!(
+            status_of(&app, "/boom").await,
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    // Once open, the breaker sheds load itself: 503, not the handler's 500.
+    assert_eq!(
+        status_of(&app, "/boom").await,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "circuit breaker did not open after sustained 5xx -- the failure \
+         classifier is likely counting only `Err`, which an infallible \
+         inbound route never produces"
+    );
+}
+
+#[tokio::test]
+async fn breaker_ignores_4xx_client_errors() {
+    let app = apply_resilience(
+        Router::new().route("/bad", get(|| async { StatusCode::BAD_REQUEST })),
+        &trip_fast_config(),
+    );
+
+    // A client's malformed requests are not the service failing; the circuit
+    // must stay closed no matter how many arrive.
+    for _ in 0..6 {
+        assert_eq!(status_of(&app, "/bad").await, StatusCode::BAD_REQUEST);
+    }
+}
+
+#[tokio::test]
+async fn disabling_both_patterns_leaves_router_untouched() {
+    let config = ResilienceConfig::new()
+        .with_circuit_breaker(false)
+        .with_bulkhead(false);
+    let app = apply_resilience(
+        Router::new().route("/boom", get(|| async { StatusCode::INTERNAL_SERVER_ERROR })),
+        &config,
+    );
+
+    // With the breaker disabled, 5xx never turns into 503 no matter how many.
+    for _ in 0..5 {
+        assert_eq!(
+            status_of(&app, "/boom").await,
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+}
+
+#[tokio::test]
+async fn bulkhead_alone_attaches_to_router() {
+    let config = ResilienceConfig::new()
+        .with_circuit_breaker(false)
+        .with_bulkhead(true)
+        .with_bulkhead_max_concurrent(4);
+    let app = apply_resilience(Router::new().route("/", get(|| async { "ok" })), &config);
+
+    assert_eq!(status_of(&app, "/").await, StatusCode::OK);
+}


### PR DESCRIPTION
Closes #33.

## What the issue reported

`circuit_breaker_layer::<Req, Err>()` required `Req: Clone`, which axum's `Request<Body>` does not satisfy, so the layer could not be attached to a `Router`.

## What was actually wrong

The reported bound is real, but it was the surface of several distinct problems. Two of them made the middleware **silently inert** rather than failing to compile, which is the more dangerous class of bug.

**1. The type parameter was mislabeled.** Upstream's first parameter is the *response* type, not the request. Nothing in the builder needed `Clone`. The doctest only compiled because `Request<()>` happens to be cloneable — it was teaching the wrong type.

**2. We were six minor versions stale.** On 0.4.7 the layer genuinely could not attach: `CircuitBreakerRequestLayer` had a spurious `Req: Clone` from a `#[derive]`, and `CircuitBreaker` held `PhantomData<Req>` making it `!Sync`. Both were fixed upstream (0.9.0 removed the request type parameter outright). Upgrading 0.4.7 → 0.10.0 resolves them.

**3. State was reset on every request.** axum re-invokes `Layer::layer` per request, and `build()` mints fresh state each application — verified empirically: 8 layer applications for 4 requests. The breaker's failure window reset between requests so it could never open, and every request received its own full set of bulkhead permits so the concurrency cap never applied. Both now use `build_with_handle()`, which shares state.

**4. The default classifier never fires on inbound HTTP.** An inbound axum route is infallible — a failing handler returns `Ok(Response)` with a 5xx status, never `Err`. The default classifier counts only `Err`. A hand-attached breaker would compile, look correct, and never trip.

Problems 3 and 4 both produce middleware that appears installed and does nothing. Neither would have been caught by a test that only asserts the stack compiles.

## The change

- Bump `tower-resilience-circuitbreaker` / `-bulkhead` 0.4.7 → 0.10.0
- `circuit_breaker_layer()` loses its type parameters and the bogus `Clone` bound
- New `http_circuit_breaker_layer()` with a 5xx-aware classifier (4xx is the caller's fault and does not trip the circuit)
- New `apply_resilience(Router, &ResilienceConfig) -> Router`, following the existing `apply_security_headers` convention. It wires the classifier, the error handler converting rejections to 503 (`Router::layer` requires `Infallible`), and ordering that puts the bulkhead inside the breaker so overload rejections count as failures.
- Docs updated, including removal of an invented rationale ("the breaker may need to inspect a request more than once") that was never the reason for the bound.

## Testing

`acton-service/tests/resilience_router.rs` asserts the breaker **actually opens** end-to-end, not just that the stack compiles. The trip test failed against the first version of this fix, which is what surfaced problem 3.

- 114/114 package tests pass
- clippy clean, no suppressions
- doctests pass

## Note for review

`circuit_breaker_layer()` losing its type parameters is a breaking API change. It's source-compatible for callers who never used the turbofish, but anyone who followed the old doctest (`::<Request<()>, String>`) was already constructing a nonsense layer. Worth calling out in the changelog.

I did not audit 0.4→0.10 for behavioral changes in breaker semantics beyond what these tests cover; upstream #283 ("Align circuit-breaker semantics with ex_resilience") suggests there were some. Flagging rather than silently assuming parity.