### PR TITLE
fix(tls)!: refuse to start instead of degrading to plaintext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **tls**: A `[tls]` or `[grpc.tls]` section with `enabled = true` whose
+  certificate or key fails to load is now a hard startup failure. Previously
+  the loader logged the error and returned `None`, and the listener came up
+  in **plaintext** on whatever bind was configured — including a
+  non-loopback one — while the application believed it was serving TLS. A
+  section that says `enabled = true` is the operator's explicit statement of
+  intended posture; silently serving a weaker posture than configured
+  inverts the fail-safe direction. (#41)
+- **auth**: Invalid PASETO or JWT token configuration is likewise fatal.
+  It previously logged a warning and *skipped the authentication middleware
+  entirely*, so a typo in the token config silently published every
+  authenticated route unauthenticated. (#41)
+
+### Features
+
+- **builder**: `ServiceBuilder::try_build()` returns
+  `Result<ActonService<T>>`, reporting the misconfigurations above at build
+  time. The existing infallible `build()` is unchanged and remains the
+  ergonomic path — it defers the same error to `serve()`, which now returns
+  it before binding any listener. (#41)
+- **tls**: `ServiceBuilder::with_tls_config()` and
+  `with_grpc_tls_config()` accept a pre-built
+  `Arc<rustls::ServerConfig>`. An application that has already loaded and
+  validated its key material can hand the builder exactly the object it
+  checked, eliminating the second read of the cert files and with it the
+  time-of-check/time-of-use window in which renewal hooks or permission
+  changes could alter the material between validation and listen. When set,
+  the override wins over the corresponding config section. (#41)
+
+### Notes
+
+- The strict behavior is the default rather than an opt-in flag: there is no
+  coherent posture in which "attempt TLS, but plaintext is acceptable" is
+  the intended outcome of an enabled TLS section. Deployments that were
+  unknowingly relying on the degrade will now fail to start — which is the
+  point, and the failure names the cert path that could not be loaded.
+
 ## [acton-service-v0.28.0] - 2026-07-17
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-build",
  "rand 0.10.1",
+ "rcgen",
  "redis",
  "regex",
  "reqwest 0.12.28",
@@ -484,6 +485,45 @@ name = "askama_web_derive"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940074e50ab8a902980dec23d265697dd1e8789e66be664d183dbb24c79b8e7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1001,7 +1041,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -1009,6 +1049,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1959,6 +2008,20 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -4681,6 +4744,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5836,6 +5908,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "reblessive"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6378,6 +6464,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -9683,6 +9778,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9699,6 +9812,16 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/acton-service/Cargo.toml
+++ b/acton-service/Cargo.toml
@@ -330,4 +330,5 @@ tonic-build.workspace = true
 tonic-prost-build.workspace = true
 
 [dev-dependencies]
+rcgen = "0.14.8"
 tempfile = "3.24.0"

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -134,6 +134,14 @@ where
     graphql: Option<crate::graphql::VersionedGraphQL>,
     agent_runtime: Option<acton_reactive::prelude::ActorRuntime>,
     actor_extensions: Vec<Box<dyn crate::extensions::ActorExtensionSpawner>>,
+    /// Pre-built HTTP TLS config supplied by the caller. When set, `build()`
+    /// uses it verbatim and never reads `[tls]` cert/key files.
+    #[cfg(feature = "tls")]
+    tls_config_override: Option<std::sync::Arc<tokio_rustls::rustls::ServerConfig>>,
+    /// Pre-built gRPC TLS config supplied by the caller. When set, `build()`
+    /// uses it verbatim and never reads `[grpc.tls]` cert/key files.
+    #[cfg(all(feature = "grpc", feature = "tls"))]
+    grpc_tls_config_override: Option<std::sync::Arc<tokio_rustls::rustls::ServerConfig>>,
 }
 
 impl<T> ServiceBuilder<T>
@@ -156,7 +164,46 @@ where
             graphql: None,
             agent_runtime: None,
             actor_extensions: Vec::new(),
+            #[cfg(feature = "tls")]
+            tls_config_override: None,
+            #[cfg(all(feature = "grpc", feature = "tls"))]
+            grpc_tls_config_override: None,
         }
+    }
+
+    /// Supply a pre-built HTTP TLS configuration.
+    ///
+    /// When set, `build()` uses this config verbatim for the HTTP listener and
+    /// never reads the `[tls]` `cert_path` / `key_path` files. Use this when the
+    /// application has already loaded and validated the key material: it removes
+    /// the second read that would otherwise sit between your check and the
+    /// listener coming up, closing that time-of-check/time-of-use window.
+    ///
+    /// The override applies whenever it is set, regardless of what `[tls]` says.
+    #[cfg(feature = "tls")]
+    pub fn with_tls_config(
+        mut self,
+        config: std::sync::Arc<tokio_rustls::rustls::ServerConfig>,
+    ) -> Self {
+        self.tls_config_override = Some(config);
+        self
+    }
+
+    /// Supply a pre-built TLS configuration for the separate-port gRPC listener.
+    ///
+    /// The gRPC twin of [`with_tls_config`](Self::with_tls_config), carrying the
+    /// same time-of-check/time-of-use guarantee. Applies only to the dual-port
+    /// gRPC listener; in single-port mode the HTTP TLS config terminates both.
+    ///
+    /// The override applies whenever it is set, regardless of what `[grpc.tls]`
+    /// says, and suppresses the fallback to the shared `[tls]` config.
+    #[cfg(all(feature = "grpc", feature = "tls"))]
+    pub fn with_grpc_tls_config(
+        mut self,
+        config: std::sync::Arc<tokio_rustls::rustls::ServerConfig>,
+    ) -> Self {
+        self.grpc_tls_config_override = Some(config);
+        self
     }
 
     /// Register a custom actor extension.
@@ -401,6 +448,12 @@ where
     /// // → Uses your config, spawns appropriate pool agents
     /// ```
     pub fn build(mut self) -> ActonService<T> {
+        // Collects the first fatal misconfiguration found while building.
+        // Surfaced by `try_build()`, or by `serve()` before any socket binds.
+        // Security-relevant subsystems (TLS, token auth) record here instead of
+        // degrading to a weaker posture than the operator configured.
+        let mut startup_error: Option<crate::error::Error> = None;
+
         // Load config if not provided
         let config = self.config.take().unwrap_or_else(|| {
             Config::<T>::load().unwrap_or_else(|e| {
@@ -1152,7 +1205,16 @@ where
 
         // Apply general middleware stack (CORS, compression, timeout, TraceLayer, etc.)
         // Layers are applied in reverse order (bottom layer is innermost/first)
-        let mut app = Self::apply_middleware(app, &config);
+        // Whether the HTTP listener will terminate TLS. An injected config
+        // activates TLS independently of the `[tls]` section, so both sources
+        // count — otherwise HSTS would be dropped on encrypted connections.
+        #[cfg(feature = "tls")]
+        let tls_active = self.tls_config_override.is_some()
+            || config.tls.as_ref().is_some_and(|t| t.enabled);
+        #[cfg(not(feature = "tls"))]
+        let tls_active = false;
+
+        let mut app = Self::apply_middleware(app, &config, tls_active);
 
         // Apply session middleware if configured
         // Session runs after general middleware, before JWT/Cedar
@@ -1290,7 +1352,12 @@ where
                             ));
                         }
                         Err(e) => {
-                            tracing::warn!("PASETO configuration invalid, skipping authentication middleware: {}", e);
+                            tracing::error!(
+                                "PASETO configuration invalid; refusing to start rather than \
+                                 serving unauthenticated: {}",
+                                e
+                            );
+                            record_startup_error(&mut startup_error, e);
                         }
                     }
                 }
@@ -1311,10 +1378,12 @@ where
                             ));
                         }
                         Err(e) => {
-                            tracing::warn!(
-                                "JWT configuration invalid, skipping authentication middleware: {}",
+                            tracing::error!(
+                                "JWT configuration invalid; refusing to start rather than \
+                                 serving unauthenticated: {}",
                                 e
                             );
+                            record_startup_error(&mut startup_error, e);
                         }
                     }
                 }
@@ -1332,10 +1401,17 @@ where
         let listener_addr =
             std::net::SocketAddr::new(config.service.bind, config.service.port);
 
-        // Load TLS config once at build time (fail fast on bad certs)
+        // Resolve the HTTP TLS config. A `[tls]` section with `enabled = true`
+        // is the operator's explicit statement of intended posture, so a load
+        // failure is fatal: it is recorded in `startup_error` and surfaced by
+        // `try_build()` / `serve()` before any listener binds. Serving plaintext
+        // where TLS was configured would silently invert the fail-safe direction.
         #[cfg(feature = "tls")]
         let tls_config = {
-            if let Some(ref tls_cfg) = config.tls {
+            if let Some(sc) = self.tls_config_override.take() {
+                tracing::info!("TLS configured from caller-supplied ServerConfig");
+                Some(sc)
+            } else if let Some(ref tls_cfg) = config.tls {
                 if tls_cfg.enabled {
                     match crate::tls::load_server_config(tls_cfg) {
                         Ok(sc) => {
@@ -1347,7 +1423,11 @@ where
                             Some(sc)
                         }
                         Err(e) => {
-                            tracing::error!("Failed to load TLS configuration: {}", e);
+                            tracing::error!(
+                                "Failed to load TLS configuration; refusing to start: {}",
+                                e
+                            );
+                            record_startup_error(&mut startup_error, e);
                             None
                         }
                     }
@@ -1360,33 +1440,45 @@ where
         };
 
         // Resolve per-listener TLS for the separate-port gRPC listener.
-        // Mirrors the HTTP TLS handling above (log-and-degrade on load error).
         // A present `[grpc.tls]` section is authoritative for the gRPC
         // listener — `enabled = false` means plaintext gRPC even when the
         // shared `[tls]` is active. Only an absent section inherits it.
+        // As with HTTP above, a failed load of an enabled section is fatal
+        // rather than a silent downgrade to plaintext.
         #[cfg(all(feature = "grpc", feature = "tls"))]
-        let grpc_tls_config = match config.grpc.as_ref().and_then(|g| g.tls.as_ref()) {
-            Some(grpc_tls) if grpc_tls.enabled => match crate::tls::load_server_config(grpc_tls) {
-                Ok(sc) => {
-                    tracing::info!(
-                        "gRPC TLS configured (cert: {}, key: {})",
-                        grpc_tls.cert_path.display(),
-                        grpc_tls.key_path.display()
-                    );
-                    Some(sc)
+        let grpc_tls_config = if let Some(sc) = self.grpc_tls_config_override.take() {
+            tracing::info!("gRPC TLS configured from caller-supplied ServerConfig");
+            Some(sc)
+        } else {
+            match config.grpc.as_ref().and_then(|g| g.tls.as_ref()) {
+                Some(grpc_tls) if grpc_tls.enabled => {
+                    match crate::tls::load_server_config(grpc_tls) {
+                        Ok(sc) => {
+                            tracing::info!(
+                                "gRPC TLS configured (cert: {}, key: {})",
+                                grpc_tls.cert_path.display(),
+                                grpc_tls.key_path.display()
+                            );
+                            Some(sc)
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to load gRPC TLS configuration; refusing to start: {}",
+                                e
+                            );
+                            record_startup_error(&mut startup_error, e);
+                            None
+                        }
+                    }
                 }
-                Err(e) => {
-                    tracing::error!("Failed to load gRPC TLS configuration: {}", e);
+                Some(_) => {
+                    tracing::info!(
+                        "gRPC TLS explicitly disabled; separate-port gRPC listener serves plaintext"
+                    );
                     None
                 }
-            },
-            Some(_) => {
-                tracing::info!(
-                    "gRPC TLS explicitly disabled; separate-port gRPC listener serves plaintext"
-                );
-                None
+                None => tls_config.clone(),
             }
-            None => tls_config.clone(),
         };
 
         ActonService {
@@ -1401,6 +1493,27 @@ where
             #[cfg(all(feature = "grpc", feature = "tls"))]
             grpc_tls_config,
             agent_runtime: self.agent_runtime,
+            startup_error,
+        }
+    }
+
+    /// Build the service, returning an error on fatal misconfiguration.
+    ///
+    /// Identical to [`build`](Self::build) except that a security-relevant
+    /// misconfiguration is reported here rather than at [`ActonService::serve`].
+    /// Prefer this when the caller wants to observe the failure before the
+    /// service is handed off. The conditions are the same either way — a
+    /// configured-but-unloadable TLS section, or invalid token-auth config —
+    /// and in neither case does a listener bind.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first fatal misconfiguration encountered during the build.
+    pub fn try_build(self) -> crate::error::Result<ActonService<T>> {
+        let mut service = self.build();
+        match service.startup_error.take() {
+            Some(e) => Err(e),
+            None => Ok(service),
         }
     }
 
@@ -1570,7 +1683,13 @@ where
     /// Apply middleware stack based on configuration
     ///
     /// Applies middleware in the correct order to ensure proper request handling
-    fn apply_middleware(app: Router, config: &Config<T>) -> Router {
+    ///
+    /// `tls_active` reports whether the HTTP listener will actually terminate
+    /// TLS. It is passed in rather than re-derived from `config.tls` because a
+    /// caller-supplied config via [`with_tls_config`](Self::with_tls_config)
+    /// enables TLS regardless of what the `[tls]` section says; deriving it here
+    /// would drop HSTS from connections that are in fact encrypted.
+    fn apply_middleware(app: Router, config: &Config<T>, tls_active: bool) -> Router {
         let body_limit = config.middleware.body_limit_mb * 1024 * 1024;
 
         let mut app = app;
@@ -1591,18 +1710,11 @@ where
         app = app.layer(cors_layer);
 
         // Security headers (after CORS, before compression)
-        {
-            #[cfg(feature = "tls")]
-            let tls_enabled = config.tls.as_ref().map(|t| t.enabled).unwrap_or(false);
-            #[cfg(not(feature = "tls"))]
-            let tls_enabled = false;
-
-            app = crate::middleware::security_headers::apply_security_headers(
-                app,
-                &config.middleware.security_headers,
-                tls_enabled,
-            );
-        }
+        app = crate::middleware::security_headers::apply_security_headers(
+            app,
+            &config.middleware.security_headers,
+            tls_active,
+        );
 
         // Compression - configurable
         if config.middleware.compression {
@@ -1663,6 +1775,17 @@ where
     }
 }
 
+/// Record a fatal build-time misconfiguration, keeping the first one seen.
+///
+/// The build continues after a failure so that every problem gets logged in one
+/// pass rather than one per restart, but only the first error is returned to the
+/// caller — it is the one that stopped the intended posture from being honoured.
+fn record_startup_error(slot: &mut Option<crate::error::Error>, error: crate::error::Error) {
+    if slot.is_none() {
+        *slot = Some(error);
+    }
+}
+
 impl<T> Default for ServiceBuilder<T>
 where
     T: Serialize + DeserializeOwned + Clone + Default + Send + Sync + 'static,
@@ -1698,6 +1821,10 @@ where
     #[cfg(all(feature = "grpc", feature = "tls"))]
     grpc_tls_config: Option<std::sync::Arc<tokio_rustls::rustls::ServerConfig>>,
     agent_runtime: Option<acton_reactive::prelude::ActorRuntime>,
+    /// Fatal misconfiguration recorded during `build()`. `serve()` returns this
+    /// before binding any listener, so a service that could not honour its
+    /// configured security posture never accepts a connection.
+    startup_error: Option<crate::error::Error>,
 }
 
 impl<T> ActonService<T>
@@ -1727,6 +1854,13 @@ where
     pub async fn serve(mut self) -> crate::error::Result<()> {
         use tokio::net::TcpListener;
         use tokio::signal;
+
+        // Fail before any socket binds. A misconfiguration that would force a
+        // weaker posture than configured (TLS that could not load, invalid token
+        // auth) must never reach the point of accepting connections.
+        if let Some(e) = self.startup_error.take() {
+            return Err(e);
+        }
 
         // Graceful shutdown signal
         async fn shutdown_signal() {
@@ -2039,5 +2173,217 @@ mod tests {
         // let routes = VersionedRoutes { router: Router::new() };
 
         // The ONLY way to create VersionedRoutes is through VersionedApiBuilder
+    }
+
+    /// A `[tls]` section pointing at cert material that cannot be loaded must be
+    /// a hard failure. Serving plaintext where the operator configured TLS is a
+    /// silent downgrade of the configured security posture.
+    #[cfg(feature = "tls")]
+    #[test]
+    fn tls_load_failure_is_fatal_not_a_plaintext_downgrade() {
+        use crate::config::{Config, TlsConfig};
+        use crate::prelude::ServiceBuilder;
+
+        let config = Config::<()> {
+            tls: Some(TlsConfig {
+                enabled: true,
+                cert_path: "/nonexistent/cert.pem".into(),
+                key_path: "/nonexistent/key.pem".into(),
+            }),
+            ..Default::default()
+        };
+
+        let result = ServiceBuilder::new().with_config(config).try_build();
+
+        assert!(
+            result.is_err(),
+            "unloadable TLS material must fail the build, not degrade to plaintext"
+        );
+    }
+
+    /// The gRPC twin of the above: `[grpc.tls]` is authoritative for the
+    /// separate-port listener, so a failed load there must not leave that
+    /// listener serving plaintext on a possibly non-loopback bind.
+    #[cfg(all(feature = "grpc", feature = "tls"))]
+    #[test]
+    fn grpc_tls_load_failure_is_fatal_not_a_plaintext_downgrade() {
+        use crate::config::{Config, GrpcConfig, TlsConfig};
+        use crate::prelude::ServiceBuilder;
+
+        let grpc = Some(GrpcConfig {
+            enabled: true,
+            use_separate_port: true,
+            bind: None,
+            tls: Some(TlsConfig {
+                enabled: true,
+                cert_path: "/nonexistent/cert.pem".into(),
+                key_path: "/nonexistent/key.pem".into(),
+            }),
+            port: 50051,
+            reflection_enabled: false,
+            health_check_enabled: false,
+            max_message_size_mb: 4,
+            connection_timeout_secs: 10,
+            timeout_secs: 30,
+            proto: Default::default(),
+        });
+        let config = Config::<()> {
+            grpc,
+            ..Default::default()
+        };
+
+        let result = ServiceBuilder::new().with_config(config).try_build();
+
+        assert!(
+            result.is_err(),
+            "unloadable gRPC TLS material must fail the build, not degrade to plaintext"
+        );
+    }
+
+    /// TLS that is present but explicitly disabled is a deliberate operator
+    /// choice, not a failure — it must still build.
+    #[cfg(feature = "tls")]
+    #[test]
+    fn disabled_tls_section_builds_successfully() {
+        use crate::config::{Config, TlsConfig};
+        use crate::prelude::ServiceBuilder;
+
+        let config = Config::<()> {
+            tls: Some(TlsConfig {
+                enabled: false,
+                cert_path: "/nonexistent/cert.pem".into(),
+                key_path: "/nonexistent/key.pem".into(),
+            }),
+            ..Default::default()
+        };
+
+        assert!(
+            ServiceBuilder::new().with_config(config).try_build().is_ok(),
+            "an explicitly disabled TLS section must not block startup"
+        );
+    }
+
+    /// An injected config must be used verbatim, with no read of the configured
+    /// cert paths — that second read is the time-of-check/time-of-use window
+    /// `with_tls_config` exists to close. Paths that would fail to load prove
+    /// they were never touched.
+    #[cfg(feature = "tls")]
+    #[test]
+    fn injected_tls_config_bypasses_the_file_load() {
+        use crate::config::{Config, TlsConfig};
+        use crate::prelude::ServiceBuilder;
+
+        let config = Config::<()> {
+            tls: Some(TlsConfig {
+                enabled: true,
+                cert_path: "/nonexistent/cert.pem".into(),
+                key_path: "/nonexistent/key.pem".into(),
+            }),
+            ..Default::default()
+        };
+
+        let result = ServiceBuilder::new()
+            .with_config(config)
+            .with_tls_config(test_server_config())
+            .try_build();
+
+        assert!(
+            result.is_ok(),
+            "an injected ServerConfig must be used without reading the configured paths"
+        );
+    }
+
+    /// `serve()` must reject a degraded build before it binds any listener, so
+    /// callers using the infallible `build()` are protected too.
+    #[cfg(feature = "tls")]
+    #[tokio::test]
+    async fn serve_refuses_to_bind_after_a_failed_tls_load() {
+        use crate::config::{Config, TlsConfig};
+        use crate::prelude::ServiceBuilder;
+
+        let base = Config::<()>::default();
+        let config = Config::<()> {
+            // Port 0 binds successfully, so any error can only come from the
+            // startup gate rather than from an unavailable port.
+            service: crate::config::ServiceConfig {
+                port: 0,
+                ..base.service.clone()
+            },
+            tls: Some(TlsConfig {
+                enabled: true,
+                cert_path: "/nonexistent/cert.pem".into(),
+                key_path: "/nonexistent/key.pem".into(),
+            }),
+            ..base
+        };
+
+        let service = ServiceBuilder::new().with_config(config).build();
+
+        assert!(
+            service.serve().await.is_err(),
+            "serve() must surface the failed TLS load instead of listening in plaintext"
+        );
+    }
+
+    /// An injected TLS config activates TLS independently of the `[tls]`
+    /// section, so HSTS must still be sent. Deriving the flag from
+    /// `config.tls.enabled` alone would drop the header on connections that are
+    /// in fact encrypted.
+    #[cfg(feature = "tls")]
+    #[tokio::test]
+    async fn injected_tls_config_still_sends_hsts() {
+        use crate::config::Config;
+        use crate::prelude::ServiceBuilder;
+        use axum::body::Body;
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        // No `[tls]` section at all — TLS comes purely from the injected config.
+        let config = Config::<()>::default();
+        assert!(config.tls.is_none(), "test premise: no [tls] section");
+
+        let service = ServiceBuilder::new()
+            .with_config(config)
+            .with_tls_config(test_server_config())
+            .try_build()
+            .expect("build with injected TLS config");
+
+        let response = service
+            .app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("health request");
+
+        assert!(
+            response
+                .headers()
+                .contains_key("strict-transport-security"),
+            "HSTS must be sent when an injected config puts the listener on TLS"
+        );
+    }
+
+    /// Build a usable self-signed `ServerConfig` for injection tests.
+    #[cfg(feature = "tls")]
+    fn test_server_config() -> std::sync::Arc<tokio_rustls::rustls::ServerConfig> {
+        use tokio_rustls::rustls::pki_types::PrivatePkcs8KeyDer;
+        use tokio_rustls::rustls::ServerConfig;
+
+        crate::crypto::ensure_default_crypto_provider();
+
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("self-signed cert generation");
+        let key = PrivatePkcs8KeyDer::from(cert.signing_key.serialize_der());
+
+        std::sync::Arc::new(
+            ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(vec![cert.cert.der().clone()], key.into())
+                .expect("server config"),
+        )
     }
 }

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -1352,12 +1352,13 @@ where
                             ));
                         }
                         Err(e) => {
-                            tracing::error!(
-                                "PASETO configuration invalid; refusing to start rather than \
-                                 serving unauthenticated: {}",
-                                e
-                            );
-                            record_startup_error(&mut startup_error, e);
+                            let err = crate::error::Error::Internal(format!(
+                                "PASETO authentication is configured but its configuration is \
+                                 invalid; refusing to start rather than serving authenticated \
+                                 routes without authentication: {e}"
+                            ));
+                            tracing::error!("{}", err);
+                            record_startup_error(&mut startup_error, err);
                         }
                     }
                 }
@@ -1378,12 +1379,13 @@ where
                             ));
                         }
                         Err(e) => {
-                            tracing::error!(
-                                "JWT configuration invalid; refusing to start rather than \
-                                 serving unauthenticated: {}",
-                                e
-                            );
-                            record_startup_error(&mut startup_error, e);
+                            let err = crate::error::Error::Internal(format!(
+                                "JWT authentication is configured but its configuration is \
+                                 invalid; refusing to start rather than serving authenticated \
+                                 routes without authentication: {e}"
+                            ));
+                            tracing::error!("{}", err);
+                            record_startup_error(&mut startup_error, err);
                         }
                     }
                 }
@@ -1423,11 +1425,12 @@ where
                             Some(sc)
                         }
                         Err(e) => {
-                            tracing::error!(
-                                "Failed to load TLS configuration; refusing to start: {}",
-                                e
-                            );
-                            record_startup_error(&mut startup_error, e);
+                            let err = crate::error::Error::Internal(format!(
+                                "TLS is enabled but its configuration failed to load; \
+                                 refusing to start a plaintext listener: {e}"
+                            ));
+                            tracing::error!("{}", err);
+                            record_startup_error(&mut startup_error, err);
                             None
                         }
                     }
@@ -1462,11 +1465,12 @@ where
                             Some(sc)
                         }
                         Err(e) => {
-                            tracing::error!(
-                                "Failed to load gRPC TLS configuration; refusing to start: {}",
-                                e
-                            );
-                            record_startup_error(&mut startup_error, e);
+                            let err = crate::error::Error::Internal(format!(
+                                "gRPC TLS is enabled but its configuration failed to load; \
+                                 refusing to start a plaintext gRPC listener: {e}"
+                            ));
+                            tracing::error!("{}", err);
+                            record_startup_error(&mut startup_error, err);
                             None
                         }
                     }
@@ -2193,11 +2197,23 @@ mod tests {
             ..Default::default()
         };
 
-        let result = ServiceBuilder::new().with_config(config).try_build();
+        let error = ServiceBuilder::new()
+            .with_config(config)
+            .try_build()
+            .err()
+            .expect("unloadable TLS material must fail the build, not degrade to plaintext");
 
+        // The returned error must stand on its own. An operator who sees only
+        // this (a crash message, a supervisor log) should not have to go find
+        // the tracing line to learn why startup was refused.
+        let message = error.to_string();
         assert!(
-            result.is_err(),
-            "unloadable TLS material must fail the build, not degrade to plaintext"
+            message.contains("refusing to start a plaintext listener"),
+            "error must explain the refusal, got: {message}"
+        );
+        assert!(
+            message.contains("/nonexistent/cert.pem"),
+            "error must name the material that could not be loaded, got: {message}"
         );
     }
 


### PR DESCRIPTION
Closes #41. Closes #29.

#29 is the HTTP-side report of the same defect, filed earlier against 0.27.0; #41 is the gRPC-side report against 0.28.0. Both are the single `Err => None` shape in `ServiceBuilder::build()`, so one fix closes both. Worth noting that `src/server.rs:105` already did the right thing (`load_server_config(tls_config)?`) — the codebase held the correct semantics in one path and the degrade in the other, and this brings `ServiceBuilder` in line with it.

## The gap

`ServiceBuilder::build()` resolved TLS by calling `crate::tls::load_server_config`, and on `Err` logged and returned `None`. `serve()` then gated on `if let Some(ref server_config)` and fell through to plaintext `axum::serve`. A `[grpc.tls] enabled = true` with an unreadable cert brought the separate-port gRPC listener up in the clear on whatever `[grpc] bind` said. The comment above the block even claimed "fail fast on bad certs" — nothing failed.

The root cause was structural: `build()` returns `ActonService<T>`, not a `Result`, so there was no way to report the failure.

The same shape was present for token auth (`PASETO configuration invalid, skipping authentication middleware`), which dropped authentication entirely on a config typo. Same inverted fail-safe, wider blast radius — so it is fixed here too.

## The fix

**Fatal, not degraded.** `build()` collects a `startup_error`, surfaced by the new `try_build() -> Result<ActonService<T>>` or by `serve()` as its very first statement — before any `TcpListener::bind`, including the one handed to the spawned gRPC task. `build()` keeps its signature, so this is not source-breaking.

**Strict by default, not a flag.** Issue #41 offered a builder flag as one option. There is no coherent posture in which "attempt TLS, but plaintext is acceptable" is the intended reading of `enabled = true`, so making it opt-in would leave the footgun loaded for everyone who doesn't know to reach for it.

**Injectable configs.** `with_tls_config()` / `with_grpc_tls_config()` take an `Arc<rustls::ServerConfig>` and bypass the file read entirely. Deferring the error narrows the TOCTOU window the issue describes; only removing the second load closes it. When set, the override wins over the corresponding config section.

## Reviewer-caught regression, fixed here

An independent review of the diff caught that `apply_middleware` derived its HSTS flag from `config.tls.enabled`. That was a faithful proxy before this PR, but an injected config activates TLS with `[tls]` absent or disabled — so HSTS would have been silently dropped on genuinely encrypted connections. The flag is now computed from the resolved posture and covered by `injected_tls_config_still_sends_hsts`.

## Compatibility

Behavior change, so this wants a minor (0.x breaking) bump rather than a patch. Deployments unknowingly relying on the degrade will now fail to start — which is the point; the error names the cert path that could not be loaded.

## Verification

Both CI configurations, clean:

- `cargo clippy --all-targets --features full -- -D warnings` — zero warnings, no suppressions added
- `cargo nextest run --features full` — 536 passed
- same two under `--no-default-features --features "full,crypto-ring"` — 536 passed

Six new tests cover: HTTP and gRPC load failure being fatal, an explicitly disabled section still building, injection bypassing the file read, `serve()` refusing to bind (on port 0, which would otherwise bind successfully — so the error can only come from the gate), and the HSTS regression.

## Follow-up commit

Per #29's ask, the *returned* error now explains the refusal rather than carrying only `load_server_config`'s raw message. The refusal reason previously lived just in the `tracing::error!` line — and "one log line that is easy to miss under startup noise" is precisely the failure mode these changes exist to close, so an operator seeing only the propagated error should not have to hunt for the log to learn why startup was refused. Each fatal path now builds one error carrying both the refusal and the underlying cause, logs that, and returns it. The test asserts the message both explains the refusal and names the unloadable path.

#29 also independently reached the same conclusion this PR did on the design question — that log-and-downgrade must never be the default, and any back-compat fallback would have to be explicit opt-in.
