### PR TITLE
ci: install protoc from the Ubuntu archive instead of GitHub releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # Installed from the Ubuntu archive rather than downloaded from GitHub
+      # releases: keeps a GitHub outage from failing the build before anything
+      # is compiled. Ubuntu 24.04 ships protoc 3.21.12, which is sufficient --
+      # every .proto here is plain proto3 with no editions or proto3 optional.
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -33,9 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # Installed from the Ubuntu archive rather than downloaded from GitHub
+      # releases: keeps a GitHub outage from failing the build before anything
+      # is compiled. Ubuntu 24.04 ships protoc 3.21.12, which is sufficient --
+      # every .proto here is plain proto3 with no editions or proto3 optional.
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy


### PR DESCRIPTION
Closes #48.

## Problem

`arduino/setup-protoc@v3` downloads protoc from GitHub releases at job start. When GitHub had an incident on 2026-07-19, that step failed and **every subsequent step was skipped** — Clippy and Nextest included — in both matrix legs:

```
3 Run arduino/setup-protoc@v3:        failure
4 Run dtolnay/rust-toolchain@stable:  skipped
7 Clippy:                             skipped
8 Nextest:                            skipped
```

The build showed red having compiled and tested nothing, which reads identically to a real compile or test failure. That's the part worth fixing: it invites dismissing genuine failures as "just the flaky protoc step," and it made #44/#46 unverifiable by CI.

## Change

Install protoc from the Ubuntu archive. This takes a GitHub-releases network dependency off the critical path of every build. It also removes the workflow's only `secrets.GITHUB_TOKEN` reference and the floating `v3` action tag — one less unpinned third-party action, which is the same exposure upstream #318 addressed for `dtolnay/rust-toolchain`.

## Verifying the runner's protoc is actually sufficient

I checked this rather than assuming it, since it's the obvious way this change could silently break the build:

- `ubuntu-latest` resolves to Ubuntu 24.04 (runner-images manifest).
- protoc is **not** preinstalled on that image — hence the original action.
- Ubuntu 24.04 ships `protobuf-compiler` **3.21.12** (Launchpad: `3.21.12-8.2build1`, `3.21.12-8.2ubuntu0.3`).
- Downloaded protoc v21.12 — the identical version — and built against it with `PROTOC` set:
  - all three descriptor sets generate (`ping`, `orders`, `hello`)
  - `cargo nextest run -p acton-service --features full` → **540/540 pass**

The margin is comfortable: every `.proto` in the repo is plain `syntax = "proto3"` with no editions, no proto3 `optional`, no imports, and no maps. Nothing here approaches the 3.21 feature ceiling, so this isn't a change that only just barely works.

## Note

This PR validates itself — its own CI run exercises the modified workflow.