### PR TITLE
chore(cli): mark acton-cli as publish = false

### DIFF
--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -12,6 +12,11 @@ readme = "README.md"
 keywords = ["microservice", "cli", "scaffolding", "codegen", "framework"]
 categories = ["command-line-utilities", "development-tools::build-utils"]
 
+# The CLI is being deprecated and will not receive further crates.io releases.
+# `cargo publish` refuses this crate outright rather than relying on whoever
+# runs the release to remember to skip it.
+publish = false
+
 [[bin]]
 name = "acton"
 path = "src/main.rs"


### PR DESCRIPTION
## What

Adds `publish = false` to `acton-cli/Cargo.toml`.

## Why

The CLI is being deprecated and will not receive further crates.io releases. This repo has no `cargo publish` automation — releases are cut by hand — so today nothing stops the CLI from going out except the person running the release remembering to skip it. `publish = false` makes cargo refuse the crate outright.

This also backs the won't-fix on #35 (CLI accepts silently-ignored flags), which was closed on the grounds that the CLI is going away.

## Verification

`cargo metadata` confirms the flag applies to the intended crate only:

```
acton-service -> publish: None   (still publishable)
acton-cli     -> publish: []     (publish = false)
```

`cargo check --workspace` passes. `acton-cli` stays in `members` and `default-members`, so it still builds and tests in CI — this only blocks publication.

## Note, unrelated to this change

`cargo check` on default features surfaces a pre-existing warning that arrived with #57:

```
warning: function `runtime_supports_block_in_place` is never used
  --> acton-service/src/service_builder.rs:1935:4
```

It is not truly dead — it is called at lines 608, 741, and 784, but every call site is behind `#[cfg(any(feature = "database", feature = "cache", feature = "events", feature = "turso", feature = "surrealdb", feature = "clickhouse"))]` while the definition carries no `cfg`. Fixed in a separate PR, not folded in here.