### PR TITLE
fix(resilience)!: wire [middleware.resilience] to layers, drop inert config

### DIFF
--- a/acton-cli/src/commands/service/add/middleware.rs
+++ b/acton-cli/src/commands/service/add/middleware.rs
@@ -197,14 +197,10 @@ fn show_resilience_middleware() {
     println!("   circuit_breaker_min_requests = 10");
     println!("   circuit_breaker_wait_secs = 30");
     println!();
-    println!("   # Retry");
-    println!("   retry_enabled = true");
-    println!("   retry_max_attempts = 3");
-    println!("   retry_backoff_ms = 100");
-    println!();
     println!("   # Bulkhead");
     println!("   bulkhead_enabled = true");
     println!("   bulkhead_max_concurrent = 100");
+    println!("   bulkhead_max_wait_ms = 5000");
     println!();
 
     println!("{}", "Automatic integration:".cyan().bold());

--- a/acton-docs/src/app/docs/concepts/page.md
+++ b/acton-docs/src/app/docs/concepts/page.md
@@ -227,12 +227,12 @@ per_user_rpm = 200
 per_client_rpm = 1000
 window_secs = 60
 
-# Resilience: circuit breaker, retry, bulkhead
+# Resilience: circuit breaker, bulkhead
 [middleware.resilience]
 circuit_breaker_enabled = true
 circuit_breaker_threshold = 0.5
-retry_enabled = true
-retry_max_attempts = 3
+bulkhead_enabled = true
+bulkhead_max_concurrent = 100
 ```
 
 Your builder chain stays free of middleware wiring:
@@ -504,11 +504,15 @@ Three resilience patterns solve different problems:
 - In-memory operations
 - Local file access
 
-### Retry
+### Retry (outbound clients only)
 
 **Problem:** Transient errors that might succeed if retried
 
 **Solution:** Automatically retry with exponential backoff
+
+**Where:** Compose this into your **outbound** client stacks. It is not
+available as server middleware — retrying means replaying a request, and an
+inbound request body is a stream that can only be consumed once.
 
 **When to use:**
 - Network timeouts
@@ -537,20 +541,21 @@ Three resilience patterns solve different problems:
 - Fast, lightweight operations (<10ms)
 - Already rate-limited endpoints
 
-### Using All Three Together
+### Using Both Together
 
 ```rust
 ResilienceConfig::new()
     .with_circuit_breaker(true)  // Detect failures
-    .with_retry(true)             // Handle transient errors
     .with_bulkhead(true)          // Prevent resource exhaustion
 ```
 
-Execution order:
-1. **Bulkhead** - Check if capacity available
-2. **Circuit Breaker** - Fail fast if dependency is down
-3. **Retry** - Retry if request failed
-4. **Request** - Execute actual handler
+Execution order (outermost first):
+1. **Circuit Breaker** - Fail fast while the service is unhealthy
+2. **Bulkhead** - Check if capacity is available
+3. **Request** - Execute actual handler
+
+The bulkhead sits inside the breaker so that a capacity rejection is observed
+as a failure, letting sustained overload open the circuit.
 
 ---
 

--- a/acton-docs/src/app/docs/resilience/page.md
+++ b/acton-docs/src/app/docs/resilience/page.md
@@ -161,8 +161,6 @@ resilience.circuit_breaker_wait_duration = Duration::from_secs(60);    // How lo
 | --- | --- | --- |
 | `with_circuit_breaker(bool)` | enable flag | Turns the circuit breaker on or off |
 | `with_circuit_breaker_threshold(f64)` | `0.0`–`1.0` | Failure rate that opens the circuit (clamped) |
-| `with_retry(bool)` | enable flag | Sets the retry flag (see [Retry Logic](#retry-logic)) |
-| `with_retry_max_attempts(usize)` | attempt count | Sets the retry attempt count |
 | `with_bulkhead(bool)` | enable flag | Turns the bulkhead on or off |
 | `with_bulkhead_max_concurrent(usize)` | concurrency cap | Maximum concurrent calls |
 
@@ -256,36 +254,13 @@ info!(
 
 ## Retry Logic
 
-{% callout type="warning" title="Retry has no layer today" %}
-`ResilienceConfig` carries retry settings — `retry_enabled`, `retry_max_attempts`, `retry_base_delay`, `retry_max_delay`, plus the `with_retry()` and `with_retry_max_attempts()` builders — and `[middleware.resilience]` accepts the matching TOML keys. **But no retry layer is constructed from them.** There is no `retry_layer()` constructor, and neither `ServiceBuilder` nor the resilience module builds retry middleware.
+{% callout type="warning" title="Retry is not server middleware" %}
+There is no retry layer, and there will not be one at this position. Retrying means **replaying** a request, and an inbound `Request<Body>` wraps a stream that is consumed once — the underlying retry layer requires `Req: Clone`, which an inbound request cannot satisfy. Buffering every request body to make it replayable would be a memory-exhaustion risk on a public endpoint.
 
-Setting these values changes nothing at runtime. Until a retry layer ships, implement retries in your client code (or with a tower retry layer of your own) and use the guidance below to decide *what* to retry.
+Retry belongs on **outbound** client stacks, where you control the request and can cheaply reconstruct it. Compose `tower-resilience-retry` (or `tower::retry`) into the clients you use to call databases and downstream services, and use the guidance below to decide *what* to retry.
+
+The `retry_*` fields and TOML keys were removed in the release following this note; they never did anything.
 {% /callout %}
-
-### Retry Settings (Configuration Only)
-
-```rust
-use acton_service::middleware::ResilienceConfig;
-use std::time::Duration;
-
-let mut resilience = ResilienceConfig::new()
-    .with_retry(true)
-    .with_retry_max_attempts(3);
-
-// Public fields — no builder methods for these
-resilience.retry_base_delay = Duration::from_millis(100);
-resilience.retry_max_delay = Duration::from_secs(10);
-```
-
-```toml
-[middleware.resilience]
-retry_enabled = true
-retry_max_attempts = 3
-retry_base_delay_ms = 100
-retry_max_delay_ms = 10000
-```
-
-There are no `with_retry_initial_backoff_ms()`, `with_retry_max_backoff_ms()`, `with_retry_backoff_multiplier()`, or `with_retry_jitter()` methods, and no backoff-multiplier or jitter fields.
 
 ### Backoff Strategy
 
@@ -535,7 +510,7 @@ Order your stack so that each layer protects the ones inside it:
 
 ## Configuration Templates
 
-Every method below exists on `ResilienceConfig`. The `with_retry*` calls set config fields for forward-compatibility but have no runtime effect until a retry layer ships — only the circuit breaker and bulkhead settings reach a layer.
+Every method below exists on `ResilienceConfig`, and every one reaches a layer.
 
 ### Conservative (Low-Risk Services)
 
@@ -543,8 +518,6 @@ Every method below exists on `ResilienceConfig`. The `with_retry*` calls set con
 ResilienceConfig::new()
     .with_circuit_breaker(true)
     .with_circuit_breaker_threshold(0.7)       // Higher threshold
-    .with_retry(true)
-    .with_retry_max_attempts(5)                // More retries
     .with_bulkhead(true)
     .with_bulkhead_max_concurrent(200)         // Higher capacity
 ```
@@ -555,8 +528,6 @@ ResilienceConfig::new()
 ResilienceConfig::new()
     .with_circuit_breaker(true)
     .with_circuit_breaker_threshold(0.3)       // Lower threshold
-    .with_retry(true)
-    .with_retry_max_attempts(2)                // Fewer retries
     .with_bulkhead(true)
     .with_bulkhead_max_concurrent(50)          // Lower capacity
 ```
@@ -567,8 +538,6 @@ ResilienceConfig::new()
 ResilienceConfig::new()
     .with_circuit_breaker(true)
     .with_circuit_breaker_threshold(0.5)       // Moderate threshold
-    .with_retry(true)
-    .with_retry_max_attempts(3)                // Standard retries
     .with_bulkhead(true)
     .with_bulkhead_max_concurrent(100)         // Moderate capacity
 ```

--- a/acton-docs/src/app/docs/service-discovery/page.md
+++ b/acton-docs/src/app/docs/service-discovery/page.md
@@ -422,14 +422,11 @@ acton-service includes circuit breaker middleware for fault tolerance:
 ```rust
 use acton_service::prelude::*;
 
-let resilience = ResilienceConfig {
-    circuit_breaker_enabled: true,
-    circuit_breaker_threshold: 5,
-    circuit_breaker_timeout_secs: 30,
-    retry_enabled: true,
-    retry_max_attempts: 3,
-    ..Default::default()
-};
+let resilience = ResilienceConfig::new()
+    .with_circuit_breaker(true)
+    .with_circuit_breaker_threshold(0.5)   // failure rate, 0.0-1.0
+    .with_bulkhead(true)
+    .with_bulkhead_max_concurrent(100);
 ```
 
 See [Resilience Patterns](/docs/resilience) for detailed circuit breaker configuration.

--- a/acton-service/src/config.rs
+++ b/acton-service/src/config.rs
@@ -1111,22 +1111,6 @@ pub struct ResilienceConfig {
     #[serde(default = "default_circuit_breaker_wait_secs")]
     pub circuit_breaker_wait_secs: u64,
 
-    /// Enable retry logic
-    #[serde(default = "default_true")]
-    pub retry_enabled: bool,
-
-    /// Maximum number of retry attempts
-    #[serde(default = "default_retry_max_attempts")]
-    pub retry_max_attempts: usize,
-
-    /// Base delay for exponential backoff (milliseconds)
-    #[serde(default = "default_retry_base_delay_ms")]
-    pub retry_base_delay_ms: u64,
-
-    /// Maximum delay for exponential backoff (milliseconds)
-    #[serde(default = "default_retry_max_delay_ms")]
-    pub retry_max_delay_ms: u64,
-
     /// Enable bulkhead (concurrency limiting)
     #[serde(default = "default_true")]
     pub bulkhead_enabled: bool,
@@ -1135,9 +1119,9 @@ pub struct ResilienceConfig {
     #[serde(default = "default_bulkhead_max_concurrent")]
     pub bulkhead_max_concurrent: usize,
 
-    /// Maximum queued requests
-    #[serde(default = "default_bulkhead_max_queued")]
-    pub bulkhead_max_queued: usize,
+    /// Maximum time a request waits for a bulkhead slot (milliseconds)
+    #[serde(default = "default_bulkhead_max_wait_ms")]
+    pub bulkhead_max_wait_ms: u64,
 }
 
 impl ResilienceConfig {
@@ -1146,12 +1130,9 @@ impl ResilienceConfig {
         Duration::from_secs(self.circuit_breaker_wait_secs)
     }
 
-    pub fn retry_base_delay(&self) -> Duration {
-        Duration::from_millis(self.retry_base_delay_ms)
-    }
-
-    pub fn retry_max_delay(&self) -> Duration {
-        Duration::from_millis(self.retry_max_delay_ms)
+    /// Maximum time a request waits for a bulkhead slot.
+    pub fn bulkhead_max_wait(&self) -> Duration {
+        Duration::from_millis(self.bulkhead_max_wait_ms)
     }
 }
 
@@ -1345,24 +1326,12 @@ fn default_circuit_breaker_wait_secs() -> u64 {
     30
 }
 
-fn default_retry_max_attempts() -> usize {
-    3
-}
-
-fn default_retry_base_delay_ms() -> u64 {
-    100
-}
-
-fn default_retry_max_delay_ms() -> u64 {
-    10000 // 10 seconds
-}
-
 fn default_bulkhead_max_concurrent() -> usize {
     100
 }
 
-fn default_bulkhead_max_queued() -> usize {
-    200
+fn default_bulkhead_max_wait_ms() -> u64 {
+    5000 // 5 seconds
 }
 
 // Metrics default functions

--- a/acton-service/src/middleware/resilience.rs
+++ b/acton-service/src/middleware/resilience.rs
@@ -1,7 +1,12 @@
 //! Resilience middleware for fault tolerance and reliability
 //!
-//! This module provides production-ready circuit breaker, retry, and bulkhead patterns
+//! This module provides production-ready circuit breaker and bulkhead patterns
 //! using tower-resilience to ensure service stability and graceful degradation.
+//!
+//! Retry is deliberately absent. Retrying means replaying a request, and an
+//! inbound `Request<Body>` wraps a stream that is consumed once -- the retry
+//! layer requires `Req: Clone`, which it cannot satisfy. Retry belongs on
+//! outbound client stacks, which callers compose themselves.
 
 use std::convert::Infallible;
 use std::time::Duration;
@@ -50,15 +55,6 @@ pub struct ResilienceConfig {
     /// Duration to wait before attempting to close circuit
     pub circuit_breaker_wait_duration: Duration,
 
-    /// Enable retry logic
-    pub retry_enabled: bool,
-    /// Maximum number of retry attempts
-    pub retry_max_attempts: usize,
-    /// Base delay for exponential backoff
-    pub retry_base_delay: Duration,
-    /// Maximum delay for exponential backoff
-    pub retry_max_delay: Duration,
-
     /// Enable bulkhead (concurrency limiting)
     pub bulkhead_enabled: bool,
     /// Maximum concurrent requests
@@ -75,14 +71,29 @@ impl Default for ResilienceConfig {
             circuit_breaker_min_requests: 10,
             circuit_breaker_wait_duration: Duration::from_secs(30),
 
-            retry_enabled: true,
-            retry_max_attempts: 3,
-            retry_base_delay: Duration::from_millis(100),
-            retry_max_delay: Duration::from_secs(10),
-
             bulkhead_enabled: true,
             bulkhead_max_concurrent: 100,
             bulkhead_max_wait: Duration::from_secs(5),
+        }
+    }
+}
+
+/// Bridge the TOML-facing config to the layer-building config.
+///
+/// [`crate::config::ResilienceConfig`] is what `[middleware.resilience]`
+/// deserializes into and stores its durations as integer seconds/milliseconds;
+/// this type is what actually builds layers and uses [`Duration`].
+impl From<&crate::config::ResilienceConfig> for ResilienceConfig {
+    fn from(config: &crate::config::ResilienceConfig) -> Self {
+        Self {
+            circuit_breaker_enabled: config.circuit_breaker_enabled,
+            circuit_breaker_threshold: config.circuit_breaker_threshold,
+            circuit_breaker_min_requests: config.circuit_breaker_min_requests,
+            circuit_breaker_wait_duration: config.circuit_breaker_wait_duration(),
+
+            bulkhead_enabled: config.bulkhead_enabled,
+            bulkhead_max_concurrent: config.bulkhead_max_concurrent,
+            bulkhead_max_wait: config.bulkhead_max_wait(),
         }
     }
 }
@@ -102,18 +113,6 @@ impl ResilienceConfig {
     /// Set circuit breaker threshold
     pub fn with_circuit_breaker_threshold(mut self, threshold: f64) -> Self {
         self.circuit_breaker_threshold = threshold.clamp(0.0, 1.0);
-        self
-    }
-
-    /// Set retry enabled
-    pub fn with_retry(mut self, enabled: bool) -> Self {
-        self.retry_enabled = enabled;
-        self
-    }
-
-    /// Set maximum retry attempts
-    pub fn with_retry_max_attempts(mut self, attempts: usize) -> Self {
-        self.retry_max_attempts = attempts;
         self
     }
 
@@ -319,7 +318,6 @@ mod tests {
     fn test_default_config() {
         let config = ResilienceConfig::default();
         assert!(config.circuit_breaker_enabled);
-        assert!(config.retry_enabled);
         assert!(config.bulkhead_enabled);
         assert_eq!(config.circuit_breaker_threshold, 0.5);
         assert_eq!(config.bulkhead_max_concurrent, 100);
@@ -329,11 +327,9 @@ mod tests {
     fn test_builder_pattern() {
         let config = ResilienceConfig::new()
             .with_circuit_breaker(false)
-            .with_retry_max_attempts(5)
             .with_bulkhead_max_concurrent(50);
 
         assert!(!config.circuit_breaker_enabled);
-        assert_eq!(config.retry_max_attempts, 5);
         assert_eq!(config.bulkhead_max_concurrent, 50);
     }
 

--- a/acton-service/src/server.rs
+++ b/acton-service/src/server.rs
@@ -62,6 +62,16 @@ impl Server {
             tls_enabled,
         );
 
+        // Resilience (circuit breaker + bulkhead) from [middleware.resilience]
+        #[cfg(feature = "resilience")]
+        let app = match self.config.middleware.resilience {
+            Some(ref resilience) => crate::middleware::resilience::apply_resilience(
+                app,
+                &crate::middleware::resilience::ResilienceConfig::from(resilience),
+            ),
+            None => app,
+        };
+
         let app = app
             // Compression - always enabled (minimal overhead)
             .layer(CompressionLayer::new())
@@ -144,13 +154,24 @@ impl Server {
 
         // Log optional advanced middleware
         if let Some(ref resilience) = self.config.middleware.resilience {
-            tracing::info!("  - Resilience configured:");
-            tracing::info!(
-                "    - Circuit breaker: {}",
-                resilience.circuit_breaker_enabled
-            );
-            tracing::info!("    - Retry: {}", resilience.retry_enabled);
-            tracing::info!("    - Bulkhead: {}", resilience.bulkhead_enabled);
+            // Report what was actually applied, not merely what was parsed.
+            #[cfg(feature = "resilience")]
+            {
+                tracing::info!("  - Resilience applied:");
+                tracing::info!(
+                    "    - Circuit breaker: {}",
+                    resilience.circuit_breaker_enabled
+                );
+                tracing::info!("    - Bulkhead: {}", resilience.bulkhead_enabled);
+            }
+            #[cfg(not(feature = "resilience"))]
+            {
+                let _ = resilience;
+                tracing::warn!(
+                    "  - Resilience: [middleware.resilience] is configured but the \
+                     'resilience' feature is disabled -- no resilience middleware is active"
+                );
+            }
         } else {
             tracing::info!("  - Resilience: not configured");
         }

--- a/acton-service/tests/resilience_router.rs
+++ b/acton-service/tests/resilience_router.rs
@@ -129,3 +129,43 @@ async fn bulkhead_alone_attaches_to_router() {
 
     assert_eq!(status_of(&app, "/").await, StatusCode::OK);
 }
+
+/// Issue #32: `[middleware.resilience]` was parsed but never reached a layer.
+/// This asserts the TOML-facing config bridges to a working breaker, so the
+/// wiring cannot silently regress to a no-op again.
+#[tokio::test]
+async fn toml_config_bridges_to_a_live_breaker() {
+    let toml_config = acton_service::config::ResilienceConfig {
+        circuit_breaker_enabled: true,
+        circuit_breaker_threshold: 0.5,
+        circuit_breaker_min_requests: 2,
+        circuit_breaker_wait_secs: 60,
+        bulkhead_enabled: false,
+        bulkhead_max_concurrent: 100,
+        bulkhead_max_wait_ms: 5_000,
+    };
+
+    let middleware_config = ResilienceConfig::from(&toml_config);
+    assert_eq!(middleware_config.circuit_breaker_min_requests, 2);
+    assert_eq!(
+        middleware_config.circuit_breaker_wait_duration,
+        Duration::from_secs(60)
+    );
+
+    let app = apply_resilience(
+        Router::new().route("/boom", get(|| async { StatusCode::INTERNAL_SERVER_ERROR })),
+        &middleware_config,
+    );
+
+    for _ in 0..2 {
+        assert_eq!(
+            status_of(&app, "/boom").await,
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+    assert_eq!(
+        status_of(&app, "/boom").await,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "config from [middleware.resilience] did not reach a live circuit breaker"
+    );
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -99,16 +99,14 @@ circuit_breaker_threshold = 0.5      # 50% failure rate opens circuit
 circuit_breaker_min_requests = 10    # Minimum requests before calculating
 circuit_breaker_wait_secs = 30       # Wait before attempting to close
 
-# Retry configuration
-retry_enabled = true
-retry_max_attempts = 3
-retry_base_delay_ms = 100           # Initial delay (exponential backoff)
-retry_max_delay_ms = 10000          # Maximum delay (10 seconds)
+# Retry is not server middleware: an inbound request body is a stream that can
+# only be consumed once, so it cannot be replayed. Compose retry into your
+# outbound clients instead.
 
 # Bulkhead configuration (concurrency limiting)
 bulkhead_enabled = true
 bulkhead_max_concurrent = 100       # Max concurrent requests
-bulkhead_max_queued = 200           # Max queued requests
+bulkhead_max_wait_ms = 5000         # Max wait for a slot (5 seconds)
 
 # ----------------------------------------------------------------------------
 # HTTP Metrics (OpenTelemetry)


### PR DESCRIPTION
Closes #32. **Stacked on #44** (`fix/33-resilience-axum-router`) — it depends on `apply_resilience` from that branch. Merge #44 first; base will retarget to `main` automatically.

## The problem was worse than "silently no-ops"

`config.middleware.resilience` had exactly one consumer in the crate — `server.rs`, which *logged* it:

```
- Resilience configured:
  - Circuit breaker: true
  - Retry: true
  - Bulkhead: true
```

…while applying nothing. An operator checking startup logs to confirm a production config would reasonably conclude the protection was on.

## Changes

**Wiring.** `ServiceBuilder` now applies circuit breaker + bulkhead from `[middleware.resilience]` via `apply_resilience`, next to the existing `apply_security_headers` call. A `From<&config::ResilienceConfig>` impl bridges the TOML type (integer secs/millis) to the layer type (`Duration`) — the two had no connection at all before.

**Logging.** Reports what was actually applied, and warns when the section is present but the `resilience` feature is compiled out (previously that combination was indistinguishable from working).

## Breaking changes

**Retry config removed** — `retry_enabled`, `retry_max_attempts`, `retry_base_delay_ms`, `retry_max_delay_ms`, plus `with_retry()` / `with_retry_max_attempts()`.

Wiring retry was not an option. Retrying means *replaying* a request, and an inbound `Request<Body>` wraps a stream consumed once — `tower-resilience-retry` requires `Req: Clone` (`src/lib.rs:241`, still true in the latest 0.10.0). Buffering every request body to make it replayable would be a memory-exhaustion risk on a public endpoint. Retry belongs on outbound client stacks. The docs now say that, rather than promising a layer that cannot ship.

**`bulkhead_max_queued` → `bulkhead_max_wait_ms`.** The old key had no consumer and no counterpart in the layer, which has no queue-limit concept. The new one maps to `max_wait_duration`, which the layer *does* support and TOML previously could not set. Same dead-config bug class as retry, found while fixing it.

Both were taken now per maintainer direction, since the next release carries other breaking changes.

## Also fixed

The CLI scaffold (`acton service add middleware`) printed a `retry_backoff_ms` key that never existed on the struct under any name.

## Testing

`toml_config_bridges_to_a_live_breaker` asserts the TOML config produces a breaker that actually opens — not just that it deserializes. That's the regression guard: the original bug was config parsing fine and reaching nothing.

- 537/537 tests pass (`--features full`)
- clippy clean across `acton-service` and `acton-cli` with `-D warnings`, no suppressions
- doctests pass