### PR TITLE
feat(audit): emit the remaining declared auth audit events

### DIFF
--- a/acton-docs/src/app/docs/audit/page.md
+++ b/acton-docs/src/app/docs/audit/page.md
@@ -139,11 +139,33 @@ When `audit_auth_events` is enabled (default), the PASETO and JWT middleware aut
 | `AuthTokenInvalid` | Bearer token failed validation (bad signature, expired, malformed claims) | Warning |
 | `AuthTokenRevoked` | Revoked token presented. Event metadata carries `jti` for SIEM correlation. | Warning |
 | `AuthPermissionDenied` | Cedar policy returned `Deny` (HTTP middleware and gRPC tower service) | Warning |
-| `HttpRequestDenied` | Rate-limit rejection (`Error::RateLimitExceeded`) | Warning |
+| `HttpRequestDenied` | Rate-limit rejection (`Error::RateLimitExceeded`), from both the Redis-backed and governor limiters | Warning |
+| `AuthLogout` | `TypedSession<AuthSession>::logout()` called; subject is the previously authenticated user | Notice |
 
 > `AuthLoginFailed` is no longer emitted by the auth middleware. It is reserved for application-level login handlers (e.g. `POST /auth/login`) where credentials are submitted. The middleware emits `AuthTokenMissing` or `AuthTokenInvalid` instead, so unauthenticated probes against protected routes (health checks, scanners) no longer drown out real failed-login signal. See the 0.27 release notes for the migration.
 
 No additional code is required. These events include the client IP, user agent, request ID, and authenticated subject. The IP and request ID come from the request-context middleware, which resolves them once per request — from `X-Forwarded-For` / `X-Real-IP` when an upstream proxy supplies them, falling back to the direct TCP peer address otherwise — and runs after the request ID is generated. Token-failure events therefore carry a usable source even when a proxy strips forwarding headers (see [Execution Order](/docs/middleware#execution-order)).
+
+### Auth Storage Decorators
+
+Token refresh, API-key lifecycle, and OAuth callbacks run through storage and provider traits that your application constructs, so the framework cannot emit those events automatically. Wrap what you build with the decorators in `acton_service::audit` and every backend emits the same events:
+
+```rust
+use acton_service::audit::{AuditedApiKeyStorage, AuditedOAuthProvider, AuditedRefreshStorage};
+
+let logger = state.audit_logger().expect("audit enabled").clone();
+let refresh = AuditedRefreshStorage::new(RedisRefreshStorage::new(pool.clone()), logger.clone());
+let api_keys = AuditedApiKeyStorage::new(RedisApiKeyStorage::new(pool, "sk_live"), logger.clone());
+let google = AuditedOAuthProvider::new(google_provider, logger);
+```
+
+| Decorator | Emits | When |
+|---|---|---|
+| `AuditedRefreshStorage` | `AuthTokenRefresh` | Successful token rotation; source carries the user ID plus the IP/user agent captured at issuance |
+| `AuditedApiKeyStorage` | `AuthApiKeyCreated` / `AuthApiKeyRevoked` | Successful create/revoke; metadata carries key ID, name, prefix, and scopes — never the key or its hash |
+| `AuditedOAuthProvider` | `AuthOAuthCallback` | Authorization-code exchange, success (Notice) or failure (Warning) |
+
+Failed operations propagate their errors without emitting lifecycle events, and all decorator emissions honor `audit_auth_events`.
 
 ## Per-Route Auditing
 

--- a/acton-service/Cargo.toml
+++ b/acton-service/Cargo.toml
@@ -185,7 +185,7 @@ auth = ["dep:argon2", "dep:rand", "dep:blake3", "dep:base64"] # Core: password h
 oauth = ["auth", "dep:oauth2", "dep:openidconnect", "dep:base64"]  # OAuth/OIDC providers (requires auth)
 auth-full = ["auth", "oauth", "jwt", "cache", "database", "login-lockout", "accounts"]  # All auth features (excludes turso - mutually exclusive with database)
 
-full = ["http", "grpc", "websocket", "database", "cache", "events", "observability", "resilience", "otel-metrics", "prometheus-metrics", "governor", "openapi", "cedar-authz", "jwt", "auth", "session-memory", "session-redis", "htmx", "askama", "sse", "pagination-full", "handlers", "login-lockout", "tls", "accounts", "account-handlers", "journald", "graphql", "graphql-cedar", "audit"]
+full = ["http", "grpc", "websocket", "database", "cache", "events", "observability", "resilience", "otel-metrics", "prometheus-metrics", "governor", "openapi", "cedar-authz", "jwt", "auth", "session-memory", "session-redis", "htmx", "askama", "sse", "pagination-full", "handlers", "login-lockout", "tls", "accounts", "account-handlers", "journald", "graphql", "graphql-cedar", "audit", "oauth"]
 tonic-health = ["dep:tonic-health"]
 tonic-reflection = ["dep:tonic-reflection"]
 tower-resilience-circuitbreaker = ["dep:tower-resilience-circuitbreaker"]

--- a/acton-service/src/audit/decorators.rs
+++ b/acton-service/src/audit/decorators.rs
@@ -1,0 +1,687 @@
+//! Audit-emitting decorators for auth storage backends.
+//!
+//! The framework declares audit event kinds for token refresh, API-key
+//! lifecycle, and OAuth callbacks, but the flows they describe run through
+//! storage traits ([`RefreshTokenStorage`], [`ApiKeyStorage`]) and the
+//! [`OAuthProvider`] trait — implemented once per backend and constructed by
+//! the application, not by `ServiceBuilder`. Emitting inside each backend
+//! would duplicate the same lines four times per family, so emission lives in
+//! these wrappers instead: wrap whatever you construct, hand it the
+//! [`AuditLogger`] from `AppState::audit_logger()`, and every backend emits
+//! the same events (issue #16).
+//!
+//! ```rust,ignore
+//! let storage = RedisRefreshStorage::new(pool);
+//! let storage = AuditedRefreshStorage::new(storage, logger.clone());
+//! ```
+//!
+//! All emissions honor `[audit] audit_auth_events` like the built-in auth
+//! middleware events.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use crate::auth::api_keys::{ApiKey, ApiKeyStorage};
+#[cfg(feature = "oauth")]
+use crate::auth::oauth::provider::{OAuthProvider, OAuthTokens, OAuthUserInfo};
+use crate::auth::tokens::refresh::{
+    RefreshTokenData, RefreshTokenMetadata, RefreshTokenStorage,
+};
+use crate::error::Error;
+
+use super::event::{AuditEvent, AuditEventKind, AuditSeverity, AuditSource};
+use super::logger::AuditLogger;
+
+/// Server-side operations have no request context; the source carries only
+/// the subject (and, for refresh rotation, whatever the stored token metadata
+/// captured at issuance).
+fn subject_source(subject: Option<String>) -> AuditSource {
+    AuditSource {
+        ip: None,
+        user_agent: None,
+        subject,
+        request_id: None,
+    }
+}
+
+async fn emit(
+    logger: &AuditLogger,
+    kind: AuditEventKind,
+    severity: AuditSeverity,
+    source: AuditSource,
+    metadata: serde_json::Value,
+) {
+    if !logger.config().audit_auth_events {
+        return;
+    }
+    let event = AuditEvent::new(kind, severity, logger.service_name().to_string())
+        .with_source(source)
+        .with_metadata(metadata);
+    logger.log(event).await;
+}
+
+/// [`RefreshTokenStorage`] wrapper that emits `AuthTokenRefresh` on every
+/// successful rotation.
+///
+/// Only `rotate` emits: `store` is initial issuance (part of login, already
+/// audited by the auth middleware) and revocations have their own event kinds.
+pub struct AuditedRefreshStorage<S> {
+    inner: S,
+    logger: AuditLogger,
+}
+
+impl<S: RefreshTokenStorage> AuditedRefreshStorage<S> {
+    /// Wrap a refresh-token storage backend.
+    pub fn new(inner: S, logger: AuditLogger) -> Self {
+        Self { inner, logger }
+    }
+}
+
+#[async_trait]
+impl<S: RefreshTokenStorage> RefreshTokenStorage for AuditedRefreshStorage<S> {
+    async fn store(
+        &self,
+        token_id: &str,
+        user_id: &str,
+        family_id: &str,
+        expires_at: DateTime<Utc>,
+        metadata: &RefreshTokenMetadata,
+    ) -> Result<(), Error> {
+        self.inner
+            .store(token_id, user_id, family_id, expires_at, metadata)
+            .await
+    }
+
+    async fn get(&self, token_id: &str) -> Result<Option<RefreshTokenData>, Error> {
+        self.inner.get(token_id).await
+    }
+
+    async fn revoke(&self, token_id: &str) -> Result<(), Error> {
+        self.inner.revoke(token_id).await
+    }
+
+    async fn revoke_family(&self, family_id: &str) -> Result<u64, Error> {
+        self.inner.revoke_family(family_id).await
+    }
+
+    async fn revoke_all_for_user(&self, user_id: &str) -> Result<u64, Error> {
+        self.inner.revoke_all_for_user(user_id).await
+    }
+
+    async fn rotate(
+        &self,
+        old_token_id: &str,
+        new_token_id: &str,
+        user_id: &str,
+        family_id: &str,
+        expires_at: DateTime<Utc>,
+        metadata: &RefreshTokenMetadata,
+    ) -> Result<(), Error> {
+        self.inner
+            .rotate(
+                old_token_id,
+                new_token_id,
+                user_id,
+                family_id,
+                expires_at,
+                metadata,
+            )
+            .await?;
+
+        let source = AuditSource {
+            ip: metadata.ip_address.clone(),
+            user_agent: metadata.user_agent.clone(),
+            subject: Some(user_id.to_string()),
+            request_id: None,
+        };
+        emit(
+            &self.logger,
+            AuditEventKind::AuthTokenRefresh,
+            AuditSeverity::Notice,
+            source,
+            serde_json::json!({
+                "family_id": family_id,
+                "old_token_id": old_token_id,
+                "new_token_id": new_token_id,
+            }),
+        )
+        .await;
+        Ok(())
+    }
+
+    async fn cleanup_expired(&self) -> Result<u64, Error> {
+        self.inner.cleanup_expired().await
+    }
+}
+
+/// [`ApiKeyStorage`] wrapper that emits `AuthApiKeyCreated` and
+/// `AuthApiKeyRevoked` on the respective successful operations.
+///
+/// Event metadata never includes the key material or its hash — only the ID,
+/// display name, prefix, and scopes.
+pub struct AuditedApiKeyStorage<S> {
+    inner: S,
+    logger: AuditLogger,
+}
+
+impl<S: ApiKeyStorage> AuditedApiKeyStorage<S> {
+    /// Wrap an API-key storage backend.
+    pub fn new(inner: S, logger: AuditLogger) -> Self {
+        Self { inner, logger }
+    }
+}
+
+#[async_trait]
+impl<S: ApiKeyStorage> ApiKeyStorage for AuditedApiKeyStorage<S> {
+    async fn get_by_key(&self, key: &str) -> Result<Option<ApiKey>, Error> {
+        self.inner.get_by_key(key).await
+    }
+
+    async fn get_by_prefix(&self, prefix: &str) -> Result<Option<ApiKey>, Error> {
+        self.inner.get_by_prefix(prefix).await
+    }
+
+    async fn get_by_id(&self, id: &str) -> Result<Option<ApiKey>, Error> {
+        self.inner.get_by_id(id).await
+    }
+
+    async fn create(&self, key: &ApiKey) -> Result<(), Error> {
+        self.inner.create(key).await?;
+
+        emit(
+            &self.logger,
+            AuditEventKind::AuthApiKeyCreated,
+            AuditSeverity::Notice,
+            subject_source(Some(key.user_id.clone())),
+            serde_json::json!({
+                "key_id": key.id,
+                "name": key.name,
+                "prefix": key.prefix,
+                "scopes": key.scopes,
+            }),
+        )
+        .await;
+        Ok(())
+    }
+
+    async fn update_last_used(&self, id: &str) -> Result<(), Error> {
+        self.inner.update_last_used(id).await
+    }
+
+    async fn revoke(&self, id: &str) -> Result<(), Error> {
+        self.inner.revoke(id).await?;
+
+        emit(
+            &self.logger,
+            AuditEventKind::AuthApiKeyRevoked,
+            AuditSeverity::Notice,
+            subject_source(None),
+            serde_json::json!({ "key_id": id }),
+        )
+        .await;
+        Ok(())
+    }
+
+    async fn list_by_user(&self, user_id: &str) -> Result<Vec<ApiKey>, Error> {
+        self.inner.list_by_user(user_id).await
+    }
+
+    async fn delete(&self, id: &str) -> Result<(), Error> {
+        self.inner.delete(id).await
+    }
+}
+
+/// [`OAuthProvider`] wrapper that emits `AuthOAuthCallback` when an
+/// authorization code is exchanged — the framework-visible moment of the
+/// OAuth callback — on both success and failure.
+#[cfg(feature = "oauth")]
+pub struct AuditedOAuthProvider<P> {
+    inner: P,
+    logger: AuditLogger,
+}
+
+#[cfg(feature = "oauth")]
+impl<P: OAuthProvider> AuditedOAuthProvider<P> {
+    /// Wrap an OAuth provider.
+    pub fn new(inner: P, logger: AuditLogger) -> Self {
+        Self { inner, logger }
+    }
+}
+
+#[cfg(feature = "oauth")]
+#[async_trait]
+impl<P: OAuthProvider> OAuthProvider for AuditedOAuthProvider<P> {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn authorization_url(&self, state: &str, scopes: &[String]) -> String {
+        self.inner.authorization_url(state, scopes)
+    }
+
+    async fn exchange_code(&self, code: &str) -> Result<OAuthTokens, Error> {
+        match self.inner.exchange_code(code).await {
+            Ok(tokens) => {
+                emit(
+                    &self.logger,
+                    AuditEventKind::AuthOAuthCallback,
+                    AuditSeverity::Notice,
+                    subject_source(None),
+                    serde_json::json!({
+                        "provider": self.inner.name(),
+                        "outcome": "success",
+                    }),
+                )
+                .await;
+                Ok(tokens)
+            }
+            Err(e) => {
+                emit(
+                    &self.logger,
+                    AuditEventKind::AuthOAuthCallback,
+                    AuditSeverity::Warning,
+                    subject_source(None),
+                    serde_json::json!({
+                        "provider": self.inner.name(),
+                        "outcome": "failure",
+                        "error": e.to_string(),
+                    }),
+                )
+                .await;
+                Err(e)
+            }
+        }
+    }
+
+    async fn get_user_info(&self, access_token: &str) -> Result<OAuthUserInfo, Error> {
+        self.inner.get_user_info(access_token).await
+    }
+
+    async fn refresh_token(&self, refresh_token: &str) -> Result<OAuthTokens, Error> {
+        self.inner.refresh_token(refresh_token).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use acton_reactive::prelude::*;
+    use async_trait::async_trait;
+    use chrono::Utc;
+
+    use super::*;
+    use crate::audit::agent::AuditAgent;
+    use crate::audit::config::{AuditConfig, SyslogConfig};
+    use crate::audit::storage::AuditStorage;
+
+    /// AuditStorage that records every appended event for assertions.
+    #[derive(Default)]
+    struct CapturingAuditStorage {
+        events: Mutex<Vec<AuditEvent>>,
+    }
+
+    #[async_trait]
+    impl AuditStorage for CapturingAuditStorage {
+        async fn append(&self, event: &AuditEvent) -> Result<(), Error> {
+            self.events.lock().expect("events lock").push(event.clone());
+            Ok(())
+        }
+
+        async fn latest(&self) -> Result<Option<AuditEvent>, Error> {
+            Ok(None)
+        }
+
+        async fn query_range(
+            &self,
+            _from: chrono::DateTime<Utc>,
+            _to: chrono::DateTime<Utc>,
+            _limit: usize,
+        ) -> Result<Vec<AuditEvent>, Error> {
+            Ok(Vec::new())
+        }
+
+        async fn verify_chain(&self, _from_sequence: u64) -> Result<Option<u64>, Error> {
+            Ok(None)
+        }
+    }
+
+    /// Spawn a real audit agent backed by the capturing storage. The runtime
+    /// must stay alive for the agent to process events, so it is returned
+    /// alongside the logger.
+    async fn capturing_logger() -> (ActorRuntime, Arc<CapturingAuditStorage>, AuditLogger) {
+        let mut runtime = ActonApp::launch_async().await;
+        let storage = Arc::new(CapturingAuditStorage::default());
+        let config = AuditConfig {
+            syslog: SyslogConfig {
+                transport: "none".to_string(),
+                ..SyslogConfig::default()
+            },
+            ..AuditConfig::default()
+        };
+        let handle = AuditAgent::spawn(
+            &mut runtime,
+            config.clone(),
+            Some(storage.clone() as Arc<dyn AuditStorage>),
+            "test-svc".to_string(),
+        )
+        .await
+        .expect("spawn audit agent");
+        let logger = AuditLogger::new(handle, "test-svc".to_string(), config);
+
+        // The chain initializes asynchronously (after_start -> ChainLoaded) and
+        // the agent drops events that arrive before it finishes, so probe with
+        // sentinel events until one lands, then discard the sentinels.
+        for _ in 0..100 {
+            logger
+                .log_custom("test.chain-probe", AuditSeverity::Informational, None)
+                .await;
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            if !storage.events.lock().expect("events lock").is_empty() {
+                break;
+            }
+        }
+        storage.events.lock().expect("events lock").clear();
+
+        (runtime, storage, logger)
+    }
+
+    /// Fire-and-forget emission: poll until the expected kind shows up.
+    async fn wait_for_event(
+        storage: &CapturingAuditStorage,
+        kind: &AuditEventKind,
+    ) -> Option<AuditEvent> {
+        for _ in 0..50 {
+            if let Some(event) = storage
+                .events
+                .lock()
+                .expect("events lock")
+                .iter()
+                .find(|e| &e.kind == kind)
+                .cloned()
+            {
+                return Some(event);
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        None
+    }
+
+    #[derive(Default)]
+    struct NoopRefreshStorage;
+
+    #[async_trait]
+    impl RefreshTokenStorage for NoopRefreshStorage {
+        async fn store(
+            &self,
+            _token_id: &str,
+            _user_id: &str,
+            _family_id: &str,
+            _expires_at: chrono::DateTime<Utc>,
+            _metadata: &RefreshTokenMetadata,
+        ) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn get(&self, _token_id: &str) -> Result<Option<RefreshTokenData>, Error> {
+            Ok(None)
+        }
+
+        async fn revoke(&self, _token_id: &str) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn revoke_family(&self, _family_id: &str) -> Result<u64, Error> {
+            Ok(0)
+        }
+
+        async fn revoke_all_for_user(&self, _user_id: &str) -> Result<u64, Error> {
+            Ok(0)
+        }
+
+        async fn rotate(
+            &self,
+            _old_token_id: &str,
+            _new_token_id: &str,
+            _user_id: &str,
+            _family_id: &str,
+            _expires_at: chrono::DateTime<Utc>,
+            _metadata: &RefreshTokenMetadata,
+        ) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn cleanup_expired(&self) -> Result<u64, Error> {
+            Ok(0)
+        }
+    }
+
+    /// Refresh storage whose rotate always fails, to prove no event is
+    /// emitted for failed rotations.
+    #[derive(Default)]
+    struct FailingRefreshStorage;
+
+    #[async_trait]
+    impl RefreshTokenStorage for FailingRefreshStorage {
+        async fn store(
+            &self,
+            _token_id: &str,
+            _user_id: &str,
+            _family_id: &str,
+            _expires_at: chrono::DateTime<Utc>,
+            _metadata: &RefreshTokenMetadata,
+        ) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn get(&self, _token_id: &str) -> Result<Option<RefreshTokenData>, Error> {
+            Ok(None)
+        }
+
+        async fn revoke(&self, _token_id: &str) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn revoke_family(&self, _family_id: &str) -> Result<u64, Error> {
+            Ok(0)
+        }
+
+        async fn revoke_all_for_user(&self, _user_id: &str) -> Result<u64, Error> {
+            Ok(0)
+        }
+
+        async fn rotate(
+            &self,
+            _old_token_id: &str,
+            _new_token_id: &str,
+            _user_id: &str,
+            _family_id: &str,
+            _expires_at: chrono::DateTime<Utc>,
+            _metadata: &RefreshTokenMetadata,
+        ) -> Result<(), Error> {
+            Err(Error::Internal("rotation failed".to_string()))
+        }
+
+        async fn cleanup_expired(&self) -> Result<u64, Error> {
+            Ok(0)
+        }
+    }
+
+    #[derive(Default)]
+    struct NoopApiKeyStorage;
+
+    #[async_trait]
+    impl ApiKeyStorage for NoopApiKeyStorage {
+        async fn get_by_key(&self, _key: &str) -> Result<Option<ApiKey>, Error> {
+            Ok(None)
+        }
+
+        async fn get_by_prefix(&self, _prefix: &str) -> Result<Option<ApiKey>, Error> {
+            Ok(None)
+        }
+
+        async fn get_by_id(&self, _id: &str) -> Result<Option<ApiKey>, Error> {
+            Ok(None)
+        }
+
+        async fn create(&self, _key: &ApiKey) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn update_last_used(&self, _id: &str) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn revoke(&self, _id: &str) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn list_by_user(&self, _user_id: &str) -> Result<Vec<ApiKey>, Error> {
+            Ok(Vec::new())
+        }
+
+        async fn delete(&self, _id: &str) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    fn test_api_key() -> ApiKey {
+        ApiKey {
+            id: "key_123".to_string(),
+            user_id: "user_9".to_string(),
+            name: "ci deploy key".to_string(),
+            prefix: "sk_test".to_string(),
+            key_hash: "not-logged".to_string(),
+            scopes: vec!["deploy".to_string()],
+            rate_limit: None,
+            is_revoked: false,
+            last_used_at: None,
+            expires_at: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rotate_emits_auth_token_refresh_with_stored_metadata() {
+        let (_runtime, storage, logger) = capturing_logger().await;
+        let wrapped = AuditedRefreshStorage::new(NoopRefreshStorage, logger);
+
+        let metadata = RefreshTokenMetadata {
+            ip_address: Some("203.0.113.5".to_string()),
+            user_agent: Some("acton-test/1.0".to_string()),
+            ..RefreshTokenMetadata::default()
+        };
+        wrapped
+            .rotate("old_jti", "new_jti", "user_9", "fam_1", Utc::now(), &metadata)
+            .await
+            .expect("rotate");
+
+        let event = wait_for_event(&storage, &AuditEventKind::AuthTokenRefresh)
+            .await
+            .expect("AuthTokenRefresh emitted");
+        assert_eq!(event.source.subject.as_deref(), Some("user_9"));
+        assert_eq!(event.source.ip.as_deref(), Some("203.0.113.5"));
+        let metadata = event.metadata.expect("metadata attached");
+        assert_eq!(metadata["family_id"], "fam_1");
+        assert_eq!(metadata["old_token_id"], "old_jti");
+        assert_eq!(metadata["new_token_id"], "new_jti");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn failed_rotate_emits_nothing() {
+        let (_runtime, storage, logger) = capturing_logger().await;
+        let wrapped = AuditedRefreshStorage::new(FailingRefreshStorage, logger);
+
+        let result = wrapped
+            .rotate(
+                "old_jti",
+                "new_jti",
+                "user_9",
+                "fam_1",
+                Utc::now(),
+                &RefreshTokenMetadata::default(),
+            )
+            .await;
+        assert!(result.is_err(), "inner failure must propagate");
+
+        // Give the fire-and-forget path a moment to (incorrectly) deliver.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            storage.events.lock().expect("events lock").is_empty(),
+            "failed rotation must not be audited as a refresh"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn api_key_create_and_revoke_emit_without_key_material() {
+        let (_runtime, storage, logger) = capturing_logger().await;
+        let wrapped = AuditedApiKeyStorage::new(NoopApiKeyStorage, logger);
+
+        wrapped.create(&test_api_key()).await.expect("create");
+        let created = wait_for_event(&storage, &AuditEventKind::AuthApiKeyCreated)
+            .await
+            .expect("AuthApiKeyCreated emitted");
+        let metadata = created.metadata.expect("metadata attached");
+        assert_eq!(metadata["key_id"], "key_123");
+        assert!(
+            !metadata.to_string().contains("not-logged"),
+            "key hash must never reach the audit log"
+        );
+        assert_eq!(created.source.subject.as_deref(), Some("user_9"));
+
+        wrapped.revoke("key_123").await.expect("revoke");
+        let revoked = wait_for_event(&storage, &AuditEventKind::AuthApiKeyRevoked)
+            .await
+            .expect("AuthApiKeyRevoked emitted");
+        assert_eq!(revoked.metadata.expect("metadata")["key_id"], "key_123");
+    }
+
+    #[cfg(feature = "oauth")]
+    mod oauth_tests {
+        use super::*;
+        use crate::auth::oauth::provider::{OAuthProvider, OAuthTokens, OAuthUserInfo};
+
+        struct FailingProvider;
+
+        #[async_trait]
+        impl OAuthProvider for FailingProvider {
+            fn name(&self) -> &str {
+                "test-provider"
+            }
+
+            fn authorization_url(&self, _state: &str, _scopes: &[String]) -> String {
+                "https://example.com/auth".to_string()
+            }
+
+            async fn exchange_code(&self, _code: &str) -> Result<OAuthTokens, Error> {
+                Err(Error::Internal("exchange rejected".to_string()))
+            }
+
+            async fn get_user_info(&self, _access_token: &str) -> Result<OAuthUserInfo, Error> {
+                Err(Error::Internal("unused".to_string()))
+            }
+
+            async fn refresh_token(&self, _refresh_token: &str) -> Result<OAuthTokens, Error> {
+                Err(Error::Internal("unused".to_string()))
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn failed_code_exchange_emits_oauth_callback_warning() {
+            let (_runtime, storage, logger) = capturing_logger().await;
+            let wrapped = AuditedOAuthProvider::new(FailingProvider, logger);
+
+            let result = wrapped.exchange_code("bad-code").await;
+            assert!(result.is_err(), "inner failure must propagate");
+
+            let event = wait_for_event(&storage, &AuditEventKind::AuthOAuthCallback)
+                .await
+                .expect("AuthOAuthCallback emitted on failure");
+            assert_eq!(event.severity, AuditSeverity::Warning);
+            let metadata = event.metadata.expect("metadata attached");
+            assert_eq!(metadata["provider"], "test-provider");
+            assert_eq!(metadata["outcome"], "failure");
+        }
+    }
+}

--- a/acton-service/src/audit/mod.rs
+++ b/acton-service/src/audit/mod.rs
@@ -24,6 +24,8 @@ pub mod archive;
 pub mod chain;
 pub mod config;
 pub mod config_audit;
+#[cfg(feature = "auth")]
+pub mod decorators;
 pub mod event;
 pub(crate) mod failure_tracker;
 pub mod logger;
@@ -44,6 +46,10 @@ pub use config::{AlertConfig, AuditConfig, SyslogConfig};
 pub use config_audit::{
     compute_config_fingerprint, drift_check_handler, redact_config, DriftCheckResult,
 };
+#[cfg(feature = "auth")]
+pub use decorators::{AuditedApiKeyStorage, AuditedRefreshStorage};
+#[cfg(feature = "oauth")]
+pub use decorators::AuditedOAuthProvider;
 pub use event::{AuditEvent, AuditEventKind, AuditSeverity, AuditSource};
 pub use logger::AuditLogger;
 pub use middleware::{audit_layer, AuditRoute};

--- a/acton-service/src/auth/oauth/state.rs
+++ b/acton-service/src/auth/oauth/state.rs
@@ -43,8 +43,7 @@ pub trait OAuthStateManager: Send + Sync {
 
 /// Generate a cryptographically secure random state value
 pub fn generate_state() -> String {
-    use rand::Rng;
-    let bytes: [u8; 32] = rand::rng().random();
+    let bytes: [u8; 32] = rand::random();
     base64_url_encode(&bytes)
 }
 

--- a/acton-service/src/middleware/governor.rs
+++ b/acton-service/src/middleware/governor.rs
@@ -231,7 +231,36 @@ impl GovernorRateLimit {
         );
 
         // Check rate limit and get result for headers
-        let result = rate_limit.check_rate_limit(&method, &path, claims.as_ref(), client_ip)?;
+        let result = match rate_limit.check_rate_limit(&method, &path, claims.as_ref(), client_ip)
+        {
+            Ok(result) => result,
+            Err(e) => {
+                // Mirror the Redis rate limiter: rejections are audit-visible
+                // as HttpRequestDenied (issue #16).
+                #[cfg(feature = "audit")]
+                if matches!(e, Error::RateLimitExceeded) {
+                    if let Some(logger) = request
+                        .extensions()
+                        .get::<crate::audit::AuditLogger>()
+                        .cloned()
+                    {
+                        if logger.config().audit_auth_events {
+                            let mut source =
+                                super::request_context::audit_source_for_request(&request);
+                            source.subject = claims.as_ref().map(|c| c.sub.clone());
+                            logger
+                                .log_auth(
+                                    crate::audit::event::AuditEventKind::HttpRequestDenied,
+                                    crate::audit::event::AuditSeverity::Warning,
+                                    source,
+                                )
+                                .await;
+                        }
+                    }
+                }
+                return Err(e);
+            }
+        };
 
         // Run the request
         let mut response = next.run(request).await;

--- a/acton-service/src/middleware/rate_limit.rs
+++ b/acton-service/src/middleware/rate_limit.rs
@@ -105,26 +105,9 @@ impl RateLimit {
                 .cloned();
             #[cfg(feature = "audit")]
             let audit_source = {
-                use crate::audit::event::AuditSource;
-                AuditSource {
-                    ip: request
-                        .headers()
-                        .get("x-forwarded-for")
-                        .or_else(|| request.headers().get("x-real-ip"))
-                        .and_then(|v| v.to_str().ok())
-                        .map(|s| s.split(',').next().unwrap_or(s).trim().to_string()),
-                    user_agent: request
-                        .headers()
-                        .get("user-agent")
-                        .and_then(|v| v.to_str().ok())
-                        .map(String::from),
-                    subject: claims.as_ref().map(|c| c.sub.clone()),
-                    request_id: request
-                        .headers()
-                        .get("x-request-id")
-                        .and_then(|v| v.to_str().ok())
-                        .map(String::from),
-                }
+                let mut source = super::request_context::audit_source_for_request(&request);
+                source.subject = claims.as_ref().map(|c| c.sub.clone());
+                source
             };
 
             // Check rate limit and get result for headers

--- a/acton-service/src/middleware/request_context.rs
+++ b/acton-service/src/middleware/request_context.rs
@@ -134,7 +134,7 @@ pub(crate) fn audit_source_for_request<B>(
 /// Unlike [`extract_client_ip`] this does not parse the IP, so a malformed
 /// `X-Forwarded-For` still round-trips verbatim into the audit record.
 #[cfg(feature = "audit")]
-fn audit_source_from_headers(headers: &HeaderMap) -> crate::audit::event::AuditSource {
+pub(crate) fn audit_source_from_headers(headers: &HeaderMap) -> crate::audit::event::AuditSource {
     crate::audit::event::AuditSource {
         ip: headers
             .get("x-forwarded-for")

--- a/acton-service/src/session/extractors.rs
+++ b/acton-service/src/session/extractors.rs
@@ -62,6 +62,10 @@ use crate::error::Error;
 pub struct TypedSession<T> {
     session: Session,
     data: T,
+    /// Captured at extraction so session methods can emit audit events
+    /// without access to the request (issue #16).
+    #[cfg(feature = "audit")]
+    audit: Option<(crate::audit::AuditLogger, crate::audit::event::AuditSource)>,
 }
 
 impl<T> TypedSession<T>
@@ -169,6 +173,43 @@ where
     }
 }
 
+impl TypedSession<AuthSession> {
+    /// Log the user out: clear the authentication data, persist the cleared
+    /// session, and emit an `AuthLogout` audit event whose subject is the
+    /// previously authenticated user ID.
+    ///
+    /// This is the audited logout path. Calling [`AuthSession::logout`] on
+    /// the data directly performs the same state change without the audit
+    /// event; combine with [`destroy`](Self::destroy) afterwards if the
+    /// session ID itself should be invalidated.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the cleared session cannot be written.
+    pub async fn logout(&mut self) -> Result<(), Error> {
+        #[cfg(feature = "audit")]
+        let subject = self.data.user_id.clone();
+        self.data.logout();
+        self.save().await?;
+
+        #[cfg(feature = "audit")]
+        if let Some((logger, source)) = &self.audit {
+            if logger.config().audit_auth_events {
+                let mut source = source.clone();
+                source.subject = subject;
+                let event = crate::audit::event::AuditEvent::new(
+                    crate::audit::event::AuditEventKind::AuthLogout,
+                    crate::audit::event::AuditSeverity::Notice,
+                    logger.service_name().to_string(),
+                )
+                .with_source(source);
+                logger.log(event).await;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl<S, T> FromRequestParts<S> for TypedSession<T>
 where
     S: Send + Sync,
@@ -191,7 +232,30 @@ where
             .map_err(|e| Error::Session(format!("Failed to read session data: {e}")))?
             .unwrap_or_default();
 
-        Ok(Self { session, data })
+        #[cfg(feature = "audit")]
+        let audit = parts
+            .extensions
+            .get::<crate::audit::AuditLogger>()
+            .cloned()
+            .map(|logger| {
+                let source = parts
+                    .extensions
+                    .get::<crate::middleware::request_context::RequestContext>()
+                    .map(crate::middleware::request_context::RequestContext::audit_source)
+                    .unwrap_or_else(|| {
+                        crate::middleware::request_context::audit_source_from_headers(
+                            &parts.headers,
+                        )
+                    });
+                (logger, source)
+            });
+
+        Ok(Self {
+            session,
+            data,
+            #[cfg(feature = "audit")]
+            audit,
+        })
     }
 }
 


### PR DESCRIPTION
Closes #16

## What

Every `AuditEventKind` the framework declares is now either emitted by the framework or has a documented, single-implementation opt-in:

| Variant | How it's emitted now |
|---|---|
| `AuthLogout` | `TypedSession<AuthSession>::logout()` — logger + request context captured at extraction |
| `AuthTokenRefresh` | `AuditedRefreshStorage` decorator, on successful rotation |
| `AuthApiKeyCreated` / `AuthApiKeyRevoked` | `AuditedApiKeyStorage` decorator (no key material/hashes in metadata) |
| `AuthOAuthCallback` | `AuditedOAuthProvider` decorator, on code exchange (success and failure) |
| `HttpRequestDenied` | governor middleware now emits on rejection, matching the Redis limiter |
| `AuthPasswordChanged`, `AuthPermissionDenied` | already emitted (accounts / cedar) — tracker boxes ticked |

Decorator rationale: refresh/API-key storage and OAuth providers are app-constructed trait objects with four backends each — wrapping once at the trait level beats duplicating emission 4× per family, and `ServiceBuilder` never sees these objects so auto-wiring isn't possible.

## Also in here

- **`oauth` added to `full`** (flagged for veto): same CI blind spot #26 fixed for `audit` — and enabling it immediately surfaced a latent `rand 0.10` API break in `oauth/state.rs::generate_state()` that CI had never compiled. Fixed here.
- Redis rate limiter's `AuditSource` construction migrated to the #17 request-context path (extension first, header fallback → ConnectInfo-aware).
- First end-to-end `AuditAgent` emission tests (capturing `AuditStorage` + real agent). Writing them uncovered a startup window where events sent before chain initialization are **silently dropped** — filed as #61 with a repro description.

## Verification

- `cargo clippy -p acton-service --all-targets --features full -- -D warnings` — clean
- `cargo nextest run -p acton-service --features full` — **648/648** (suite grew from 619: new tests + oauth now compiled)
- Full matrix (both crypto legs + three audit-storage backend legs) runs on this PR's CI.

https://claude.ai/code/session_01Ksi4GWwt3rWY4ZhzRAiyKE