### PR TITLE
fix(grpc)!: enforce configured auth and Cedar on gRPC routes, make Cedar layer usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   It previously logged a warning and *skipped the authentication middleware
   entirely*, so a typo in the token config silently published every
   authenticated route unauthenticated. (#41)
+- **grpc**: gRPC routes now receive framework-managed token authentication
+  and Cedar authorization. Merged axum routers do not inherit each other's
+  layers, so the gRPC surface was previously mounted with *none* of the
+  HTTP-side auto-applied middleware: a service configuring `[token]` and
+  `[cedar]` served every gRPC method unauthenticated and unauthorized unless
+  the developer hand-wired interceptors per service. With `[token]`
+  configured, a `GrpcTokenAuthLayer` now validates the `authorization`
+  metadata and injects `Claims`; with `[cedar]` enabled, each method is
+  authorized as `Action::"/package.Service/Method"`. Health
+  (`grpc.health.v1.Health`) and reflection services stay credential-free for
+  infrastructure probes, and `public_paths` prefixes are honored for
+  intentionally public methods. Deployments that relied on open gRPC
+  alongside a configured `[token]` section must list those methods in
+  `public_paths`. (#36)
+- **cedar**: An enabled `[cedar]` section whose initialization fails (e.g.
+  unreadable or invalid policy file) is now a hard startup failure surfaced
+  via `try_build()`/`serve()`. Previously it logged a warning and served
+  every route with **no policy enforcement at all** — the same
+  silently-weaker-than-configured class as the TLS and token-auth degrades
+  fixed by #41. (#36)
 
 ### Features
 
@@ -37,6 +57,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   time-of-check/time-of-use window in which renewal hooks or permission
   changes could alter the material between validation and listen. When set,
   the override wins over the corresponding config section. (#41)
+- **grpc**: `GrpcTokenAuthLayer` — an HTTP-level, `NamedService`-forwarding
+  token authentication layer for manual gRPC stack composition (validates
+  bearer tokens via any `TokenValidator`, injects `Claims` into request
+  extensions, answers failures with `UNAUTHENTICATED`). The framework
+  applies it automatically when `[token]` is configured; the type is public
+  for hand-rolled stacks. (#36)
+- **examples**: `cedar-grpc` — a runnable end-to-end example of
+  framework-managed gRPC authentication + Cedar authorization, with demo
+  tokens printed at startup and grpcurl commands for the allow, deny, and
+  unauthenticated paths. (#36)
 
 ### Notes
 
@@ -48,6 +78,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- **cedar**: The gRPC `CedarAuthzLayer`/`CedarAuthzService` is now usable.
+  The previous `Service` impl was generic over `tonic::Request` with
+  `Error = Status` — bounds no tonic generated server (or anything else)
+  satisfies — so the layer could not wrap any service, and it read the
+  method from the `:path` metadata key, which HTTP/2 pseudo-headers never
+  populate. The service now operates at the HTTP level
+  (`http::Request<B>` → `http::Response<B>`, gRPC statuses for denials),
+  takes the method from the request URI, and forwards `NamedService` from
+  the inner service, so a wrapped service registers cleanly with
+  `GrpcServicesBuilder::add_service`. (#36)
 - **audit**: Database-backed audit storage is now actually attached. The
   builder previously hardcoded the audit logger's storage to `None`, so a
   service enabling `audit` plus a database feature got tracing/syslog-only

--- a/acton-docs/src/app/docs/cedar-auth/page.md
+++ b/acton-docs/src/app/docs/cedar-auth/page.md
@@ -508,8 +508,8 @@ When the `audit` feature is enabled, the Cedar middleware automatically emits an
 The event records:
 
 - The authenticated subject (from JWT `sub`)
-- Client user-agent and request-id (HTTP picks these up from headers; gRPC picks them up from metadata)
-- Client IP (HTTP only; gRPC has no peer IP at this layer)
+- Client user-agent and request-id (from headers for HTTP; gRPC metadata is carried in the same headers)
+- Client IP (from `x-forwarded-for`/`x-real-ip` when present)
 
 No additional code is required — emission is on by default when `audit_auth_events: true` is set in the audit configuration (the default). See [Audit Logging](/docs/audit) for storage and SIEM export.
 
@@ -551,28 +551,50 @@ Token authentication provides authentication (who you are), Cedar provides autho
 
 ### gRPC Support
 
-With the `grpc` feature, Cedar is available as a tower layer for tonic
-services: `CedarAuthzLayer` wraps a service in `CedarAuthzService`, which
-authorizes each request from the `Claims` that the PASETO/JWT interceptor
-placed in request extensions.
+With the `grpc` feature, the same configuration that protects HTTP routes
+protects gRPC services — no per-service wiring required. When `[token]` is
+configured, `ServiceBuilder` applies token authentication to all registered
+gRPC services (validating the `authorization` metadata and injecting
+`Claims`), and when `[cedar]` is enabled it authorizes every method as
+`Action::"/package.Service/Method"`:
 
-`CedarAuthzLayer::new` takes a built `CedarAuthz` instance (not a
-`CedarConfig`), so construct the authorizer first and apply the layer where
-you compose your tonic service stack:
-
-```rust
-use acton_service::middleware::{CedarAuthz, CedarAuthzLayer};
-
-let cedar = CedarAuthz::builder(config.cedar.clone())
-    .build()
-    .await?;
-
-// A tower layer over tonic services — apply it when composing a tonic
-// stack manually (e.g. tonic's Server::builder().layer(...)).
-let cedar_layer = CedarAuthzLayer::new(cedar);
+```cedar
+permit(
+    principal,
+    action == Action::"/hello.v1.HelloService/SayHello",
+    resource
+) when { context.roles.contains("user") };
 ```
 
-Path normalization handles gRPC method names automatically.
+Health (`grpc.health.v1.Health`) and reflection services are exempt so
+infrastructure probes work without credentials, and `public_paths` prefixes
+in the token configuration are honored for intentionally public methods.
+Denials are returned as gRPC statuses (`UNAUTHENTICATED`,
+`PERMISSION_DENIED`), not transport errors.
+
+For manual stack composition, both layers are available as HTTP-level tower
+layers that forward `NamedService`, so wrapped services register directly
+with `GrpcServicesBuilder::add_service`:
+
+```rust
+use acton_service::grpc::GrpcTokenAuthLayer;
+use acton_service::middleware::cedar::{CedarAuthz, CedarAuthzLayer};
+use tower::Layer;
+
+let cedar = CedarAuthz::builder(cedar_config).build().await?;
+
+let services = GrpcServicesBuilder::new()
+    .add_service(
+        // Auth outermost: it injects the Claims that Cedar authorizes.
+        GrpcTokenAuthLayer::new(paseto_auth).layer(
+            CedarAuthzLayer::new(cedar).layer(MyServiceServer::new(svc)),
+        ),
+    )
+    .build(None);
+```
+
+See the runnable `cedar-grpc` example for an end-to-end demonstration with
+test tokens and grpcurl commands.
 
 ## Next Steps
 

--- a/acton-docs/src/app/docs/grpc-guide/page.md
+++ b/acton-docs/src/app/docs/grpc-guide/page.md
@@ -582,7 +582,34 @@ async fn get_user(&self, request: Request<GetUserRequest>)
 
 ### Token Authentication (PASETO/JWT)
 
-Validate tokens in gRPC requests using PASETO (default) or JWT:
+When `[token]` is configured, token authentication is applied to all
+registered gRPC services **automatically** — no interceptor wiring needed.
+The `authorization` metadata is validated, `Claims` are injected into
+request extensions, and failures return `UNAUTHENTICATED`. Health and
+reflection services are exempt so infrastructure probes work without
+credentials, and `public_paths` prefixes in the token config exempt
+intentionally public methods:
+
+```toml
+[token]
+format = "paseto"
+version = "v4"
+purpose = "local"
+key_path = "./keys/paseto.key"
+# Optional: methods that stay public, matched by prefix
+public_paths = ["/hello.v1.PublicService/"]
+```
+
+With `[cedar]` also enabled, each method is additionally authorized against
+Cedar policies as `Action::"/package.Service/Method"` — see
+[Cedar Authorization](/docs/cedar-auth) and the runnable `cedar-grpc`
+example.
+
+For manually composed stacks you can still wire validation yourself, either
+with the HTTP-level `GrpcTokenAuthLayer` (forwards `NamedService`, so the
+wrapped service registers directly with `add_service`) or with tonic
+interceptors. Note that manual wiring on top of a configured `[token]`
+section validates the token twice — harmless, but redundant:
 
 ```rust
 use acton_service::grpc::interceptors::paseto_auth_interceptor;

--- a/acton-docs/src/app/docs/token-auth/page.md
+++ b/acton-docs/src/app/docs/token-auth/page.md
@@ -420,7 +420,33 @@ The middleware no longer emits `AuthLoginFailed`. That event is reserved for app
 
 ## gRPC Support
 
-Token authentication is available for gRPC services via interceptors:
+When `[token]` is configured, `ServiceBuilder` applies token authentication
+to all registered gRPC services automatically — the same configuration that
+protects HTTP routes protects gRPC methods, with no per-service wiring. The
+`authorization` metadata is validated and `Claims` are injected into request
+extensions where handlers (and Cedar) can read them. Failures are returned
+as gRPC statuses (`UNAUTHENTICATED`), health
+(`grpc.health.v1.Health`) and reflection services stay credential-free for
+infrastructure probes, and `public_paths` prefixes are honored for
+intentionally public methods (match against the full method path, e.g.
+`"/hello.v1.HelloService/"`).
+
+For manually composed stacks, `GrpcTokenAuthLayer` is the same layer as a
+public type — it forwards `NamedService`, so a wrapped service registers
+directly with `GrpcServicesBuilder::add_service`:
+
+```rust
+use acton_service::grpc::GrpcTokenAuthLayer;
+use tower::Layer;
+
+let services = GrpcServicesBuilder::new()
+    .add_service(GrpcTokenAuthLayer::new(paseto_auth).layer(MyServiceServer::new(svc)))
+    .build(None);
+```
+
+Tonic interceptors remain available for custom `with_interceptor` stacks
+(note that combining them with the framework-managed layer validates the
+token twice — harmless, but redundant):
 
 ```rust
 use acton_service::grpc::{paseto_auth_interceptor, request_id_interceptor};

--- a/acton-service/Cargo.toml
+++ b/acton-service/Cargo.toml
@@ -272,6 +272,11 @@ name = "single-port"
 path = "examples/grpc/single-port.rs"
 required-features = ["grpc"]
 
+[[example]]
+name = "cedar-grpc"
+path = "examples/grpc/cedar-grpc.rs"
+required-features = ["grpc", "cedar-authz", "auth"]
+
 # Event-driven examples
 [[example]]
 name = "event-driven"

--- a/acton-service/examples/authorization/README.md
+++ b/acton-service/examples/authorization/README.md
@@ -371,7 +371,7 @@ fail_open = true
 
 1. **Add more policies**: Extend the example with your use cases
 2. **Integrate with database**: Load resource attributes from DB
-3. **Add gRPC support**: Use `CedarAuthzLayer` for gRPC services
+3. **Add gRPC support**: Enable `[cedar]` alongside gRPC and every method is authorized automatically — see the `cedar-grpc` example
 4. **Implement policy management API**: CRUD operations for policies
 5. **Add policy testing**: Unit tests for Cedar policies
 6. **Monitor policy decisions**: Track allow/deny metrics

--- a/acton-service/examples/grpc/README.md
+++ b/acton-service/examples/grpc/README.md
@@ -19,6 +19,25 @@ Run with:
 cargo run --manifest-path=../../Cargo.toml --example single-port --features grpc
 ```
 
+### cedar-grpc.rs
+
+**Framework-managed authentication + Cedar authorization for gRPC**
+
+Demonstrates:
+- PASETO token authentication applied automatically to all gRPC services
+  (from the `[token]` config, no interceptor wiring)
+- Cedar policy enforcement per gRPC method (`Action::"/package.Service/Method"`)
+- Health/reflection exemption for credential-less infrastructure probes
+- Denials returned as proper gRPC statuses (`UNAUTHENTICATED`, `PERMISSION_DENIED`)
+
+Run with:
+```bash
+cargo run --manifest-path=../../Cargo.toml --example cedar-grpc --features "grpc,cedar-authz,auth"
+```
+
+The example prints ready-to-use test tokens on startup; see the module docs
+in `cedar-grpc.rs` for grpcurl commands exercising the allow and deny paths.
+
 ## Prerequisites
 
 The gRPC examples require:

--- a/acton-service/examples/grpc/cedar-grpc.rs
+++ b/acton-service/examples/grpc/cedar-grpc.rs
@@ -1,0 +1,219 @@
+//! gRPC + Cedar Authorization Example
+//!
+//! Demonstrates the framework-managed authentication and authorization path
+//! for gRPC: when `[token]` and `[cedar]` are configured, `ServiceBuilder`
+//! automatically applies PASETO token authentication and Cedar policy
+//! enforcement to every registered gRPC service. No per-service interceptor
+//! wiring is required.
+//!
+//! Health (`grpc.health.v1.Health`) and reflection services are exempt, so
+//! infrastructure probes keep working without credentials — reflection is
+//! what lets the unauthenticated grpcurl commands below resolve descriptors.
+//!
+//! ## Running
+//!
+//! ```bash
+//! cargo run --example cedar-grpc --features "grpc,cedar-authz,auth"
+//! ```
+//!
+//! The example creates its policy and key files in
+//! `~/.config/acton-service/cedar-grpc-example/` and prints ready-to-use
+//! test tokens on startup.
+//!
+//! ## Testing
+//!
+//! ```bash
+//! # Denied without a token (UNAUTHENTICATED)
+//! grpcurl -plaintext -d '{"name":"World"}' localhost:8080 hello.v1.HelloService/SayHello
+//!
+//! # Allowed with the "user" role token printed at startup
+//! grpcurl -plaintext -H "authorization: Bearer <USER_TOKEN>" \
+//!     -d '{"name":"World"}' localhost:8080 hello.v1.HelloService/SayHello
+//!
+//! # Denied by policy with the role-less token (PERMISSION_DENIED)
+//! grpcurl -plaintext -H "authorization: Bearer <GUEST_TOKEN>" \
+//!     -d '{"name":"World"}' localhost:8080 hello.v1.HelloService/SayHello
+//! ```
+
+use acton_service::auth::{PasetoGenerator, TokenGenerator};
+use acton_service::config::{GrpcConfig, PasetoConfig, TokenConfig};
+use acton_service::middleware::Claims;
+use acton_service::prelude::*;
+
+// ============================================================================
+// Protocol Buffers
+// ============================================================================
+
+pub mod hello {
+    tonic::include_proto!("hello.v1");
+
+    pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("hello_descriptor");
+}
+
+use hello::{
+    hello_service_server::{HelloService as HelloServiceTrait, HelloServiceServer},
+    HelloRequest, HelloResponse,
+};
+
+// ============================================================================
+// gRPC Service Implementation
+// ============================================================================
+
+#[derive(Debug, Default, Clone)]
+struct HelloServiceImpl;
+
+#[tonic::async_trait]
+impl HelloServiceTrait for HelloServiceImpl {
+    async fn say_hello(
+        &self,
+        request: tonic::Request<HelloRequest>,
+    ) -> std::result::Result<tonic::Response<HelloResponse>, tonic::Status> {
+        let name = request.into_inner().name;
+
+        Ok(tonic::Response::new(HelloResponse {
+            message: format!("Hello, {}! (authorized by Cedar)", name),
+        }))
+    }
+}
+
+// ============================================================================
+// Example Setup
+// ============================================================================
+
+/// Demo-only symmetric key. Never ship a fixed key in a real service.
+const DEMO_KEY: &[u8; 32] = b"acton-cedar-grpc-example-demo-k!";
+
+fn setup_example_files() -> Result<(std::path::PathBuf, std::path::PathBuf)> {
+    let config_dir = std::path::Path::new(&std::env::var("HOME").expect("HOME must be set"))
+        .join(".config/acton-service/cedar-grpc-example");
+    std::fs::create_dir_all(&config_dir)?;
+
+    // Copy the policy file (always overwrite to pick up changes)
+    let policy_path = config_dir.join("policies.cedar");
+    let policy_src =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/grpc/policies.cedar");
+    std::fs::copy(&policy_src, &policy_path)?;
+
+    // Write the demo PASETO key
+    let key_path = config_dir.join("paseto.key");
+    std::fs::write(&key_path, DEMO_KEY)?;
+
+    Ok((policy_path, key_path))
+}
+
+fn demo_token(key_path: &std::path::Path, sub: &str, roles: Vec<String>) -> Result<String> {
+    let paseto_config = acton_service::auth::PasetoGenerationConfig {
+        version: "v4".to_string(),
+        purpose: "local".to_string(),
+        key_path: key_path.to_path_buf(),
+        issuer: None,
+        audience: None,
+    };
+    let token_config = acton_service::auth::TokenGenerationConfig::default();
+    let generator = PasetoGenerator::new(&paseto_config, &token_config)?;
+
+    let claims = Claims {
+        sub: sub.to_string(),
+        email: None,
+        username: None,
+        roles,
+        perms: vec![],
+        exp: 0, // set by the generator
+        iat: None,
+        jti: None,
+        iss: None,
+        aud: None,
+        custom: Default::default(),
+    };
+
+    generator.generate_token(&claims)
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let (policy_path, key_path) = setup_example_files()?;
+
+    let user_token = demo_token(&key_path, "user:alice", vec!["user".to_string()])?;
+    let guest_token = demo_token(&key_path, "user:guest", vec![])?;
+
+    println!("🚀 gRPC + Cedar Authorization Example (port 8080)");
+    println!();
+    println!("Token with the \"user\" role (SayHello permitted):");
+    println!("  {user_token}");
+    println!();
+    println!("Token without roles (SayHello denied by policy):");
+    println!("  {guest_token}");
+    println!();
+    println!("Try it:");
+    println!("  grpcurl -plaintext -d '{{\"name\":\"World\"}}' localhost:8080 hello.v1.HelloService/SayHello");
+    println!("  grpcurl -plaintext -H \"authorization: Bearer <TOKEN>\" -d '{{\"name\":\"World\"}}' localhost:8080 hello.v1.HelloService/SayHello");
+    println!();
+
+    // Build gRPC services — no auth or Cedar wiring needed here; the
+    // framework applies both to all gRPC routes because `[token]` and
+    // `[cedar]` are configured below.
+    let grpc_routes = acton_service::grpc::server::GrpcServicesBuilder::new()
+        .with_reflection()
+        .add_file_descriptor_set(hello::FILE_DESCRIPTOR_SET)
+        .add_service(HelloServiceServer::new(HelloServiceImpl))
+        .build(None);
+
+    let mut config = Config::default();
+    config.service.port = 8080;
+
+    config.grpc = Some(GrpcConfig {
+        enabled: true,
+        use_separate_port: false, // single-port HTTP + gRPC
+        bind: None,
+        #[cfg(feature = "tls")]
+        tls: None,
+        port: 50051,
+        reflection_enabled: true,
+        health_check_enabled: true,
+        max_message_size_mb: 4,
+        connection_timeout_secs: 10,
+        timeout_secs: 30,
+        proto: Default::default(),
+    });
+
+    config.token = Some(TokenConfig::Paseto(PasetoConfig {
+        version: "v4".to_string(),
+        purpose: "local".to_string(),
+        key_path,
+        issuer: None,
+        audience: None,
+        public_paths: Vec::new(),
+    }));
+
+    config.cedar = Some(CedarConfig {
+        enabled: true,
+        policy_path,
+        hot_reload: false,
+        hot_reload_interval_secs: 60,
+        cache_enabled: false,
+        cache_ttl_secs: 300,
+        fail_open: false,
+    });
+
+    // A tiny HTTP route so the same port also serves REST
+    let http_routes = VersionedApiBuilder::new()
+        .with_base_path("/api")
+        .add_version(ApiVersion::V1, |router| {
+            router.route("/hello", get(|| async { "Hello from HTTP!" }))
+        })
+        .build_routes();
+
+    ServiceBuilder::new()
+        .with_config(config)
+        .with_routes(http_routes)
+        .with_grpc_services(grpc_routes)
+        .try_build()?
+        .serve()
+        .await?;
+
+    Ok(())
+}

--- a/acton-service/examples/grpc/policies.cedar
+++ b/acton-service/examples/grpc/policies.cedar
@@ -1,0 +1,11 @@
+// Cedar policies for the cedar-grpc example.
+//
+// gRPC actions are the full method path: Action::"/package.Service/Method".
+// The context carries the authenticated principal's roles and permissions.
+
+// Any authenticated principal with the "user" role may call SayHello.
+permit(
+    principal,
+    action == Action::"/hello.v1.HelloService/SayHello",
+    resource
+) when { context.roles.contains("user") };

--- a/acton-service/src/grpc/middleware.rs
+++ b/acton-service/src/grpc/middleware.rs
@@ -4,12 +4,15 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
+use tonic::server::NamedService;
 use tonic::{Request, Response, Status};
 use tower::{Layer, Service};
 
 use crate::grpc::interceptors::RequestIdExtension;
+use crate::middleware::token::{extract_token, TokenValidator};
 
 /// Logging middleware for gRPC requests
 #[derive(Clone)]
@@ -283,6 +286,157 @@ where
     }
 }
 
+/// Whether a gRPC method path belongs to infrastructure services that are
+/// exempt from authentication and authorization.
+///
+/// Covers the standard health checking protocol (`grpc.health.v1.Health`),
+/// which infrastructure probes call without credentials, and server
+/// reflection (`grpc.reflection.*`), mirroring the `/health` and `/ready`
+/// exemptions on the HTTP side.
+pub(crate) fn is_grpc_infra_path(path: &str) -> bool {
+    path.starts_with("/grpc.health.v1.Health/") || path.starts_with("/grpc.reflection.")
+}
+
+/// HTTP-level token authentication layer for gRPC services
+///
+/// Validates the `authorization` bearer token (gRPC metadata is carried in
+/// HTTP headers) using any [`TokenValidator`] and inserts the resulting
+/// [`Claims`](crate::middleware::token::Claims) into the request extensions,
+/// where downstream layers such as
+/// [`CedarAuthzLayer`](crate::middleware::cedar::CedarAuthzLayer) and service
+/// handlers can read them. Requests that fail validation are answered with a
+/// gRPC `UNAUTHENTICATED` status without reaching the inner service.
+///
+/// Unlike the tonic interceptor helpers in
+/// [`interceptors`](crate::grpc::interceptors), which run *inside* a generated
+/// server via `with_interceptor`, this layer wraps the service from the
+/// outside, so claims are available to other wrapping layers. The
+/// `NamedService` impl forwards the inner service's name, so a wrapped service
+/// can be registered with
+/// [`GrpcServicesBuilder::add_service`](crate::grpc::server::GrpcServicesBuilder::add_service).
+///
+/// Health and reflection service methods are exempt, as are any configured
+/// public path prefixes.
+///
+/// # Example
+/// ```ignore
+/// let auth_layer = GrpcTokenAuthLayer::new(paseto_auth);
+///
+/// let services = GrpcServicesBuilder::new()
+///     .add_service(auth_layer.layer(MyServiceServer::new(svc)))
+///     .build(None);
+/// ```
+///
+/// When token auth is configured through [`Config`](crate::config::Config),
+/// the framework applies this layer to all gRPC routes automatically; this
+/// type is for manual composition.
+///
+/// Note: like the tonic interceptor helpers (and unlike the HTTP
+/// middleware), this layer validates the token itself but does not consult
+/// a token revocation list.
+#[derive(Clone)]
+pub struct GrpcTokenAuthLayer<V> {
+    validator: V,
+    public_paths: Arc<[String]>,
+}
+
+impl<V> GrpcTokenAuthLayer<V> {
+    /// Create a new token authentication layer from a validator
+    pub fn new(validator: V) -> Self {
+        Self {
+            validator,
+            public_paths: Arc::from(Vec::new()),
+        }
+    }
+
+    /// Exempt gRPC method paths starting with any of these prefixes
+    ///
+    /// Prefixes match against the full method path, e.g.
+    /// `"/hello.v1.HelloService/"` exempts every method of that service.
+    pub fn with_public_paths(mut self, paths: Vec<String>) -> Self {
+        self.public_paths = paths.into();
+        self
+    }
+}
+
+impl<S, V: Clone> Layer<S> for GrpcTokenAuthLayer<V> {
+    type Service = GrpcTokenAuthService<S, V>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        GrpcTokenAuthService {
+            inner,
+            validator: self.validator.clone(),
+            public_paths: self.public_paths.clone(),
+        }
+    }
+}
+
+/// HTTP-level token authentication service for gRPC
+///
+/// See [`GrpcTokenAuthLayer`] for usage.
+#[derive(Clone)]
+pub struct GrpcTokenAuthService<S, V> {
+    inner: S,
+    validator: V,
+    public_paths: Arc<[String]>,
+}
+
+impl<S: NamedService, V> NamedService for GrpcTokenAuthService<S, V> {
+    const NAME: &'static str = S::NAME;
+}
+
+impl<S, V, ReqBody, ResBody> Service<http::Request<ReqBody>> for GrpcTokenAuthService<S, V>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    V: TokenValidator,
+    ReqBody: Send + 'static,
+    ResBody: Default + Send + 'static,
+{
+    type Response = http::Response<ResBody>;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<ReqBody>) -> Self::Future {
+        // Take the ready inner service and leave a fresh clone in its place,
+        // so the readiness obtained via poll_ready is the one consumed here.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        let path = req.uri().path();
+        let public = is_grpc_infra_path(path)
+            || self
+                .public_paths
+                .iter()
+                .any(|p| path.starts_with(p.as_str()));
+
+        if !public {
+            let validated = extract_token(req.headers())
+                .and_then(|token| self.validator.validate_token(&token));
+            match validated {
+                Ok(claims) => {
+                    tracing::debug!(
+                        sub = %claims.sub,
+                        roles = ?claims.roles,
+                        "gRPC request authenticated"
+                    );
+                    req.extensions_mut().insert(claims);
+                }
+                Err(e) => {
+                    let status = Status::unauthenticated(e.to_string());
+                    return Box::pin(async move { Ok(status.into_http()) });
+                }
+            }
+        }
+
+        Box::pin(async move { inner.call(req).await })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -316,5 +470,158 @@ mod tests {
         );
         assert_eq!(extract_method_name("/Service/Method"), "Method");
         assert_eq!(extract_method_name("invalid"), "unknown");
+    }
+
+    #[test]
+    fn test_is_grpc_infra_path() {
+        assert!(is_grpc_infra_path("/grpc.health.v1.Health/Check"));
+        assert!(is_grpc_infra_path("/grpc.health.v1.Health/Watch"));
+        assert!(is_grpc_infra_path(
+            "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo"
+        ));
+        assert!(is_grpc_infra_path(
+            "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"
+        ));
+        assert!(!is_grpc_infra_path("/hello.v1.HelloService/SayHello"));
+    }
+
+    mod token_auth {
+        use super::super::*;
+        use crate::error::Error;
+        use crate::middleware::token::Claims;
+        use std::convert::Infallible;
+
+        #[derive(Clone)]
+        struct TestValidator;
+
+        impl TokenValidator for TestValidator {
+            fn validate_token(&self, token: &str) -> Result<Claims, Error> {
+                if token == "good" {
+                    Ok(Claims {
+                        sub: "user:123".to_string(),
+                        email: None,
+                        username: None,
+                        roles: vec![],
+                        perms: vec![],
+                        exp: 0,
+                        iat: None,
+                        jti: None,
+                        iss: None,
+                        aud: None,
+                        custom: Default::default(),
+                    })
+                } else {
+                    Err(Error::Unauthorized("Invalid token".to_string()))
+                }
+            }
+        }
+
+        /// Reports whether Claims were present when the request arrived
+        #[derive(Clone)]
+        struct ClaimsProbe;
+
+        impl NamedService for ClaimsProbe {
+            const NAME: &'static str = "test.v1.ClaimsProbe";
+        }
+
+        impl Service<http::Request<String>> for ClaimsProbe {
+            type Response = http::Response<String>;
+            type Error = Infallible;
+            type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+            fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, req: http::Request<String>) -> Self::Future {
+                let body = if req.extensions().get::<Claims>().is_some() {
+                    "claims"
+                } else {
+                    "no-claims"
+                };
+                std::future::ready(Ok(http::Response::new(body.to_string())))
+            }
+        }
+
+        fn request(path: &str, token: Option<&str>) -> http::Request<String> {
+            let mut builder = http::Request::builder().uri(path);
+            if let Some(token) = token {
+                builder = builder.header("authorization", format!("Bearer {token}"));
+            }
+            builder.body(String::new()).unwrap()
+        }
+
+        fn grpc_status(resp: &http::Response<String>) -> Option<&str> {
+            resp.headers()
+                .get("grpc-status")
+                .and_then(|v| v.to_str().ok())
+        }
+
+        fn service() -> GrpcTokenAuthService<ClaimsProbe, TestValidator> {
+            GrpcTokenAuthLayer::new(TestValidator).layer(ClaimsProbe)
+        }
+
+        #[test]
+        fn named_service_impl_forwards_the_inner_name() {
+            assert_eq!(
+                <GrpcTokenAuthService<ClaimsProbe, TestValidator> as NamedService>::NAME,
+                "test.v1.ClaimsProbe"
+            );
+        }
+
+        #[tokio::test]
+        async fn valid_token_injects_claims() {
+            let resp = service()
+                .call(request("/hello.v1.HelloService/SayHello", Some("good")))
+                .await
+                .unwrap();
+            assert_eq!(resp.body(), "claims");
+        }
+
+        #[tokio::test]
+        async fn missing_token_is_unauthenticated() {
+            let resp = service()
+                .call(request("/hello.v1.HelloService/SayHello", None))
+                .await
+                .unwrap();
+            // tonic Code::Unauthenticated == 16
+            assert_eq!(grpc_status(&resp), Some("16"));
+        }
+
+        #[tokio::test]
+        async fn invalid_token_is_unauthenticated() {
+            let resp = service()
+                .call(request("/hello.v1.HelloService/SayHello", Some("bad")))
+                .await
+                .unwrap();
+            assert_eq!(grpc_status(&resp), Some("16"));
+        }
+
+        #[tokio::test]
+        async fn health_service_is_exempt() {
+            let resp = service()
+                .call(request("/grpc.health.v1.Health/Check", None))
+                .await
+                .unwrap();
+            assert_eq!(resp.body(), "no-claims");
+        }
+
+        #[tokio::test]
+        async fn public_path_prefixes_are_exempt() {
+            let mut svc = GrpcTokenAuthLayer::new(TestValidator)
+                .with_public_paths(vec!["/hello.v1.HelloService/".to_string()])
+                .layer(ClaimsProbe);
+            let resp = svc
+                .call(request("/hello.v1.HelloService/SayHello", None))
+                .await
+                .unwrap();
+            assert_eq!(resp.body(), "no-claims");
+
+            let resp = svc
+                .call(request("/other.v1.OtherService/Do", None))
+                .await
+                .unwrap();
+            assert_eq!(grpc_status(&resp), Some("16"));
+        }
     }
 }

--- a/acton-service/src/grpc/mod.rs
+++ b/acton-service/src/grpc/mod.rs
@@ -3,12 +3,25 @@
 //! This module provides gRPC server functionality that can run alongside HTTP services.
 //! It supports both single-port (HTTP + gRPC multiplexed) and dual-port modes.
 //!
+//! ## Authentication and Authorization
+//!
+//! When `[token]` is configured, `ServiceBuilder` automatically applies
+//! token authentication ([`GrpcTokenAuthLayer`]) to all registered gRPC
+//! services, validating the `authorization` metadata and injecting
+//! [`Claims`](crate::middleware::token::Claims) into request extensions.
+//! With the `cedar-authz` feature and `[cedar]` enabled, each method is
+//! additionally authorized against Cedar policies as
+//! `Action::"/package.Service/Method"`. Health and reflection services are
+//! exempt, as are configured `public_paths` prefixes. See the `cedar-grpc`
+//! example for an end-to-end demonstration.
+//!
 //! ## Middleware and Interceptors
 //!
-//! The gRPC implementation provides middleware parity with HTTP:
+//! For manual composition, the module also provides:
 //! - **Request ID**: Automatic generation and propagation
 //! - **Tracing**: OpenTelemetry integration with proper span context
-//! - **Authentication**: PASETO (default) or JWT token validation via interceptors
+//! - **Authentication**: [`GrpcTokenAuthLayer`] as an HTTP-level tower
+//!   layer, or PASETO/JWT interceptors for use with `with_interceptor`
 //! - **Rate Limiting**: Governor-based rate limiting (when `governor` feature is enabled)
 //!
 //! ## Example
@@ -72,7 +85,10 @@ pub use interceptors::{
 pub use interceptors::jwt_auth_interceptor;
 
 #[cfg(feature = "grpc")]
-pub use middleware::{GrpcTracingLayer, GrpcTracingService, LoggingLayer, LoggingService};
+pub use middleware::{
+    GrpcTokenAuthLayer, GrpcTokenAuthService, GrpcTracingLayer, GrpcTracingService, LoggingLayer,
+    LoggingService,
+};
 
 #[cfg(all(feature = "grpc", feature = "governor"))]
 pub use middleware::{GrpcRateLimitLayer, GrpcRateLimitService};

--- a/acton-service/src/lib.rs
+++ b/acton-service/src/lib.rs
@@ -260,6 +260,9 @@ pub mod prelude {
     #[cfg(all(feature = "cedar-authz", feature = "grpc"))]
     pub use crate::middleware::{CedarAuthzLayer, CedarAuthzService};
 
+    #[cfg(feature = "grpc")]
+    pub use crate::grpc::{GrpcTokenAuthLayer, GrpcTokenAuthService};
+
     #[cfg(feature = "observability")]
     pub use crate::observability::init_tracing;
 

--- a/acton-service/src/middleware/cedar.rs
+++ b/acton-service/src/middleware/cedar.rs
@@ -716,11 +716,35 @@ use std::pin::Pin;
 #[cfg(feature = "grpc")]
 use std::task::{Context as TaskContext, Poll};
 #[cfg(feature = "grpc")]
-use tonic::{body::Body as TonicBody, Request as TonicRequest, Response as TonicResponse, Status};
+use tonic::{server::NamedService, Status};
 #[cfg(feature = "grpc")]
 use tower::{Layer, Service};
 
 /// Tower Layer for Cedar authorization in gRPC services
+///
+/// Operates at the HTTP level (`http::Request<B>` → `http::Response<B>`), the
+/// shape of tonic's generated servers, so a wrapped service can be registered
+/// with [`GrpcServicesBuilder::add_service`](crate::grpc::server::GrpcServicesBuilder::add_service)
+/// (the `NamedService` impl forwards the inner service's name). Authorization
+/// requires [`Claims`] in the request extensions, so an HTTP-level
+/// authentication layer such as
+/// [`GrpcTokenAuthLayer`](crate::grpc::middleware::GrpcTokenAuthLayer) must
+/// wrap this layer (run before it). Denials are returned as gRPC status
+/// responses (`PERMISSION_DENIED`), not transport errors.
+///
+/// # Example
+/// ```ignore
+/// let cedar_layer = CedarAuthzLayer::new(cedar);
+/// let auth_layer = GrpcTokenAuthLayer::new(paseto_auth);
+///
+/// let services = GrpcServicesBuilder::new()
+///     .add_service(auth_layer.layer(cedar_layer.layer(MyServiceServer::new(svc))))
+///     .build(None);
+/// ```
+///
+/// When Cedar and token auth are configured through [`Config`], the framework
+/// applies both to all gRPC routes automatically; this layer is for manual
+/// composition.
 #[cfg(feature = "grpc")]
 #[derive(Clone)]
 pub struct CedarAuthzLayer {
@@ -748,6 +772,8 @@ impl<S> Layer<S> for CedarAuthzLayer {
 }
 
 /// Tower Service for Cedar authorization in gRPC
+///
+/// See [`CedarAuthzLayer`] for usage and composition requirements.
 #[cfg(feature = "grpc")]
 #[derive(Clone)]
 pub struct CedarAuthzService<S> {
@@ -756,16 +782,19 @@ pub struct CedarAuthzService<S> {
 }
 
 #[cfg(feature = "grpc")]
-impl<S, ReqBody> Service<TonicRequest<ReqBody>> for CedarAuthzService<S>
+impl<S: NamedService> NamedService for CedarAuthzService<S> {
+    const NAME: &'static str = S::NAME;
+}
+
+#[cfg(feature = "grpc")]
+impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for CedarAuthzService<S>
 where
-    S: Service<TonicRequest<ReqBody>, Response = TonicResponse<TonicBody>, Error = Status>
-        + Clone
-        + Send
-        + 'static,
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
     S::Future: Send + 'static,
     ReqBody: Send + 'static,
+    ResBody: Default + Send + 'static,
 {
-    type Response = S::Response;
+    type Response = http::Response<ResBody>;
     type Error = S::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
@@ -773,99 +802,113 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, req: TonicRequest<ReqBody>) -> Self::Future {
-        let mut inner = self.inner.clone();
+    fn call(&mut self, req: http::Request<ReqBody>) -> Self::Future {
+        // Take the ready inner service and leave a fresh clone in its place,
+        // so the readiness obtained via poll_ready is the one consumed here.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
         let authz = self.authz.clone();
 
+        // Owned copies, so the authorization future does not borrow the
+        // request (whose body type need not be Sync) across an await point.
+        let headers = req.headers().clone();
+        let extensions = req.extensions().clone();
+        let method_path = req.uri().path().to_string();
+
         Box::pin(async move {
-            // Skip if Cedar is disabled
-            if !authz.config.enabled {
-                return inner.call(req).await;
-            }
-
-            // Extract JWT claims from request extensions (set by JWT interceptor)
-            let claims = req
-                .extensions()
-                .get::<Claims>()
-                .ok_or_else(|| {
-                    Status::unauthenticated(
-                        "Missing JWT claims. Ensure JWT interceptor runs before Cedar layer.",
-                    )
-                })?
-                .clone();
-
-            #[cfg(feature = "audit")]
-            let audit_logger = req
-                .extensions()
-                .get::<crate::audit::AuditLogger>()
-                .cloned();
-
-            // Extract gRPC method path from metadata
-            let method_path = req
-                .metadata()
-                .get(":path")
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("unknown")
-                .to_string();
-
-            // Build Cedar authorization request
-            let principal = build_principal(&claims)
-                .map_err(|_| Status::internal("Failed to build principal"))?;
-
-            let action = build_action_grpc(&method_path)
-                .map_err(|_| Status::internal("Failed to build action"))?;
-
-            let context = build_context_grpc(req.metadata(), &claims)
-                .map_err(|_| Status::internal("Failed to build context"))?;
-
-            // For gRPC, we use default resource
-            let resource: EntityUid = r#"Resource::"default""#
-                .parse()
-                .map_err(|_| Status::internal("Failed to parse resource"))?;
-
-            let decision = authz
-                .authorize(&principal, &action, &resource, context, &claims)
-                .await
-                .map_err(|e| Status::internal(format!("Cedar authorization error: {}", e)))?;
-
-            match decision {
-                Decision::Allow => inner.call(req).await,
-                Decision::Deny => {
-                    tracing::warn!(
-                        method = %method_path,
-                        "Cedar policy denied gRPC request"
-                    );
-                    #[cfg(feature = "audit")]
-                    if let Some(ref logger) = audit_logger {
-                        if logger.config().audit_auth_events {
-                            use crate::audit::event::AuditSource;
-                            let source = AuditSource {
-                                ip: None,
-                                user_agent: req
-                                    .metadata()
-                                    .get("user-agent")
-                                    .and_then(|v| v.to_str().ok())
-                                    .map(String::from),
-                                subject: Some(claims.sub.clone()),
-                                request_id: req
-                                    .metadata()
-                                    .get("x-request-id")
-                                    .and_then(|v| v.to_str().ok())
-                                    .map(String::from),
-                            };
-                            logger
-                                .log_auth(
-                                    crate::audit::event::AuditEventKind::AuthPermissionDenied,
-                                    crate::audit::event::AuditSeverity::Warning,
-                                    source,
-                                )
-                                .await;
-                        }
-                    }
-                    Err(Status::permission_denied("Access denied by policy"))
-                }
+            match authorize_grpc_request(&authz, &headers, &extensions, &method_path).await {
+                Ok(()) => inner.call(req).await,
+                Err(status) => Ok(status.into_http()),
             }
         })
+    }
+}
+
+/// Evaluate Cedar policies for a gRPC request at the HTTP level.
+///
+/// The gRPC method (`/package.Service/Method`) is read from the request URI
+/// path and the metadata-derived fields from the HTTP headers, which carry
+/// the same data tonic exposes as `MetadataMap`. Health and reflection
+/// service methods are exempt, mirroring the `/health` and `/ready`
+/// exemptions on the HTTP side.
+#[cfg(feature = "grpc")]
+async fn authorize_grpc_request(
+    authz: &CedarAuthz,
+    headers: &HeaderMap,
+    extensions: &http::Extensions,
+    method_path: &str,
+) -> Result<(), Status> {
+    // Skip if Cedar is disabled
+    if !authz.config.enabled {
+        return Ok(());
+    }
+
+    if crate::grpc::middleware::is_grpc_infra_path(method_path) {
+        return Ok(());
+    }
+
+    // Extract claims from request extensions (set by a token auth layer)
+    let claims = extensions
+        .get::<Claims>()
+        .ok_or_else(|| {
+            Status::unauthenticated(
+                "Missing authentication claims. Ensure a token authentication \
+                 layer runs before the Cedar layer.",
+            )
+        })?
+        .clone();
+
+    // Build Cedar authorization request
+    let principal =
+        build_principal(&claims).map_err(|_| Status::internal("Failed to build principal"))?;
+
+    let action =
+        build_action_grpc(method_path).map_err(|_| Status::internal("Failed to build action"))?;
+
+    let context = build_context_grpc(headers, &claims)
+        .map_err(|_| Status::internal("Failed to build context"))?;
+
+    let resource = build_resource().map_err(|_| Status::internal("Failed to parse resource"))?;
+
+    let decision = authz
+        .authorize(&principal, &action, &resource, context, &claims)
+        .await
+        .map_err(|e| Status::internal(format!("Cedar authorization error: {}", e)))?;
+
+    match decision {
+        Decision::Allow => Ok(()),
+        Decision::Deny => {
+            tracing::warn!(
+                method = %method_path,
+                "Cedar policy denied gRPC request"
+            );
+            #[cfg(feature = "audit")]
+            if let Some(logger) = extensions.get::<crate::audit::AuditLogger>() {
+                if logger.config().audit_auth_events {
+                    use crate::audit::event::AuditSource;
+                    let source = AuditSource {
+                        ip: extract_grpc_client_ip(headers),
+                        user_agent: headers
+                            .get("user-agent")
+                            .and_then(|v| v.to_str().ok())
+                            .map(String::from),
+                        subject: Some(claims.sub.clone()),
+                        request_id: headers
+                            .get("x-request-id")
+                            .and_then(|v| v.to_str().ok())
+                            .map(String::from),
+                    };
+                    logger
+                        .log_auth(
+                            crate::audit::event::AuditEventKind::AuthPermissionDenied,
+                            crate::audit::event::AuditSeverity::Warning,
+                            source,
+                        )
+                        .await;
+                }
+            }
+            Err(Status::permission_denied("Access denied by policy"))
+        }
     }
 }
 
@@ -882,12 +925,12 @@ fn build_action_grpc(method_path: &str) -> Result<EntityUid, Error> {
     Ok(action)
 }
 
-/// Build Cedar context from gRPC metadata and claims
+/// Build Cedar context from gRPC request headers and claims
+///
+/// gRPC metadata is carried in HTTP headers, so reading headers here is
+/// equivalent to reading tonic's `MetadataMap`.
 #[cfg(feature = "grpc")]
-fn build_context_grpc(
-    metadata: &tonic::metadata::MetadataMap,
-    claims: &Claims,
-) -> Result<Context, Error> {
+fn build_context_grpc(headers: &HeaderMap, claims: &Claims) -> Result<Context, Error> {
     let mut context_map = serde_json::Map::new();
 
     // Add user roles
@@ -917,18 +960,18 @@ fn build_context_grpc(
         }),
     );
 
-    // Add IP address from gRPC metadata
-    if let Some(ip) = extract_grpc_client_ip(metadata) {
+    // Add IP address from gRPC request headers
+    if let Some(ip) = extract_grpc_client_ip(headers) {
         context_map.insert("ip".to_string(), json!(ip));
     }
 
     // Add request ID if present
-    if let Some(request_id) = metadata.get("x-request-id").and_then(|v| v.to_str().ok()) {
+    if let Some(request_id) = headers.get("x-request-id").and_then(|v| v.to_str().ok()) {
         context_map.insert("requestId".to_string(), json!(request_id));
     }
 
     // Add user-agent if present
-    if let Some(user_agent) = metadata.get("user-agent").and_then(|v| v.to_str().ok()) {
+    if let Some(user_agent) = headers.get("user-agent").and_then(|v| v.to_str().ok()) {
         context_map.insert("userAgent".to_string(), json!(user_agent));
     }
 
@@ -936,18 +979,18 @@ fn build_context_grpc(
         .map_err(|e| Error::Internal(format!("Failed to build gRPC context: {}", e)))
 }
 
-/// Extract client IP from gRPC metadata
+/// Extract client IP from gRPC request headers
 #[cfg(feature = "grpc")]
-fn extract_grpc_client_ip(metadata: &tonic::metadata::MetadataMap) -> Option<String> {
+fn extract_grpc_client_ip(headers: &HeaderMap) -> Option<String> {
     // Try X-Forwarded-For header first
-    if let Some(xff) = metadata.get("x-forwarded-for") {
+    if let Some(xff) = headers.get("x-forwarded-for") {
         if let Ok(xff_str) = xff.to_str() {
             return xff_str.split(',').next().map(|s| s.trim().to_string());
         }
     }
 
     // Try X-Real-IP header
-    if let Some(xri) = metadata.get("x-real-ip") {
+    if let Some(xri) = headers.get("x-real-ip") {
         if let Ok(xri_str) = xri.to_str() {
             return Some(xri_str.to_string());
         }
@@ -996,4 +1039,195 @@ mod tests {
     // Note: test_build_action_http removed as it requires constructing a full Request<Body>
     // which is complex. The path normalization logic is tested via test_normalize_path_generic.
     // Integration tests should cover the full middleware flow.
+
+    #[cfg(feature = "grpc")]
+    mod grpc_layer {
+        use super::super::*;
+        use std::convert::Infallible;
+
+        fn test_claims() -> Claims {
+            Claims {
+                sub: "user:123".to_string(),
+                email: None,
+                username: None,
+                roles: vec!["user".to_string()],
+                perms: vec![],
+                exp: 0,
+                iat: None,
+                jti: None,
+                iss: None,
+                aud: None,
+                custom: Default::default(),
+            }
+        }
+
+        async fn test_authz(policy: &str, enabled: bool) -> CedarAuthz {
+            let policy_file = tempfile::NamedTempFile::new().unwrap();
+            std::fs::write(policy_file.path(), policy).unwrap();
+            let config = CedarConfig {
+                enabled,
+                policy_path: policy_file.path().to_path_buf(),
+                hot_reload: false,
+                hot_reload_interval_secs: 60,
+                cache_enabled: false,
+                cache_ttl_secs: 60,
+                fail_open: false,
+            };
+            CedarAuthz::builder(config).build().await.unwrap()
+        }
+
+        /// Minimal HTTP-level service in the shape of a tonic generated server
+        #[derive(Clone)]
+        struct TestSvc;
+
+        impl NamedService for TestSvc {
+            const NAME: &'static str = "test.v1.TestService";
+        }
+
+        impl Service<http::Request<String>> for TestSvc {
+            type Response = http::Response<String>;
+            type Error = Infallible;
+            type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+            fn poll_ready(
+                &mut self,
+                _cx: &mut TaskContext<'_>,
+            ) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, _req: http::Request<String>) -> Self::Future {
+                std::future::ready(Ok(http::Response::new("ok".to_string())))
+            }
+        }
+
+        fn grpc_request(path: &str, claims: Option<Claims>) -> http::Request<String> {
+            let mut req = http::Request::builder()
+                .uri(path)
+                .body(String::new())
+                .unwrap();
+            if let Some(claims) = claims {
+                req.extensions_mut().insert(claims);
+            }
+            req
+        }
+
+        fn grpc_status(resp: &http::Response<String>) -> Option<&str> {
+            resp.headers()
+                .get("grpc-status")
+                .and_then(|v| v.to_str().ok())
+        }
+
+        #[test]
+        fn named_service_impl_forwards_the_inner_name() {
+            assert_eq!(
+                <CedarAuthzService<TestSvc> as NamedService>::NAME,
+                "test.v1.TestService"
+            );
+        }
+
+        #[tokio::test]
+        async fn permitted_request_reaches_the_inner_service() {
+            let authz = test_authz("permit(principal, action, resource);", true).await;
+            let mut svc = CedarAuthzLayer::new(authz).layer(TestSvc);
+            let resp = svc
+                .call(grpc_request(
+                    "/test.v1.TestService/Do",
+                    Some(test_claims()),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(resp.body(), "ok");
+        }
+
+        #[tokio::test]
+        async fn denied_request_gets_permission_denied_not_a_transport_error() {
+            // An empty policy set denies by default (fail_open = false)
+            let authz = test_authz("", true).await;
+            let mut svc = CedarAuthzLayer::new(authz).layer(TestSvc);
+            let resp = svc
+                .call(grpc_request(
+                    "/test.v1.TestService/Do",
+                    Some(test_claims()),
+                ))
+                .await
+                .unwrap();
+            // tonic Code::PermissionDenied == 7
+            assert_eq!(grpc_status(&resp), Some("7"));
+        }
+
+        #[tokio::test]
+        async fn missing_claims_is_unauthenticated() {
+            let authz = test_authz("permit(principal, action, resource);", true).await;
+            let mut svc = CedarAuthzLayer::new(authz).layer(TestSvc);
+            let resp = svc
+                .call(grpc_request("/test.v1.TestService/Do", None))
+                .await
+                .unwrap();
+            // tonic Code::Unauthenticated == 16
+            assert_eq!(grpc_status(&resp), Some("16"));
+        }
+
+        #[tokio::test]
+        async fn disabled_cedar_passes_through() {
+            let authz = test_authz("", false).await;
+            let mut svc = CedarAuthzLayer::new(authz).layer(TestSvc);
+            let resp = svc
+                .call(grpc_request("/test.v1.TestService/Do", None))
+                .await
+                .unwrap();
+            assert_eq!(resp.body(), "ok");
+        }
+
+        #[tokio::test]
+        async fn health_service_is_exempt() {
+            // Deny-everything policy set, no claims: the health service must
+            // still be reachable for infrastructure probes.
+            let authz = test_authz("", true).await;
+            let mut svc = CedarAuthzLayer::new(authz).layer(TestSvc);
+            let resp = svc
+                .call(grpc_request("/grpc.health.v1.Health/Check", None))
+                .await
+                .unwrap();
+            assert_eq!(resp.body(), "ok");
+        }
+
+        #[tokio::test]
+        async fn cedar_wrapped_service_registers_with_the_grpc_builder() {
+            use tonic::body::Body as TonicBody;
+
+            /// Tonic-body twin of TestSvc to satisfy `add_service` bounds
+            #[derive(Clone)]
+            struct TonicSvc;
+
+            impl NamedService for TonicSvc {
+                const NAME: &'static str = "test.v1.TonicService";
+            }
+
+            impl Service<http::Request<TonicBody>> for TonicSvc {
+                type Response = http::Response<TonicBody>;
+                type Error = Infallible;
+                type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+                fn poll_ready(
+                    &mut self,
+                    _cx: &mut TaskContext<'_>,
+                ) -> Poll<Result<(), Self::Error>> {
+                    Poll::Ready(Ok(()))
+                }
+
+                fn call(&mut self, _req: http::Request<TonicBody>) -> Self::Future {
+                    std::future::ready(Ok(http::Response::new(TonicBody::empty())))
+                }
+            }
+
+            // The point of this test is that the issue's repro now compiles:
+            // a Cedar-wrapped (and auth-wrapped) tonic service is accepted by
+            // GrpcServicesBuilder::add_service.
+            let authz = test_authz("permit(principal, action, resource);", true).await;
+            let _routes = crate::grpc::server::GrpcServicesBuilder::new()
+                .add_service(CedarAuthzLayer::new(authz).layer(TonicSvc))
+                .build(None);
+        }
+    }
 }

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -1166,16 +1166,26 @@ where
                                     Some(cedar)
                                 }
                                 Err(e) => {
-                                    tracing::warn!(
-                                        "Failed to initialize Cedar middleware: {}",
-                                        e
-                                    );
+                                    let err = crate::error::Error::Internal(format!(
+                                        "Cedar authorization is enabled but its initialization \
+                                         failed; refusing to start rather than serving routes \
+                                         without policy enforcement: {e}"
+                                    ));
+                                    tracing::error!("{}", err);
+                                    record_startup_error(&mut startup_error, err);
                                     None
                                 }
                             }
                         }
                         Err(_) => {
-                            tracing::warn!("No tokio runtime available for Cedar initialization");
+                            let err = crate::error::Error::Internal(
+                                "Cedar authorization is enabled but no tokio runtime is \
+                                 available to initialize it; refusing to start rather than \
+                                 serving routes without policy enforcement"
+                                    .to_string(),
+                            );
+                            tracing::error!("{}", err);
+                            record_startup_error(&mut startup_error, err);
                             None
                         }
                     }
@@ -1186,6 +1196,11 @@ where
                 None
             }
         };
+
+        // Keep a Cedar handle for the gRPC routes; the HTTP middleware
+        // section below consumes `cedar_authz` itself.
+        #[cfg(all(feature = "grpc", feature = "cedar-authz"))]
+        let grpc_cedar = cedar_authz.clone();
 
         // Merge GraphQL routes (if any) BEFORE general middleware so GraphQL
         // endpoints inherit auth, tracing, CORS, etc.
@@ -1348,6 +1363,13 @@ where
         // Auto-apply token authentication middleware if configured
         // NOTE: Token auth must be applied AFTER Cedar because Axum layers run in reverse order
         // This ensures the execution order is: Request → General Middleware → Token Auth → Cedar → Handler
+        //
+        // The constructed validators are also kept for the gRPC routes below,
+        // so both listeners enforce the same identity configuration.
+        #[cfg(feature = "grpc")]
+        let mut grpc_paseto: Option<crate::middleware::paseto::PasetoAuth> = None;
+        #[cfg(all(feature = "grpc", feature = "jwt"))]
+        let mut grpc_jwt: Option<crate::middleware::jwt::JwtAuth> = None;
         if let Some(token_config) = &config.token {
             match token_config {
                 crate::config::TokenConfig::Paseto(paseto_config) => {
@@ -1359,6 +1381,10 @@ where
                             } else {
                                 paseto_auth
                             };
+                            #[cfg(feature = "grpc")]
+                            {
+                                grpc_paseto = Some(paseto_auth.clone());
+                            }
                             tracing::debug!("Auto-applying PASETO authentication middleware");
                             app = app.layer(axum::middleware::from_fn_with_state(
                                 paseto_auth,
@@ -1386,6 +1412,10 @@ where
                             } else {
                                 jwt_auth
                             };
+                            #[cfg(feature = "grpc")]
+                            {
+                                grpc_jwt = Some(jwt_auth.clone());
+                            }
                             tracing::debug!("Auto-applying JWT authentication middleware");
                             app = app.layer(axum::middleware::from_fn_with_state(
                                 jwt_auth,
@@ -1499,13 +1529,68 @@ where
             }
         };
 
+        // Convert gRPC routes to an axum router and apply their own auth and
+        // authorization stack. Merged routers do not inherit each other's
+        // layers, so without this the gRPC listener would serve every method
+        // unauthenticated regardless of what `[token]` and `[cedar]` declare.
+        // Token auth (outermost) validates the `authorization` metadata and
+        // injects Claims; Cedar (inner) then authorizes each method. Health
+        // and reflection services are exempt, as are `public_paths` prefixes.
+        #[cfg(feature = "grpc")]
+        let grpc_router: Option<axum::Router> = match self.grpc_services {
+            Some(routes) => {
+                let mut grpc_app = routes.into_axum_router();
+
+                #[cfg(feature = "cedar-authz")]
+                if let Some(cedar) = grpc_cedar {
+                    tracing::debug!("Auto-applying Cedar authorization to gRPC routes");
+                    grpc_app =
+                        grpc_app.layer(crate::middleware::cedar::CedarAuthzLayer::new(cedar));
+                }
+
+                if let Some(paseto) = grpc_paseto {
+                    tracing::debug!("Auto-applying PASETO authentication to gRPC routes");
+                    let public_paths = match &config.token {
+                        Some(crate::config::TokenConfig::Paseto(c)) => c.public_paths.clone(),
+                        _ => Vec::new(),
+                    };
+                    grpc_app = grpc_app.layer(
+                        crate::grpc::middleware::GrpcTokenAuthLayer::new(paseto)
+                            .with_public_paths(public_paths),
+                    );
+                }
+                #[cfg(feature = "jwt")]
+                if let Some(jwt) = grpc_jwt {
+                    tracing::debug!("Auto-applying JWT authentication to gRPC routes");
+                    let public_paths = match &config.token {
+                        Some(crate::config::TokenConfig::Jwt(c)) => c.public_paths.clone(),
+                        _ => Vec::new(),
+                    };
+                    grpc_app = grpc_app.layer(
+                        crate::grpc::middleware::GrpcTokenAuthLayer::new(jwt)
+                            .with_public_paths(public_paths),
+                    );
+                }
+
+                // Make the audit logger visible to the Cedar layer for denial
+                // events. Outermost, so it is inserted before auth/Cedar run.
+                #[cfg(feature = "audit")]
+                if let Some(ref logger) = audit_logger {
+                    grpc_app = grpc_app.layer(axum::Extension(logger.clone()));
+                }
+
+                Some(grpc_app)
+            }
+            None => None,
+        };
+
         ActonService {
             config,
             state: state_clone,
             listener_addr,
             app,
             #[cfg(feature = "grpc")]
-            grpc_routes: self.grpc_services,
+            grpc_routes: grpc_router,
             #[cfg(feature = "tls")]
             tls_config,
             #[cfg(all(feature = "grpc", feature = "tls"))]
@@ -1831,7 +1916,7 @@ where
     listener_addr: std::net::SocketAddr,
     app: Router,
     #[cfg(feature = "grpc")]
-    grpc_routes: Option<tonic::service::Routes>,
+    grpc_routes: Option<axum::Router>,
     #[cfg(feature = "tls")]
     tls_config: Option<std::sync::Arc<tokio_rustls::rustls::ServerConfig>>,
     /// Per-listener TLS config for the separate-port gRPC listener. Falls back
@@ -1926,8 +2011,9 @@ where
                         let http_listener = TcpListener::bind(&self.listener_addr).await?;
                         let grpc_listener = TcpListener::bind(&grpc_addr).await?;
 
-                        // Convert Routes to axum router for the gRPC listener
-                        let grpc_app = grpc_routes.into_axum_router();
+                        // The gRPC axum router (auth and Cedar layers were
+                        // applied at build time)
+                        let grpc_app = grpc_routes;
 
                         // Spawn gRPC server on separate task (with optional
                         // per-listener TLS, falling back to the HTTP TLS config).
@@ -2001,8 +2087,9 @@ where
 
                         let listener = TcpListener::bind(&self.listener_addr).await?;
 
-                        // Merge HTTP and gRPC services
-                        let hybrid_service = grpc_routes.into_axum_router().merge(self.app);
+                        // Merge HTTP and gRPC services (the gRPC router keeps
+                        // its own auth and Cedar layers through the merge)
+                        let hybrid_service = grpc_routes.merge(self.app);
 
                         // Note: the TLS path does not use ConnectInfo (orphan
                         // rules; see comment in dual-port path above).
@@ -2191,6 +2278,69 @@ mod tests {
         // let routes = VersionedRoutes { router: Router::new() };
 
         // The ONLY way to create VersionedRoutes is through VersionedApiBuilder
+    }
+
+    /// A `[cedar]` section whose policy file cannot be loaded must be a hard
+    /// failure. Serving every route without policy enforcement where the
+    /// operator configured Cedar is the same silent downgrade class as
+    /// serving plaintext where TLS was configured.
+    #[cfg(feature = "cedar-authz")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cedar_init_failure_is_fatal_not_an_unenforced_downgrade() {
+        use crate::config::{CedarConfig, Config};
+        use crate::prelude::ServiceBuilder;
+
+        let config = Config::<()> {
+            cedar: Some(CedarConfig {
+                enabled: true,
+                policy_path: "/nonexistent/policies.cedar".into(),
+                hot_reload: false,
+                hot_reload_interval_secs: 60,
+                cache_enabled: false,
+                cache_ttl_secs: 60,
+                fail_open: false,
+            }),
+            ..Default::default()
+        };
+
+        let error = ServiceBuilder::new()
+            .with_config(config)
+            .try_build()
+            .err()
+            .expect("an unloadable Cedar policy set must fail the build, not skip authorization");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("refusing to start rather than serving routes without policy enforcement"),
+            "error must explain the refusal, got: {message}"
+        );
+    }
+
+    /// A disabled `[cedar]` section must not be fatal — only an enabled one
+    /// that cannot be initialized.
+    #[cfg(feature = "cedar-authz")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn disabled_cedar_section_builds_successfully() {
+        use crate::config::{CedarConfig, Config};
+        use crate::prelude::ServiceBuilder;
+
+        let config = Config::<()> {
+            cedar: Some(CedarConfig {
+                enabled: false,
+                policy_path: "/nonexistent/policies.cedar".into(),
+                hot_reload: false,
+                hot_reload_interval_secs: 60,
+                cache_enabled: false,
+                cache_ttl_secs: 60,
+                fail_open: false,
+            }),
+            ..Default::default()
+        };
+
+        ServiceBuilder::new()
+            .with_config(config)
+            .try_build()
+            .expect("a disabled cedar section must not fail the build");
     }
 
     /// A `[tls]` section pointing at cert material that cannot be loaded must be


### PR DESCRIPTION
Closes #36

## Problem

Issue #36 reported that `CedarAuthzService` lacks a `NamedService` impl, making it unusable with `GrpcServicesBuilder::add_service`. Investigation showed the defect ran deeper:

1. **The layer was dead code.** Its `Service` impl was generic over `tonic::Request<ReqBody>` with `Error = Status` — bounds that *nothing* satisfies. Tonic generated servers (and everything `add_service` or `Server::builder().layer(...)` accepts) are HTTP-level services with `Error = Infallible`. The layer could not wrap any service, ever.
2. **The method extraction could never work.** It read the gRPC method from the `:path` metadata key, but HTTP/2 pseudo-headers are parsed into the request URI and never appear in metadata — the action would always have been `"unknown"`.
3. **No framework-managed protection for gRPC at all** (also noted in the issue): gRPC routes are mounted via `into_axum_router().merge(...)`, and merged axum routers do not inherit each other's layers — so configured `[token]` and `[cedar]` sections silently left every gRPC method unauthenticated and unauthorized.

## Fix

- **`CedarAuthzService` rewritten at the HTTP level**: body-generic `Service` impl (works both in `add_service` stacks and on axum routers), method taken from the request URI, denials returned as proper gRPC statuses (`PERMISSION_DENIED` / `UNAUTHENTICATED` trailers-only responses), and a forwarding `NamedService` impl — the exact fix the issue requested.
- **New `GrpcTokenAuthLayer`** (exported from the prelude): HTTP-level token authentication for gRPC. This is a hard prerequisite for Cedar — `with_interceptor`-based auth runs *inside* the generated server, after any outer layer, so an outer Cedar layer could never see `Claims` without an HTTP-level auth layer outside it.
- **Framework-managed wiring**: `ServiceBuilder::build()` now applies token auth (outermost) and Cedar (inner) to all gRPC routes in both single-port and dual-port modes, built from the same validators (including key-manager wrapping) as the HTTP side. Health (`grpc.health.v1.Health`) and reflection services stay credential-free for infrastructure probes; `public_paths` prefixes are honored.
- **Fail-closed Cedar init** (same class as #41/#29, fixed in #45): an enabled `[cedar]` section whose initialization fails is now a fatal startup error surfaced by `try_build()`/`serve()`, instead of a warning followed by serving every route with no policy enforcement.

## Verification

- **562/562 tests pass** on both CI feature configs (`--features full` and `--no-default-features --features "full,crypto-ring"`); clippy clean with `-D warnings` on both. 13 new tests cover allow/deny/missing-claims/disabled/health-exempt paths, `NamedService` forwarding, `add_service` composition (the issue's repro), token-auth injection/rejection/public-paths, and the fail-closed Cedar init pair.
- **Live end-to-end check** with grpcurl against the new `cedar-grpc` example: no token → `UNAUTHENTICATED`; token with the `user` role → allowed by policy; role-less token → `PERMISSION_DENIED` ("Access denied by policy"); reflection resolves descriptors without credentials.
- Docs updated: cedar-auth page (the section issue #36 noted was deferred pending this), grpc-guide, token-auth, gRPC module rustdoc, and example READMEs.

## Breaking change

Services with `[token]` configured now require valid tokens on gRPC methods (previously gRPC was silently open regardless of config). Intentionally public methods can be listed in `public_paths` (prefix match against the full method path, e.g. `"/hello.v1.PublicService/"`).

https://claude.ai/code/session_01FGC4hEbFAyPwSZVKREtrvW