### PR TITLE
fix(grpc): make the single-port example serve gRPC and expose health

### DIFF
--- a/acton-service/examples/grpc/single-port.rs
+++ b/acton-service/examples/grpc/single-port.rs
@@ -19,8 +19,9 @@
 //! ## Testing
 //!
 //! ```bash
-//! # Test HTTP endpoint
+//! # Test HTTP endpoint (`name` is optional and defaults to "World")
 //! curl http://localhost:8080/api/v1/hello
+//! curl 'http://localhost:8080/api/v1/hello?name=Alice'
 //!
 //! # Test gRPC endpoint (requires grpcurl)
 //! grpcurl -plaintext -d '{"name":"World"}' localhost:8080 hello.v1.HelloService/SayHello
@@ -29,6 +30,7 @@
 //! grpcurl -plaintext localhost:8080 grpc.health.v1.Health/Check
 //! ```
 
+use acton_service::config::GrpcConfig;
 use acton_service::prelude::*;
 
 // ============================================================================
@@ -80,20 +82,14 @@ struct HelloHttpResponse {
     message: String,
 }
 
-async fn http_hello() -> Json<HelloHttpResponse> {
-    tracing::info!("HTTP request received");
-
-    Json(HelloHttpResponse {
-        message: "Hello from HTTP!".to_string(),
-    })
-}
-
 #[derive(Debug, Deserialize)]
 struct NameQuery {
     name: Option<String>,
 }
 
-async fn http_hello_name(Query(query): Query<NameQuery>) -> Json<HelloHttpResponse> {
+/// Handles both `/hello` and `/hello?name=...`, so every documented `curl`
+/// above behaves as advertised.
+async fn http_hello(Query(query): Query<NameQuery>) -> Json<HelloHttpResponse> {
     let name = query.name.unwrap_or_else(|| "World".to_string());
 
     tracing::info!("HTTP request received: name={}", name);
@@ -114,7 +110,7 @@ async fn main() -> Result<()> {
     tracing::info!("");
     tracing::info!("Test commands:");
     tracing::info!("  HTTP: curl http://localhost:8080/api/v1/hello");
-    tracing::info!("  HTTP with name: curl http://localhost:8080/api/v1/hello?name=Alice");
+    tracing::info!("  HTTP with name: curl 'http://localhost:8080/api/v1/hello?name=Alice'");
     tracing::info!("  gRPC: grpcurl -plaintext -d '{{\"name\":\"World\"}}' localhost:8080 hello.v1.HelloService/SayHello");
     tracing::info!("  Health: grpcurl -plaintext localhost:8080 grpc.health.v1.Health/Check");
     tracing::info!("");
@@ -122,30 +118,37 @@ async fn main() -> Result<()> {
     // Build HTTP routes
     let http_routes = VersionedApiBuilder::new()
         .with_base_path("/api")
-        .add_version(ApiVersion::V1, |router| {
-            router.route("/hello", get(http_hello).post(http_hello_name))
-        })
+        .add_version(ApiVersion::V1, |router| router.route("/hello", get(http_hello)))
         .build_routes();
 
-    // Build gRPC services
-    let hello_service = HelloServiceImpl;
+    // Enable gRPC in single-port mode.
+    //
+    // `Config::default()` leaves every optional section as `None`, so the
+    // section must be *assigned*, not mutated in place — mutating through an
+    // `if let Some(..)` would never run its body and the build would be
+    // refused for registering gRPC services that no listener can expose.
+    let mut config = Config::default();
+    config.service.port = 8080;
+    config.grpc = Some(GrpcConfig {
+        enabled: true,
+        use_separate_port: false, // single-port HTTP + gRPC
+        ..Default::default()
+    });
 
+    // The health service needs an `AppState` to probe dependencies; passing
+    // `None` would skip it with only a warning and the documented
+    // `grpc.health.v1.Health/Check` call would fail. This config declares no
+    // database, cache, or event bus, so the check has nothing to probe and
+    // reports SERVING without any external service running.
+    let state = AppState::builder().config(config.clone()).build().await?;
+
+    // Build gRPC services
     let grpc_routes = acton_service::grpc::server::GrpcServicesBuilder::new()
         .with_health()
         .with_reflection()
         .add_file_descriptor_set(hello::FILE_DESCRIPTOR_SET)
-        .add_service(HelloServiceServer::new(hello_service))
-        .build(None);
-
-    // Create config with single-port mode (default)
-    let mut config = Config::default();
-    config.service.port = 8080;
-
-    // Enable gRPC and ensure single-port mode
-    if let Some(ref mut grpc_config) = config.grpc {
-        grpc_config.enabled = true;
-        grpc_config.use_separate_port = false; // CRITICAL: This enables single-port mode
-    }
+        .add_service(HelloServiceServer::new(HelloServiceImpl))
+        .build(Some(state));
 
     // Build and serve the combined service
     ServiceBuilder::new()

--- a/acton-service/src/grpc/server.rs
+++ b/acton-service/src/grpc/server.rs
@@ -160,6 +160,15 @@ impl GrpcServicesBuilder {
 
                 self.routes = self.routes.add_service(health_server);
 
+                // Reflection describes only the descriptor sets it was given.
+                // Without the health descriptor, `grpc.health.v1.Health` is
+                // routable but invisible, so reflection-driven clients such as
+                // `grpcurl` report the service as not exposed even though it is.
+                // Registered here, where the service is actually served, so the
+                // two can never disagree.
+                self.file_descriptor_sets
+                    .push(tonic_health::pb::FILE_DESCRIPTOR_SET);
+
                 tracing::info!("gRPC health service enabled");
             } else {
                 tracing::warn!(
@@ -201,5 +210,25 @@ impl GrpcServicesBuilder {
 impl Default for GrpcServicesBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// `build` registers the health descriptor set so reflection can describe
+    /// `grpc.health.v1.Health`. That is only useful if reflection actually
+    /// accepts the descriptor: an FDS with unresolved imports is rejected at
+    /// `build_v1()`, which would leave the health service routable but
+    /// invisible to `grpcurl` — the exact failure the registration fixes.
+    #[test]
+    fn health_descriptor_set_is_usable_by_reflection() {
+        let reflection = tonic_reflection::server::Builder::configure()
+            .register_encoded_file_descriptor_set(tonic_health::pb::FILE_DESCRIPTOR_SET)
+            .build_v1();
+
+        assert!(
+            reflection.is_ok(),
+            "health descriptor set must be self-contained enough for reflection to serve it"
+        );
     }
 }


### PR DESCRIPTION
Closes #53. Stacked on #56 (merged), rebased onto current `main`.

## The example never served gRPC

```rust
let mut config = Config::default();
if let Some(ref mut grpc_config) = config.grpc {
    grpc_config.enabled = true;              // never executes
    grpc_config.use_separate_port = false;
}
```

`Config::default()` leaves every optional section `None`, so the body never ran. The service started HTTP-only and every documented `grpcurl` command failed. Fixed by *assigning* the section, with a comment explaining why mutation-through-`Option` is the wrong shape here.

## Three more documented commands that could not work

**`grpc.health.v1.Health/Check`** failed for two independent reasons:

1. `build(None)` — with no `AppState` the health service is skipped behind a `tracing` warning. Now passes state. This example declares no database, cache, or event bus, so `check_dependencies` has nothing to probe and reports SERVING with no external service running.
2. Even with state, grpcurl still returned `target server does not expose service "grpc.health.v1.Health"`. Reflection describes only the descriptor sets it is handed, and the health descriptor was never among them — the service was routable but invisible.

**`curl '.../hello?name=Alice'`** returned `Hello from HTTP!`, ignoring the name. The route was `get(http_hello).post(http_hello_name)`, so the documented GET reached the handler that takes no query. Collapsed to one GET handler; the POST variant was undocumented.

### One framework change, flagged for review

Reason 2 above is fixed in `GrpcServicesBuilder::build`, not in the example — registering the health descriptor per-example would be a user-side workaround for a framework gap, and every user calling `.with_health().with_reflection()` hits it. The push sits inside the branch that registers the health server, so routing and reflection cannot drift apart. A regression test asserts the descriptor is self-contained enough for `build_v1()` to accept it.

This makes health reflection work for all users, so it warrants at least a minor bump at release time.

Say the word if you'd rather this ship separately from the example fix — I kept them together because the example's documented health command cannot work without it, and demonstrating that every documented command works is the point of the PR.

## Verified against a running instance

Not just compiled — started, exercised, killed:

| command | result |
|---|---|
| startup log | `Starting hybrid HTTP+gRPC service on 0.0.0.0:8080` (**hybrid**, not HTTP-only) |
| `curl .../api/v1/hello` | `{"message":"Hello, World! (via HTTP)"}` |
| `curl '.../api/v1/hello?name=Alice'` | `{"message":"Hello, Alice! (via HTTP)"}` |
| `grpcurl ... list` | `grpc.health.v1.Health`, `grpc.reflection.v1.ServerReflection`, `hello.v1.HelloService` |
| `grpcurl ... SayHello` | `{"message": "Hello, World! (via gRPC)"}` |
| `grpcurl ... Health/Check` | `{"status": "SERVING"}` |

Proto names in the docs were already correct (`hello.proto` declares `package hello.v1`), so they are unchanged.

`cargo clippy -p acton-service --all-targets --features full -- -D warnings` clean; `cargo nextest run -p acton-service --features full` 572 passed / 0 failed. No suppressions, no version bump.

Note: `--all-features` is structurally impossible in this repo — it trips four `compile_error!`s for mutually exclusive features (`database`/`turso`/`surrealdb`, `crypto-aws-lc-rs`/`crypto-ring`). Used the invocation CI runs.

## Sweep

The single-port example was the **only** instance of this dead-mutation pattern in the repo. All 20 optional `Config<T>` sections default to `None`, so the pattern is always dead after `Config::default()` — #56 now makes the gRPC case fatal rather than silent. Hits in `acton-docs` are immutable reads against a file-loaded `Config::load()`, so they are correct and need no change.

Adjacent, not touched: `examples/authorization/cedar-authz.rs:225` does `config.cedar.clone().unwrap()` on a file-loaded config — live, but panics if `[cedar]` is absent.