### PR TITLE
ci(audit): put audit in full and cover every storage backend in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,3 +51,32 @@ jobs:
         run: cargo clippy -p acton-service --all-targets --no-default-features --features "full,crypto-ring" -- -D warnings
       - name: Nextest
         run: cargo nextest run -p acton-service --no-default-features --features "full,crypto-ring"
+
+  # The `full` legs above cover audit with the PostgreSQL storage backend
+  # (`database` is in `full`). The optional backends are mutually exclusive
+  # with `database`, so each parser/unit path gets its own leg. All storage
+  # tests here are pure unit tests — no live services required.
+  audit-storage:
+    name: audit storage (${{ matrix.backend }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - backend: turso
+            features: --no-default-features --features "audit,turso,http,observability,crypto-aws-lc-rs"
+          - backend: surrealdb
+            features: --no-default-features --features "audit,surrealdb,http,observability,crypto-aws-lc-rs"
+          - backend: clickhouse
+            features: --features "audit,clickhouse"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: audit-${{ matrix.backend }}
+      - uses: taiki-e/install-action@nextest
+      - name: Nextest
+        run: cargo nextest run -p acton-service ${{ matrix.features }}

--- a/acton-docs/src/app/docs/feature-flags/page.md
+++ b/acton-docs/src/app/docs/feature-flags/page.md
@@ -806,6 +806,8 @@ Tamper-evident audit logging with BLAKE3 hash chaining.
 - Alerting via `AuditAlertHook` / `AlertConfig`
 - Automatic integration with `login-lockout` and `accounts` when those are enabled
 
+`audit` is part of the `full` feature set. When the feature is compiled in, audit logging is **enabled by default** (set `[audit] enabled = false` to opt out), and the audit agent requires a multi-threaded tokio runtime — on a current-thread runtime (such as a default `#[tokio::test]`), `build()` records a startup error and `serve()` refuses to start rather than running without the configured audit trail.
+
 ```toml
 {% $dep.auditOnly %}
 ```

--- a/acton-service/Cargo.toml
+++ b/acton-service/Cargo.toml
@@ -185,7 +185,7 @@ auth = ["dep:argon2", "dep:rand", "dep:blake3", "dep:base64"] # Core: password h
 oauth = ["auth", "dep:oauth2", "dep:openidconnect", "dep:base64"]  # OAuth/OIDC providers (requires auth)
 auth-full = ["auth", "oauth", "jwt", "cache", "database", "login-lockout", "accounts"]  # All auth features (excludes turso - mutually exclusive with database)
 
-full = ["http", "grpc", "websocket", "database", "cache", "events", "observability", "resilience", "otel-metrics", "prometheus-metrics", "governor", "openapi", "cedar-authz", "jwt", "auth", "session-memory", "session-redis", "htmx", "askama", "sse", "pagination-full", "handlers", "login-lockout", "tls", "accounts", "account-handlers", "journald", "graphql", "graphql-cedar"]
+full = ["http", "grpc", "websocket", "database", "cache", "events", "observability", "resilience", "otel-metrics", "prometheus-metrics", "governor", "openapi", "cedar-authz", "jwt", "auth", "session-memory", "session-redis", "htmx", "askama", "sse", "pagination-full", "handlers", "login-lockout", "tls", "accounts", "account-handlers", "journald", "graphql", "graphql-cedar", "audit"]
 tonic-health = ["dep:tonic-health"]
 tonic-reflection = ["dep:tonic-reflection"]
 tower-resilience-circuitbreaker = ["dep:tower-resilience-circuitbreaker"]

--- a/acton-service/src/extensions.rs
+++ b/acton-service/src/extensions.rs
@@ -513,7 +513,9 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
 
-    #[tokio::test]
+    // Multi-threaded: `build()` spawns the audit agent (enabled by default),
+    // which requires a runtime where `block_in_place` can block.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn service_builder_without_actors_has_empty_extensions() {
         use crate::config::Config;
         use crate::prelude::ServiceBuilder;

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -605,7 +605,7 @@ where
         let mut broker_handle = if needs_agents {
             // Use block_in_place to run async code in sync context
             // Initialize agent runtime inside the async block using launch_async()
-            if let Ok(_handle) = tokio::runtime::Handle::try_current() {
+            if runtime_supports_block_in_place() == Some(true) {
                 tokio::task::block_in_place(|| {
                     tokio::runtime::Handle::current().block_on(async {
                         // Initialize the agent runtime using launch_async() for async context
@@ -738,6 +738,16 @@ where
                         }
                     });
                 });
+            } else if runtime_supports_block_in_place() == Some(false) {
+                let err = crate::error::Error::Internal(
+                    "database/cache/events agents are configured but the tokio runtime is \
+                     single-threaded, so they cannot be spawned from ServiceBuilder::build(); \
+                     use a multi-threaded runtime (#[tokio::main], or \
+                     #[tokio::test(flavor = \"multi_thread\")] in tests)"
+                        .to_string(),
+                );
+                tracing::error!("{}", err);
+                record_startup_error(&mut startup_error, err);
             }
 
             self.broker()
@@ -771,8 +781,8 @@ where
                         },
                     );
 
-                if let Ok(_handle) = tokio::runtime::Handle::try_current() {
-                    let result = tokio::task::block_in_place(|| {
+                match runtime_supports_block_in_place() {
+                    Some(true) => tokio::task::block_in_place(|| {
                         tokio::runtime::Handle::current().block_on(async {
                             // Initialize agent runtime if not already done
                             if self.agent_runtime.is_none() {
@@ -808,11 +818,24 @@ where
                                 None
                             }
                         })
-                    });
-                    result
-                } else {
-                    tracing::warn!("No tokio runtime available for audit agent");
-                    None
+                    }),
+                    Some(false) => {
+                        let err = crate::error::Error::Internal(
+                            "audit logging is enabled (the default) but the tokio runtime is \
+                             single-threaded, so the audit agent cannot be spawned from \
+                             ServiceBuilder::build(); use a multi-threaded runtime \
+                             (#[tokio::main], or #[tokio::test(flavor = \"multi_thread\")] in \
+                             tests) or set [audit] enabled = false"
+                                .to_string(),
+                        );
+                        tracing::error!("{}", err);
+                        record_startup_error(&mut startup_error, err);
+                        None
+                    }
+                    None => {
+                        tracing::warn!("No tokio runtime available for audit agent");
+                        None
+                    }
                 }
             } else {
                 None
@@ -1807,6 +1830,18 @@ where
 /// The build continues after a failure so that every problem gets logged in one
 /// pass rather than one per restart, but only the first error is returned to the
 /// caller — it is the one that stopped the intended posture from being honoured.
+/// Whether the entered tokio runtime supports `tokio::task::block_in_place`.
+///
+/// `None` when no runtime is entered at all. `Some(false)` on a current-thread
+/// runtime, where `block_in_place` panics instead of blocking — callers must
+/// check this up front rather than discovering the flavor as a panic inside
+/// tokio during `build()`.
+fn runtime_supports_block_in_place() -> Option<bool> {
+    tokio::runtime::Handle::try_current()
+        .ok()
+        .map(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
+}
+
 fn record_startup_error(slot: &mut Option<crate::error::Error>, error: crate::error::Error) {
     if slot.is_none() {
         *slot = Some(error);
@@ -2332,10 +2367,44 @@ mod tests {
         );
     }
 
+    /// The audit agent (enabled by default) cannot be spawned from a
+    /// current-thread runtime; `build()` must record that as a startup error
+    /// that `serve()` surfaces, instead of letting `block_in_place` panic with
+    /// an unactionable message deep inside tokio. This test deliberately stays
+    /// on the default current-thread test runtime.
+    #[cfg(feature = "audit")]
+    #[tokio::test]
+    async fn serve_refuses_when_audit_cannot_spawn_on_current_thread_runtime() {
+        use crate::config::Config;
+        use crate::prelude::ServiceBuilder;
+
+        let base = Config::<()>::default();
+        let config = Config::<()> {
+            service: crate::config::ServiceConfig {
+                port: 0,
+                ..base.service.clone()
+            },
+            ..base
+        };
+
+        let service = ServiceBuilder::new().with_config(config).build();
+
+        let err = service
+            .serve()
+            .await
+            .expect_err("serve() must refuse when the audit agent could not be spawned");
+        assert!(
+            err.to_string().contains("audit"),
+            "error must name the audit subsystem: {err}"
+        );
+    }
+
     /// `serve()` must reject a degraded build before it binds any listener, so
     /// callers using the infallible `build()` are protected too.
     #[cfg(feature = "tls")]
-    #[tokio::test]
+    // Multi-threaded: `build()` spawns the audit agent (enabled by default),
+    // which requires a runtime where `block_in_place` can block.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn serve_refuses_to_bind_after_a_failed_tls_load() {
         use crate::config::{Config, TlsConfig};
         use crate::prelude::ServiceBuilder;
@@ -2369,7 +2438,9 @@ mod tests {
     /// `config.tls.enabled` alone would drop the header on connections that are
     /// in fact encrypted.
     #[cfg(feature = "tls")]
-    #[tokio::test]
+    // Multi-threaded: `build()` spawns the audit agent (enabled by default),
+    // which requires a runtime where `block_in_place` can block.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn injected_tls_config_still_sends_hsts() {
         use crate::config::Config;
         use crate::prelude::ServiceBuilder;


### PR DESCRIPTION
Closes #26

## What

- `audit` joins `full`, so both existing CI legs now compile and test the audit subsystem (PostgreSQL backend via `database`).
- New `audit-storage` CI job with one leg per optional backend — `turso`, `surrealdb`, `clickhouse` — since the first two are mutually exclusive with `database` and can't ride the `full` legs. All storage tests are pure unit tests; no service containers.
- Fixes the bug this immediately surfaced (the three failing tests documented in the issue comments): `build()` called `block_in_place` unconditionally, panicking on current-thread runtimes. Audit being on-by-default made every default `#[tokio::test]` touching `build()` panic. Now the runtime flavor is checked up front and a clear startup error flows through the #45 deferred-error mechanism — `serve()`/`try_build()` refuse with an actionable message instead. Broker/agents block gets the same guard; remaining `block_in_place` sites tracked in #54.
- Three affected tests re-flavored `multi_thread`; new current-thread regression test pins the refusal behavior.
- Feature-flags docs page updated (audit in `full`, on by default, needs multi-threaded runtime).

## Verification

- `cargo clippy -p acton-service --all-targets --features full -- -D warnings` — clean
- `cargo nextest run -p acton-service --features full` — **619/619** (previously 615/618 under `full,audit`)
- The three new backend legs validate themselves on this PR's CI run.

https://claude.ai/code/session_01Ksi4GWwt3rWY4ZhzRAiyKE