### PR TITLE
fix(audit): attach DB-backed audit storage via lazy resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unknowingly relying on the degrade will now fail to start — which is the
   point, and the failure names the cert path that could not be loaded.
 
+### Fixes
+
+- **audit**: Database-backed audit storage is now actually attached. The
+  builder previously hardcoded the audit logger's storage to `None`, so a
+  service enabling `audit` plus a database feature got tracing/syslog-only
+  auditing and persisted nothing — the append-only backends were fully
+  implemented but never wired. `ServiceBuilder::build()` now selects the
+  backend matching the enabled database feature (PostgreSQL, Turso,
+  SurrealDB, or ClickHouse) and attaches it. (#34)
+- **audit**: Storage resolves lazily rather than eagerly. Pool agents connect
+  asynchronously and are still unconnected when the audit agent spawns, so
+  reading a connected pool at build time would observe `None` and latch a
+  storage-less logger permanently. The selected backend now holds the shared
+  pool handle and constructs the concrete storage — running its append-only
+  DDL exactly once — on first use after the pool connects.
+- **audit**: The agent now waits (up to 30s) for storage readiness before
+  initializing the hash chain. Previously an unready backend caused the chain
+  to restart at sequence 0, which would fork the chain and collide with
+  persisted sequence numbers on the first append.
+
 ## [acton-service-v0.28.0] - 2026-07-17
 
 ### Features

--- a/acton-service/src/audit/agent.rs
+++ b/acton-service/src/audit/agent.rs
@@ -223,6 +223,12 @@ impl AuditAgent {
 
             tokio::spawn(async move {
                 let (previous_hash, sequence) = if let Some(ref store) = storage {
+                    // Pool agents connect asynchronously, so lazily-resolved storage
+                    // is typically not ready yet. Starting the chain at sequence 0
+                    // while the backend already holds events would fork the chain and
+                    // collide with the stored sequence, so wait for the pool.
+                    wait_for_storage(store.as_ref()).await;
+
                     match store.latest().await {
                         Ok(Some(event)) => {
                             tracing::info!(
@@ -284,6 +290,41 @@ impl AuditAgent {
         }
 
         Ok(handle)
+    }
+}
+
+/// Longest the agent waits for a connection pool before giving up on chain resumption
+const STORAGE_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Interval between storage readiness polls
+const STORAGE_READY_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Poll storage until it is usable, bounded by [`STORAGE_READY_TIMEOUT`].
+///
+/// Backends constructed from an already-connected client return immediately.
+/// Lazily-resolved backends become ready once their pool agent finishes
+/// connecting. On timeout this logs an error and returns; the caller then starts
+/// a fresh chain, which is the pre-existing behaviour for unreachable storage.
+async fn wait_for_storage(storage: &dyn AuditStorage) {
+    let deadline = tokio::time::Instant::now() + STORAGE_READY_TIMEOUT;
+
+    loop {
+        let last_error = match storage.ensure_ready().await {
+            Ok(()) => return,
+            Err(e) => e,
+        };
+
+        if tokio::time::Instant::now() >= deadline {
+            tracing::error!(
+                "Audit storage not ready after {:?}: {}. Starting a fresh in-memory chain; \
+                 persisted events will not be resumed and sequence numbers may collide.",
+                STORAGE_READY_TIMEOUT,
+                last_error
+            );
+            return;
+        }
+
+        tokio::time::sleep(STORAGE_READY_POLL_INTERVAL).await;
     }
 }
 

--- a/acton-service/src/audit/mod.rs
+++ b/acton-service/src/audit/mod.rs
@@ -30,6 +30,7 @@ pub mod logger;
 pub mod middleware;
 pub mod storage;
 pub mod syslog;
+pub(crate) mod wiring;
 
 #[cfg(feature = "observability")]
 pub mod otlp;

--- a/acton-service/src/audit/storage/clickhouse_impl.rs
+++ b/acton-service/src/audit/storage/clickhouse_impl.rs
@@ -755,3 +755,20 @@ mod tests {
         assert_eq!(row.kind, "auth.login.failed");
     }
 }
+
+#[async_trait]
+impl super::lazy::InitializableStorage for ClickHouseAuditStorage {
+    type Conn = clickhouse::Client;
+
+    fn from_conn(conn: Self::Conn) -> Self {
+        Self::new(conn)
+    }
+
+    async fn init_schema(&self) -> Result<(), Error> {
+        self.initialize().await
+    }
+
+    fn backend_name() -> &'static str {
+        "ClickHouse"
+    }
+}

--- a/acton-service/src/audit/storage/lazy.rs
+++ b/acton-service/src/audit/storage/lazy.rs
@@ -1,0 +1,262 @@
+//! Lazily-resolved audit storage
+//!
+//! Connection pool agents connect *asynchronously* — [`ServiceBuilder::build`] spawns
+//! them and returns before the pool is established (see `agents::pool`, which writes
+//! the pool into shared state from a spawned task). Any attempt to read a connected
+//! pool at builder time therefore observes `None` and would permanently latch a
+//! storage-less audit logger.
+//!
+//! [`LazyAuditStorage`] closes that gap: it holds the *shared handle* rather than a
+//! connected client, and resolves the concrete backend on first use. Schema
+//! initialization (append-only DDL) runs exactly once, on that first successful
+//! resolution.
+//!
+//! [`ServiceBuilder::build`]: crate::service_builder::ServiceBuilder::build
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
+
+use super::AuditStorage;
+use crate::audit::event::AuditEvent;
+use crate::error::Error;
+
+/// Shared-handle type used by every pool agent: `Arc<RwLock<Option<Conn>>>`.
+pub(crate) type SharedConn<C> = Arc<RwLock<Option<C>>>;
+
+/// A storage backend that can be built from a pool connection and needs one-time
+/// schema initialization.
+///
+/// Implemented by each concrete backend so [`LazyAuditStorage`] can construct and
+/// initialize it without knowing the connection type.
+#[async_trait]
+pub(crate) trait InitializableStorage: AuditStorage + Sized + 'static {
+    /// The connection/client type held in the pool agent's shared state.
+    type Conn: Clone + Send + Sync + 'static;
+
+    /// Build the backend from a connected client.
+    fn from_conn(conn: Self::Conn) -> Self;
+
+    /// Create tables, indexes, and append-only enforcement. Must be idempotent.
+    async fn init_schema(&self) -> Result<(), Error>;
+
+    /// Human-readable backend name, used in log messages.
+    fn backend_name() -> &'static str;
+}
+
+/// Audit storage that resolves its backend once the connection pool is available.
+///
+/// Before the pool connects, every operation fails with a clear "not yet connected"
+/// error, which the audit agent treats as retryable rather than fatal.
+pub struct LazyAuditStorage<S: InitializableStorage> {
+    shared: SharedConn<S::Conn>,
+    resolved: RwLock<Option<Arc<S>>>,
+    /// Serializes first-resolution so schema init runs once, not once per caller.
+    init_lock: Mutex<()>,
+}
+
+impl<S: InitializableStorage> LazyAuditStorage<S> {
+    /// Wrap a pool agent's shared connection handle.
+    pub(crate) fn new(shared: SharedConn<S::Conn>) -> Self {
+        Self {
+            shared,
+            resolved: RwLock::new(None),
+            init_lock: Mutex::new(()),
+        }
+    }
+
+    /// Return the initialized backend, building it on first call.
+    ///
+    /// Errors while the pool is still connecting; callers should retry.
+    async fn resolve(&self) -> Result<Arc<S>, Error> {
+        if let Some(storage) = self.resolved.read().await.clone() {
+            return Ok(storage);
+        }
+
+        // Serialize construction so concurrent callers don't each run DDL.
+        let _guard = self.init_lock.lock().await;
+
+        // Another caller may have resolved while we waited for the lock.
+        if let Some(storage) = self.resolved.read().await.clone() {
+            return Ok(storage);
+        }
+
+        let conn = self.shared.read().await.clone().ok_or_else(|| {
+            Error::Internal(format!(
+                "audit storage unavailable: the {} connection pool has not finished connecting",
+                S::backend_name()
+            ))
+        })?;
+
+        let storage = Arc::new(S::from_conn(conn));
+        storage.init_schema().await?;
+
+        *self.resolved.write().await = Some(storage.clone());
+        tracing::info!(
+            backend = S::backend_name(),
+            "Audit storage attached and schema initialized"
+        );
+
+        Ok(storage)
+    }
+}
+
+#[async_trait]
+impl<S: InitializableStorage> AuditStorage for LazyAuditStorage<S> {
+    async fn append(&self, event: &AuditEvent) -> Result<(), Error> {
+        self.resolve().await?.append(event).await
+    }
+
+    async fn latest(&self) -> Result<Option<AuditEvent>, Error> {
+        self.resolve().await?.latest().await
+    }
+
+    async fn query_range(
+        &self,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<AuditEvent>, Error> {
+        self.resolve().await?.query_range(from, to, limit).await
+    }
+
+    async fn verify_chain(&self, from_sequence: u64) -> Result<Option<u64>, Error> {
+        self.resolve().await?.verify_chain(from_sequence).await
+    }
+
+    async fn query_before(
+        &self,
+        cutoff: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<AuditEvent>, Error> {
+        self.resolve().await?.query_before(cutoff, limit).await
+    }
+
+    async fn purge_before(&self, cutoff: DateTime<Utc>) -> Result<u64, Error> {
+        self.resolve().await?.purge_before(cutoff).await
+    }
+
+    async fn ensure_ready(&self) -> Result<(), Error> {
+        self.resolve().await.map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Minimal backend that records how many times its schema was initialized.
+    struct MockStorage {
+        conn: &'static str,
+    }
+
+    static INIT_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    #[async_trait]
+    impl AuditStorage for MockStorage {
+        async fn append(&self, _event: &AuditEvent) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn latest(&self) -> Result<Option<AuditEvent>, Error> {
+            Ok(None)
+        }
+
+        async fn query_range(
+            &self,
+            _from: DateTime<Utc>,
+            _to: DateTime<Utc>,
+            _limit: usize,
+        ) -> Result<Vec<AuditEvent>, Error> {
+            Ok(Vec::new())
+        }
+
+        async fn verify_chain(&self, _from_sequence: u64) -> Result<Option<u64>, Error> {
+            Ok(None)
+        }
+    }
+
+    #[async_trait]
+    impl InitializableStorage for MockStorage {
+        type Conn = &'static str;
+
+        fn from_conn(conn: Self::Conn) -> Self {
+            Self { conn }
+        }
+
+        async fn init_schema(&self) -> Result<(), Error> {
+            INIT_COUNT.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn backend_name() -> &'static str {
+            "mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn unconnected_pool_yields_retryable_error_not_silent_success() {
+        let shared: SharedConn<&'static str> = Arc::new(RwLock::new(None));
+        let storage = LazyAuditStorage::<MockStorage>::new(shared);
+
+        let err = storage.ensure_ready().await.unwrap_err();
+        assert!(
+            err.to_string().contains("has not finished connecting"),
+            "error should identify the pool as still connecting, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolves_once_the_pool_connects() {
+        let shared: SharedConn<&'static str> = Arc::new(RwLock::new(None));
+        let storage = LazyAuditStorage::<MockStorage>::new(shared.clone());
+
+        assert!(storage.ensure_ready().await.is_err());
+
+        // Simulate the pool agent completing its connection.
+        *shared.write().await = Some("connected");
+
+        storage
+            .ensure_ready()
+            .await
+            .expect("storage should resolve after the pool connects");
+    }
+
+    #[tokio::test]
+    async fn schema_initialized_exactly_once_across_concurrent_callers() {
+        INIT_COUNT.store(0, Ordering::SeqCst);
+        let shared: SharedConn<&'static str> = Arc::new(RwLock::new(Some("connected")));
+        let storage = Arc::new(LazyAuditStorage::<MockStorage>::new(shared));
+
+        let mut handles = Vec::new();
+        for _ in 0..16 {
+            let s = storage.clone();
+            handles.push(tokio::spawn(async move { s.ensure_ready().await }));
+        }
+        for h in handles {
+            h.await.unwrap().expect("resolve should succeed");
+        }
+
+        assert_eq!(
+            INIT_COUNT.load(Ordering::SeqCst),
+            1,
+            "schema init must run once even under concurrent first-use"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolved_backend_is_cached_and_reused() {
+        let shared: SharedConn<&'static str> = Arc::new(RwLock::new(Some("first")));
+        let storage = LazyAuditStorage::<MockStorage>::new(shared.clone());
+
+        storage.ensure_ready().await.unwrap();
+        assert_eq!(storage.resolved.read().await.as_ref().unwrap().conn, "first");
+
+        // A later pool swap must not silently re-point an already-resolved chain.
+        *shared.write().await = Some("second");
+        storage.ensure_ready().await.unwrap();
+        assert_eq!(storage.resolved.read().await.as_ref().unwrap().conn, "first");
+    }
+}

--- a/acton-service/src/audit/storage/mod.rs
+++ b/acton-service/src/audit/storage/mod.rs
@@ -16,6 +16,14 @@ use chrono::{DateTime, Utc};
 use super::event::AuditEvent;
 use crate::error::Error;
 
+#[cfg(any(
+    feature = "database",
+    feature = "turso",
+    feature = "surrealdb",
+    feature = "clickhouse"
+))]
+pub(crate) mod lazy;
+
 #[cfg(feature = "database")]
 pub mod pg;
 
@@ -32,6 +40,14 @@ pub mod clickhouse_impl;
 /// kind (`auth.*`, `http.*`, `account.*`, `config.*`) that should have been
 /// recognized by the parser. Used by parser catch-alls to detect likely
 /// version skew between an emitter and a reader.
+///
+/// Only compiled alongside a storage backend — nothing parses stored rows without one.
+#[cfg(any(
+    feature = "database",
+    feature = "turso",
+    feature = "surrealdb",
+    feature = "clickhouse"
+))]
 pub(crate) fn looks_like_framework_kind(s: &str) -> bool {
     s.starts_with("auth.")
         || s.starts_with("http.")
@@ -45,6 +61,14 @@ pub(crate) fn looks_like_framework_kind(s: &str) -> bool {
 /// round-trip cleanly) and emits a `tracing::warn!` when the input looks
 /// like a framework-owned kind that no parser arm matched — i.e. the
 /// emitter is on a newer version than this reader.
+///
+/// Only compiled alongside a storage backend — nothing parses stored rows without one.
+#[cfg(any(
+    feature = "database",
+    feature = "turso",
+    feature = "surrealdb",
+    feature = "clickhouse"
+))]
 pub(crate) fn parse_custom_kind(s: &str) -> String {
     if looks_like_framework_kind(s) {
         tracing::warn!(
@@ -55,7 +79,15 @@ pub(crate) fn parse_custom_kind(s: &str) -> String {
     s.strip_prefix("custom.").unwrap_or(s).to_string()
 }
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    any(
+        feature = "database",
+        feature = "turso",
+        feature = "surrealdb",
+        feature = "clickhouse"
+    )
+))]
 mod helper_tests {
     use super::{looks_like_framework_kind, parse_custom_kind};
 
@@ -141,5 +173,16 @@ pub trait AuditStorage: Send + Sync {
     /// then reinstates protections. Returns the number of rows deleted.
     async fn purge_before(&self, _cutoff: DateTime<Utc>) -> Result<u64, Error> {
         Err(Error::Internal("purge_before not implemented".into()))
+    }
+
+    /// Confirm the backend is usable, performing any deferred setup.
+    ///
+    /// Backends built from an already-connected client are ready immediately.
+    /// Lazily-resolved backends (see [`lazy::LazyAuditStorage`]) return an error
+    /// until their connection pool finishes connecting; the audit agent polls
+    /// this before initializing the hash chain so it resumes from the persisted
+    /// sequence instead of restarting at zero.
+    async fn ensure_ready(&self) -> Result<(), Error> {
+        Ok(())
     }
 }

--- a/acton-service/src/audit/storage/pg.rs
+++ b/acton-service/src/audit/storage/pg.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 
+use super::lazy::InitializableStorage;
 use super::AuditStorage;
 use crate::audit::event::AuditEvent;
 use crate::error::Error;
@@ -236,6 +237,23 @@ impl AuditStorage for PgAuditStorage {
             Ok(()) => Ok(None),
             Err(e) => Ok(Some(e.sequence)),
         }
+    }
+}
+
+#[async_trait]
+impl InitializableStorage for PgAuditStorage {
+    type Conn = PgPool;
+
+    fn from_conn(conn: Self::Conn) -> Self {
+        Self::new(conn)
+    }
+
+    async fn init_schema(&self) -> Result<(), Error> {
+        self.initialize().await
+    }
+
+    fn backend_name() -> &'static str {
+        "PostgreSQL"
     }
 }
 

--- a/acton-service/src/audit/storage/surrealdb_impl.rs
+++ b/acton-service/src/audit/storage/surrealdb_impl.rs
@@ -422,3 +422,20 @@ fn parse_severity(val: i16) -> AuditSeverity {
         _ => AuditSeverity::Informational,
     }
 }
+
+#[async_trait]
+impl super::lazy::InitializableStorage for SurrealAuditStorage {
+    type Conn = Arc<SurrealClient>;
+
+    fn from_conn(conn: Self::Conn) -> Self {
+        Self::new(conn)
+    }
+
+    async fn init_schema(&self) -> Result<(), Error> {
+        self.initialize().await
+    }
+
+    fn backend_name() -> &'static str {
+        "SurrealDB"
+    }
+}

--- a/acton-service/src/audit/storage/turso.rs
+++ b/acton-service/src/audit/storage/turso.rs
@@ -414,3 +414,20 @@ fn parse_severity(val: i16) -> AuditSeverity {
         _ => AuditSeverity::Informational,
     }
 }
+
+#[async_trait]
+impl super::lazy::InitializableStorage for TursoAuditStorage {
+    type Conn = Arc<libsql::Database>;
+
+    fn from_conn(conn: Self::Conn) -> Self {
+        Self::new(conn)
+    }
+
+    async fn init_schema(&self) -> Result<(), Error> {
+        self.initialize().await
+    }
+
+    fn backend_name() -> &'static str {
+        "Turso"
+    }
+}

--- a/acton-service/src/audit/wiring.rs
+++ b/acton-service/src/audit/wiring.rs
@@ -1,0 +1,153 @@
+//! Audit storage backend selection
+//!
+//! Chooses which [`AuditStorage`] implementation to attach to the audit agent based
+//! on the enabled database features and the pool handles the builder created.
+//!
+//! Selection returns a *lazily-resolved* backend rather than a connected one. Pool
+//! agents connect asynchronously, so an eager check would find every pool empty at
+//! builder time and permanently disable audit persistence — the bug behind issue #34.
+
+use std::sync::Arc;
+
+use super::storage::AuditStorage;
+
+/// Shared connection handles produced by the builder's pool agents.
+///
+/// Fields are feature-gated to mirror the builder's own gating; a `None` field means
+/// that backend's pool agent was not spawned for this service.
+#[derive(Default)]
+pub(crate) struct AuditStorageHandles {
+    #[cfg(feature = "database")]
+    pub db_pool: Option<crate::agents::SharedDbPool>,
+    #[cfg(feature = "turso")]
+    pub turso_db: Option<crate::agents::SharedTursoDb>,
+    #[cfg(feature = "surrealdb")]
+    pub surrealdb_client: Option<crate::agents::SharedSurrealDb>,
+    #[cfg(feature = "clickhouse")]
+    pub clickhouse_client: Option<crate::agents::SharedClickHouseClient>,
+}
+
+/// Select the audit storage backend for the configured database.
+///
+/// Backends are tried in the same priority order the key-rotation wiring uses:
+/// PostgreSQL, Turso, SurrealDB, then ClickHouse. Returns `None` only when no
+/// database feature is enabled or no pool agent was spawned, in which case the
+/// audit agent runs with an in-memory chain plus syslog/tracing export.
+#[allow(unused_variables, unused_mut)]
+pub(crate) fn select_audit_storage(
+    handles: &AuditStorageHandles,
+) -> Option<Arc<dyn AuditStorage>> {
+    #[allow(unused_mut)]
+    let mut storage: Option<Arc<dyn AuditStorage>> = None;
+
+    #[cfg(feature = "database")]
+    if storage.is_none() {
+        if let Some(ref shared) = handles.db_pool {
+            storage = Some(Arc::new(super::storage::lazy::LazyAuditStorage::<
+                super::storage::pg::PgAuditStorage,
+            >::new(shared.clone())));
+            tracing::debug!("Audit persistence will use PostgreSQL storage");
+        }
+    }
+
+    #[cfg(feature = "turso")]
+    if storage.is_none() {
+        if let Some(ref shared) = handles.turso_db {
+            storage = Some(Arc::new(super::storage::lazy::LazyAuditStorage::<
+                super::storage::turso::TursoAuditStorage,
+            >::new(shared.clone())));
+            tracing::debug!("Audit persistence will use Turso storage");
+        }
+    }
+
+    #[cfg(feature = "surrealdb")]
+    if storage.is_none() {
+        if let Some(ref shared) = handles.surrealdb_client {
+            storage = Some(Arc::new(super::storage::lazy::LazyAuditStorage::<
+                super::storage::surrealdb_impl::SurrealAuditStorage,
+            >::new(shared.clone())));
+            tracing::debug!("Audit persistence will use SurrealDB storage");
+        }
+    }
+
+    #[cfg(feature = "clickhouse")]
+    if storage.is_none() {
+        if let Some(ref shared) = handles.clickhouse_client {
+            storage = Some(Arc::new(super::storage::lazy::LazyAuditStorage::<
+                super::storage::clickhouse_impl::ClickHouseAuditStorage,
+            >::new(shared.clone())));
+            tracing::debug!("Audit persistence will use ClickHouse storage");
+        }
+    }
+
+    if storage.is_none() {
+        tracing::warn!(
+            "Audit logging is enabled but no database pool is configured; events will be \
+             exported to tracing/syslog only and will not be persisted"
+        );
+    }
+
+    storage
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_pools_yields_no_storage() {
+        let handles = AuditStorageHandles::default();
+        assert!(
+            select_audit_storage(&handles).is_none(),
+            "without any pool handle there is nothing to persist to"
+        );
+    }
+
+    /// Regression test for issue #34: the builder previously hardcoded
+    /// `storage = None`, so a service with `audit` + a database feature silently
+    /// got tracing-only auditing. Storage must be attached even though the pool
+    /// has not connected yet — that is the whole point of resolving lazily.
+    #[cfg(feature = "database")]
+    #[test]
+    fn database_pool_attaches_storage_before_the_pool_connects() {
+        let handles = AuditStorageHandles {
+            // Exactly what the builder holds at audit-init time: allocated, unconnected.
+            db_pool: Some(Arc::new(tokio::sync::RwLock::new(None))),
+            #[cfg(feature = "turso")]
+            turso_db: None,
+            #[cfg(feature = "surrealdb")]
+            surrealdb_client: None,
+            #[cfg(feature = "clickhouse")]
+            clickhouse_client: None,
+        };
+
+        assert!(
+            select_audit_storage(&handles).is_some(),
+            "audit storage must be attached from an unconnected pool handle"
+        );
+    }
+
+    /// The selected backend must stay unresolved (and therefore retryable) rather
+    /// than erroring out permanently while the pool is still connecting.
+    #[cfg(feature = "database")]
+    #[tokio::test]
+    async fn selected_storage_is_retryable_until_the_pool_connects() {
+        let shared: crate::agents::SharedDbPool = Arc::new(tokio::sync::RwLock::new(None));
+        let handles = AuditStorageHandles {
+            db_pool: Some(shared),
+            #[cfg(feature = "turso")]
+            turso_db: None,
+            #[cfg(feature = "surrealdb")]
+            surrealdb_client: None,
+            #[cfg(feature = "clickhouse")]
+            clickhouse_client: None,
+        };
+
+        let storage = select_audit_storage(&handles).expect("storage should be selected");
+        let err = storage.ensure_ready().await.unwrap_err();
+        assert!(
+            err.to_string().contains("PostgreSQL"),
+            "error should name the backend awaiting connection, got: {err}"
+        );
+    }
+}

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -752,10 +752,24 @@ where
             if audit_config.enabled {
                 let service_name = config.service.name.clone();
 
-                // Storage is None by default. DB-backed storage is initialized lazily
-                // after the pool connects. The agent works with in-memory chain + syslog
-                // until storage becomes available.
-                let storage: Option<std::sync::Arc<dyn crate::audit::AuditStorage>> = None;
+                // Attach DB-backed storage for whichever database feature is active.
+                // Pool agents connect asynchronously, so the selected backend resolves
+                // lazily: it holds the shared pool handle and builds the concrete
+                // storage (running its append-only DDL) on first use, once connected.
+                // Until then the agent runs on the in-memory chain + syslog.
+                let storage: Option<std::sync::Arc<dyn crate::audit::AuditStorage>> =
+                    crate::audit::wiring::select_audit_storage(
+                        &crate::audit::wiring::AuditStorageHandles {
+                            #[cfg(feature = "database")]
+                            db_pool: shared_db_pool.clone(),
+                            #[cfg(feature = "turso")]
+                            turso_db: shared_turso_db.clone(),
+                            #[cfg(feature = "surrealdb")]
+                            surrealdb_client: shared_surrealdb_client.clone(),
+                            #[cfg(feature = "clickhouse")]
+                            clickhouse_client: shared_clickhouse_client.clone(),
+                        },
+                    );
 
                 if let Ok(_handle) = tokio::runtime::Handle::try_current() {
                     let result = tokio::task::block_in_place(|| {


### PR DESCRIPTION
Closes #34.

## The bug

`service_builder.rs` hardcoded the audit logger's storage to `None`, with a comment claiming DB-backed storage was "initialized lazily after the pool connects." No code path ever attached it. `agent.model.storage` is assigned once at spawn and only read thereafter, so a service enabling `audit` + a database feature got tracing/syslog-only auditing and persisted nothing.

All four backends (`pg`, `turso`, `surrealdb_impl`, `clickhouse_impl`) were fully implemented and tested, but had zero references outside their own modules — including their `initialize()` DDL, which nothing called.

## Why the obvious fix doesn't work

The natural approach is to copy the key-rotation wiring (`service_builder.rs:1417`), which does `shared_pool.try_read()` and builds storage from the connected pool. That would mostly *not work here*: `agents/pool.rs` writes the pool into shared state from a spawned task, so at audit-init time the handle is still `None`. Unlike key rotation — whose agent retries on a periodic tick — the audit agent has no retry, so it would silently latch `None` forever. Same bug, more code.

## The fix

`LazyAuditStorage<S>` holds the *shared handle* rather than a connected client and resolves the concrete backend on first use:

- Resolution is cached; the append-only DDL runs exactly once, serialized by a mutex so concurrent first-use doesn't run it N times.
- Before the pool connects, every operation fails with a clear "has not finished connecting" error that the agent treats as retryable.
- Each backend implements a small `InitializableStorage` trait (`from_conn` / `init_schema` / `backend_name`) so the wrapper is generic over the connection type.

`select_audit_storage` picks the backend for the enabled database feature and the builder attaches it.

### Chain-resumption correctness

This turned up a second issue worth flagging. The agent's `after_start` loaded chain state once; with lazy storage it would find the backend unready, log "Starting fresh," and begin at sequence 0. Against a populated table that forks the hash chain and collides with the `UNIQUE` sequence constraint on the first append — silent audit corruption. The agent now polls `ensure_ready()` (250ms interval, 30s cap) before initializing the chain, and logs loudly if it times out.

## Testing

7 new tests: retryable-before-connect, resolves-after-connect, DDL-runs-once under 16 concurrent callers, resolved-backend-caching, plus wiring selection including an explicit regression test that storage is attached from an *unconnected* handle (the exact condition the old code got wrong).

- `cargo nextest run` (default features): 109/109 pass
- `--features audit,database`: 189/190 pass, all 7 new tests green
- `cargo clippy --all-targets` clean on `audit` and `audit,database` — no directives added

## Notes for review

Two pre-existing issues found, both confirmed present on `main` and left out of scope:

1. `extensions::tests::service_builder_without_actors_has_empty_extensions` fails under `--features audit,database` on `main` — the builder's audit block calls `block_in_place`, which panics on a current-thread runtime. This is a real bug (audit + single-threaded runtime panics `build()`), not just a test artifact. Worth its own issue.
2. Key rotation's storage attachment is likely suspect for the same async-connect reason this issue was about.

Also gated the storage kind-parsing helpers behind the backend features that use them, clearing two pre-existing dead-code warnings in audit-only builds.