### PR TITLE
fix(grpc)!: refuse to build when gRPC services can never be served

### DIFF
--- a/acton-service/src/config.rs
+++ b/acton-service/src/config.rs
@@ -720,6 +720,34 @@ pub struct GrpcConfig {
     pub proto: ProtoConfig,
 }
 
+impl Default for GrpcConfig {
+    /// Every field reuses the serde default function that backs it, so a
+    /// programmatically constructed `GrpcConfig` and one deserialized from a
+    /// `[grpc]` section that omits those keys agree exactly.
+    ///
+    /// `enabled` is the one deliberate divergence. Deserialization defaults it
+    /// to `true` because writing a `[grpc]` section at all is a statement of
+    /// intent, whereas `GrpcConfig::default()` is only a starting point for
+    /// building one up — it must not silently stand up a gRPC surface the
+    /// caller never asked for. Set `enabled: true` explicitly to serve gRPC.
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            use_separate_port: default_false(),
+            bind: None,
+            #[cfg(feature = "tls")]
+            tls: None,
+            port: default_grpc_port(),
+            reflection_enabled: default_true(),
+            health_check_enabled: default_true(),
+            max_message_size_mb: default_grpc_max_message_mb(),
+            connection_timeout_secs: default_connection_timeout(),
+            timeout_secs: default_timeout(),
+            proto: ProtoConfig::default(),
+        }
+    }
+}
+
 /// Protocol buffer runtime configuration
 ///
 /// NOTE: This is RUNTIME configuration only. Proto compilation happens at build time.

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -1536,6 +1536,17 @@ where
         // Token auth (outermost) validates the `authorization` metadata and
         // injects Claims; Cedar (inner) then authorizes each method. Health
         // and reflection services are exempt, as are `public_paths` prefixes.
+        // Registering gRPC services that no listener will ever expose is a
+        // misconfiguration, not a preference. Caught here, before the routes
+        // are consumed, so `try_build()` / `serve()` report it without binding.
+        #[cfg(feature = "grpc")]
+        if let Some(err) =
+            grpc_registration_error(self.grpc_services.is_some(), config.grpc.as_ref())
+        {
+            tracing::error!("{}", err);
+            record_startup_error(&mut startup_error, err);
+        }
+
         #[cfg(feature = "grpc")]
         let grpc_router: Option<axum::Router> = match self.grpc_services {
             Some(routes) => {
@@ -1896,6 +1907,41 @@ fn record_startup_error(slot: &mut Option<crate::error::Error>, error: crate::er
     if slot.is_none() {
         *slot = Some(error);
     }
+}
+
+/// Detect gRPC services registered against a build that can never serve them.
+///
+/// `with_grpc_services` is an explicit statement that this process serves gRPC.
+/// If `[grpc]` is absent or `enabled = false`, those services are unreachable:
+/// the listener only ever speaks HTTP, and every RPC the caller registered
+/// fails at the client with a transport error that points nowhere near the
+/// cause. Dropping them silently is the same fail-unsafe direction as serving
+/// plaintext where TLS was configured, so it is fatal at build time instead.
+///
+/// Pure: derives the verdict solely from its two arguments.
+#[cfg(feature = "grpc")]
+fn grpc_registration_error(
+    services_registered: bool,
+    grpc: Option<&crate::config::GrpcConfig>,
+) -> Option<crate::error::Error> {
+    let grpc_enabled = grpc.is_some_and(|g| g.enabled);
+    if !services_registered || grpc_enabled {
+        return None;
+    }
+
+    let cause = match grpc {
+        Some(_) => "the `[grpc]` section sets `enabled = false`",
+        None => "no `[grpc]` section is configured",
+    };
+
+    Some(crate::error::Error::Internal(format!(
+        "gRPC services were registered with `with_grpc_services`, but gRPC is not enabled: \
+         {cause}. Those services would be silently discarded and every RPC would fail at the \
+         client, so the build is refused. To fix, either set `enabled = true` under `[grpc]` in \
+         your config file, or supply a config whose `grpc` field is \
+         `Some(GrpcConfig {{ enabled: true, ..Default::default() }})`. If gRPC is not wanted, \
+         remove the `with_grpc_services` call."
+    )))
 }
 
 impl<T> Default for ServiceBuilder<T>
@@ -2574,5 +2620,134 @@ mod tests {
                 .with_single_cert(vec![cert.cert.der().clone()], key.into())
                 .expect("server config"),
         )
+    }
+
+    /// `GrpcConfig::default()` must not stand up a gRPC surface on its own.
+    /// Callers reach for it to fill in ports and timeouts, not to opt in.
+    #[cfg(feature = "grpc")]
+    #[test]
+    fn grpc_config_default_is_disabled() {
+        use crate::config::GrpcConfig;
+
+        let config = GrpcConfig::default();
+
+        assert!(
+            !config.enabled,
+            "GrpcConfig::default() must be disabled so it cannot enable gRPC by accident"
+        );
+        assert_eq!(
+            config.port, 9090,
+            "the Default impl must agree with the serde default for `port`"
+        );
+    }
+
+    /// Registering gRPC services with no `[grpc]` section at all must fail the
+    /// build rather than start an HTTP-only service that drops every RPC.
+    #[cfg(feature = "grpc")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn grpc_services_without_grpc_config_is_fatal() {
+        use crate::config::Config;
+        use crate::prelude::ServiceBuilder;
+
+        let config = Config::<()> {
+            grpc: None,
+            ..Default::default()
+        };
+
+        let error = ServiceBuilder::new()
+            .with_config(config)
+            .with_grpc_services(tonic::service::Routes::default())
+            .try_build()
+            .err()
+            .expect("registering gRPC services with no [grpc] section must fail the build");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("no `[grpc]` section is configured"),
+            "error must name the cause, got: {message}"
+        );
+        assert!(
+            message.contains("enabled = true"),
+            "error must state the fix, got: {message}"
+        );
+    }
+
+    /// An explicitly disabled `[grpc]` section is equally fatal when services
+    /// were registered — the services still have nowhere to be served.
+    #[cfg(feature = "grpc")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn grpc_services_with_disabled_grpc_config_is_fatal() {
+        use crate::config::{Config, GrpcConfig};
+        use crate::prelude::ServiceBuilder;
+
+        let config = Config::<()> {
+            grpc: Some(GrpcConfig {
+                enabled: false,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let error = ServiceBuilder::new()
+            .with_config(config)
+            .with_grpc_services(tonic::service::Routes::default())
+            .try_build()
+            .err()
+            .expect("registering gRPC services against `enabled = false` must fail the build");
+
+        assert!(
+            error
+                .to_string()
+                .contains("the `[grpc]` section sets `enabled = false`"),
+            "error must name the cause, got: {error}"
+        );
+    }
+
+    /// The happy path: services registered against an enabled `[grpc]` section
+    /// builds, so the new check cannot regress working configurations.
+    #[cfg(feature = "grpc")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn grpc_services_with_enabled_grpc_config_builds() {
+        use crate::config::{Config, GrpcConfig};
+        use crate::prelude::ServiceBuilder;
+
+        let config = Config::<()> {
+            grpc: Some(GrpcConfig {
+                enabled: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert!(
+            ServiceBuilder::new()
+                .with_config(config)
+                .with_grpc_services(tonic::service::Routes::default())
+                .try_build()
+                .is_ok(),
+            "an enabled [grpc] section with registered services must build"
+        );
+    }
+
+    /// No services registered means nothing to lose, whatever `[grpc]` says.
+    /// Guards against the check firing on plain HTTP services.
+    #[cfg(feature = "grpc")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn no_grpc_services_without_grpc_config_builds() {
+        use crate::config::Config;
+        use crate::prelude::ServiceBuilder;
+
+        let config = Config::<()> {
+            grpc: None,
+            ..Default::default()
+        };
+
+        assert!(
+            ServiceBuilder::new()
+                .with_config(config)
+                .try_build()
+                .is_ok(),
+            "an HTTP-only service must not be affected by the gRPC registration check"
+        );
     }
 }


### PR DESCRIPTION
## Problem

Part of #53.

`ServiceBuilder::with_grpc_services` registered routes that `serve()` silently discarded whenever `config.grpc` was `None` or `enabled = false`. The gate at `service_builder.rs` had no `else` branch:

```rust
if let Some(ref grpc_config) = self.config.grpc {
    if grpc_config.enabled && self.grpc_routes.is_some() {
```

The service started HTTP-only and every registered RPC failed at the client with a transport error pointing nowhere near the cause.

This is easy to hit because `Config::default()` sets `grpc: None`, so the natural-looking pattern below never runs its body:

```rust
if let Some(ref mut grpc_config) = config.grpc {
    grpc_config.enabled = true;   // never executes
}
```

`examples/grpc/single-port.rs` has been broken this way — its documented `grpcurl` commands cannot have worked. That example is fixed in a follow-up PR, which this one is a prerequisite for.

## Change

**Fail fast at build time.** A pure `grpc_registration_error(services_registered, grpc)` detector runs in `build()` before the routes are consumed, and reports through the same deferred-error path the TLS and Cedar checks already use (#45, #51) — so `try_build()` and `serve()` both surface it with no listener bound. The message distinguishes the two causes and states the remedy.

**Add `impl Default for GrpcConfig`**, which was missing entirely and forced callers to enumerate every field — the ergonomic pressure that produced the mutation pattern in the first place. Every field delegates to the serde default function already backing it, so the programmatic and deserialized paths cannot drift.

`Config::default()` still sets `grpc: None`. Populating it with a disabled section would make the buggy mutation pattern *work*, but would also destroy the meaning of `config.grpc.is_some()` as "the user configured gRPC", which is load-bearing elsewhere.

### One judgment call worth review

`enabled` is the single deliberate divergence from the serde defaults: deserialization uses `default_true` (writing a `[grpc]` section is a statement of intent), while `Default::default()` uses `false` (a starting point to build up, not an opt-in). This is documented in the impl. It is self-consistent with the new check — reaching for `GrpcConfig::default()` and expecting gRPC on now produces a loud error rather than a silent HTTP-only service.

## Breaking change

A build registering gRPC services without gRPC enabled now errors instead of starting HTTP-only. Any code this breaks was already not serving gRPC; it just did so silently.

## Verification

- `cargo clippy -p acton-service --all-targets --features full -- -D warnings` — clean
- Same with `--no-default-features --features "grpc,crypto-ring"` (exercises the cfg-gated `tls` field) — clean
- `cargo nextest run -p acton-service --features full` — **571 passed, 0 failed**
- 5 new tests: default-is-disabled, both fatal paths, the happy path, and an HTTP-only guard against false positives

No clippy suppressions added. No version bump — releases ship via separate `chore(release)` PRs in this repo.