### PR TITLE
fix(build): gate runtime_supports_block_in_place and restore its neighbour's docs

### DIFF
--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -1921,23 +1921,34 @@ where
     }
 }
 
-/// Record a fatal build-time misconfiguration, keeping the first one seen.
-///
-/// The build continues after a failure so that every problem gets logged in one
-/// pass rather than one per restart, but only the first error is returned to the
-/// caller — it is the one that stopped the intended posture from being honoured.
 /// Whether the entered tokio runtime supports `tokio::task::block_in_place`.
 ///
 /// `None` when no runtime is entered at all. `Some(false)` on a current-thread
 /// runtime, where `block_in_place` panics instead of blocking — callers must
 /// check this up front rather than discovering the flavor as a panic inside
 /// tokio during `build()`.
+///
+/// Gated to match its call sites: every caller sits inside the agent-runtime
+/// block, which only exists when one of these features pulls in a pool agent.
+#[cfg(any(
+    feature = "database",
+    feature = "cache",
+    feature = "events",
+    feature = "turso",
+    feature = "surrealdb",
+    feature = "clickhouse"
+))]
 fn runtime_supports_block_in_place() -> Option<bool> {
     tokio::runtime::Handle::try_current()
         .ok()
         .map(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
 }
 
+/// Record a fatal build-time misconfiguration, keeping the first one seen.
+///
+/// The build continues after a failure so that every problem gets logged in one
+/// pass rather than one per restart, but only the first error is returned to the
+/// caller — it is the one that stopped the intended posture from being honoured.
 fn record_startup_error(slot: &mut Option<crate::error::Error>, error: crate::error::Error) {
     if slot.is_none() {
         *slot = Some(error);


### PR DESCRIPTION
Two defects introduced by #57, found while verifying #58. Neither is visible in CI.

## 1. Dead-code warning on default features

`runtime_supports_block_in_place` carries no `cfg`, but all three of its call sites (`service_builder.rs:608`, `:741`, `:784`) live inside the agent-runtime block gated on:

```rust
#[cfg(any(feature = "database", feature = "cache", feature = "events",
          feature = "turso", feature = "surrealdb", feature = "clickhouse"))]
```

On default features those call sites compile away and the definition is stranded:

```
warning: function `runtime_supports_block_in_place` is never used
  --> acton-service/src/service_builder.rs:1935:4
```

Fixed by mirroring the same gate onto the definition, so both sides appear and disappear together. Not suppressed — the function genuinely does not exist in builds that cannot call it.

## 2. A doc comment describing the wrong function

The same change inserted the function *between* `record_startup_error`'s doc comment and its body, which fused the two blocks into one:

```rust
/// Record a fatal build-time misconfiguration, keeping the first one seen.
///
/// The build continues after a failure so that every problem gets logged in one
/// pass rather than one per restart, but only the first error is returned to the
/// caller — it is the one that stopped the intended posture from being honoured.
/// Whether the entered tokio runtime supports `tokio::task::block_in_place`.   ← fused on
///
/// `None` when no runtime is entered at all. ...
fn runtime_supports_block_in_place() -> Option<bool> { ... }

fn record_startup_error(...) { ... }   ← left undocumented
```

Rustdoc therefore publishes the startup-error rationale under the runtime probe, and `record_startup_error` — the function that decides which build failure a caller actually sees — has no docs at all. Fixed by moving the probe above so each comment sits on the item it describes. No prose was rewritten.

## Why CI missed both

`.github/workflows/build.yml` runs clippy with `--features full`, where the function is live and the warning cannot occur. The dead-code path only appears on default features, which nothing in the matrix builds.

Worth considering a default-features clippy job. I have not touched CI here — that is a separate change and a separate call.

## Verification

`cargo clippy -p acton-service --all-targets -- -D warnings` on three combos:

| features | exit |
|---|---|
| default | 0 |
| `--no-default-features --features grpc,crypto-ring` | 0 |
| `--features full` | 0 |

Default features fails without this change and passes with it. No suppression directives. No version bump.