### PR TITLE
feat(tls): optional client certificate verification and reloadable credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,7 @@ version = "0.29.0"
 dependencies = [
  "acton-reactive",
  "anyhow",
+ "arc-swap",
  "argon2",
  "askama",
  "askama_web",
@@ -350,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]

--- a/acton-service/Cargo.toml
+++ b/acton-service/Cargo.toml
@@ -132,6 +132,7 @@ async-graphql-axum = { version = "7.2.1", optional = true }
 bytes = { version = "1.11.1", optional = true }
 rustls = { version = "0.23.40", default-features = false, features = ["logging", "tls12", "std"], optional = true }
 rustls-pki-types = { version = "1.14.1", features = ["std"], optional = true }
+arc-swap = { version = "1.9.2", optional = true }
 
 [features]
 default = ["http", "observability", "crypto-aws-lc-rs"]
@@ -223,7 +224,7 @@ repository = []
 handlers = ["repository"]
 
 # TLS support (rustls-based HTTPS)
-tls = ["dep:tokio-rustls", "dep:rustls-pki-types"]
+tls = ["dep:tokio-rustls", "dep:rustls-pki-types", "dep:arc-swap"]
 
 # Audit logging with BLAKE3 hash chaining
 audit = ["dep:blake3"]

--- a/acton-service/src/config.rs
+++ b/acton-service/src/config.rs
@@ -940,6 +940,21 @@ pub struct TlsConfig {
 
     /// Path to PEM-encoded private key
     pub key_path: PathBuf,
+
+    /// Path to a PEM-encoded CA bundle used to verify client certificates
+    /// (mutual TLS). When present, the server requests a client certificate
+    /// during the handshake and validates it against these roots. When absent
+    /// (the default), no client certificate is requested.
+    #[serde(default)]
+    pub client_ca_path: Option<PathBuf>,
+
+    /// When `true`, a client certificate is requested but not required:
+    /// connections without one still complete, and a presented certificate is
+    /// still verified against `client_ca_path`. When `false` (the default), a
+    /// certificate that validates against `client_ca_path` is mandatory and
+    /// the handshake fails without one. Ignored when `client_ca_path` is absent.
+    #[serde(default = "default_false")]
+    pub client_auth_optional: bool,
 }
 
 /// Journald logging configuration (requires `journald` feature)
@@ -1678,6 +1693,53 @@ mod tests {
         assert_eq!(config.service.port, 8080);
         assert_eq!(config.service.log_level, "info");
         assert_eq!(config.rate_limit.per_user_rpm, 200);
+    }
+
+    #[cfg(feature = "tls")]
+    #[test]
+    fn tls_config_client_auth_fields_default_to_no_mtls() {
+        let json = r#"{
+            "enabled": true,
+            "cert_path": "/etc/tls/cert.pem",
+            "key_path": "/etc/tls/key.pem"
+        }"#;
+
+        let tls: TlsConfig =
+            serde_json::from_str(json).expect("minimal TLS config must parse");
+
+        assert!(
+            tls.client_ca_path.is_none(),
+            "an absent client CA must default to no mutual TLS"
+        );
+        assert!(
+            !tls.client_auth_optional,
+            "client auth must default to required when a CA is configured"
+        );
+    }
+
+    #[cfg(feature = "tls")]
+    #[test]
+    fn tls_config_parses_mutual_tls_fields() {
+        let json = r#"{
+            "enabled": true,
+            "cert_path": "/etc/tls/cert.pem",
+            "key_path": "/etc/tls/key.pem",
+            "client_ca_path": "/etc/tls/client-ca.pem",
+            "client_auth_optional": true
+        }"#;
+
+        let tls: TlsConfig =
+            serde_json::from_str(json).expect("mutual TLS config must parse");
+
+        assert_eq!(
+            tls.client_ca_path.as_deref(),
+            Some(std::path::Path::new("/etc/tls/client-ca.pem")),
+            "the client CA path must round-trip from configuration"
+        );
+        assert!(
+            tls.client_auth_optional,
+            "the optional client-auth flag must round-trip from configuration"
+        );
     }
 
     #[test]

--- a/acton-service/src/server.rs
+++ b/acton-service/src/server.rs
@@ -102,20 +102,18 @@ impl Server {
 
         // Serve with graceful shutdown -- TLS or plain TCP
         //
-        // Note: the TLS path serves the app directly without
-        // `into_make_service_with_connect_info`. A custom listener like
-        // `TlsListener` would require a `Connected` impl which orphan
-        // rules forbid for `SocketAddr`. Deployments that terminate TLS
-        // here and need IP-based rate-limiting should set
-        // `[rate_limit] trust_forwarded_headers = true` and run behind
-        // a proxy that sets `X-Forwarded-For`.
+        // The TLS listener exposes `TlsConnectInfo` (remote address plus any
+        // verified client certificate) as connect-info.
         #[cfg(feature = "tls")]
         if let Some(ref tls_config) = self.config.tls {
             if tls_config.enabled {
                 let server_config = crate::tls::load_server_config(tls_config)?;
                 let tls_listener = crate::tls::TlsListener::new(listener, server_config);
                 tracing::info!("TLS enabled (HTTPS)");
-                axum::serve(tls_listener, app)
+                axum::serve(
+                    tls_listener,
+                    app.into_make_service_with_connect_info::<crate::tls::TlsConnectInfo>(),
+                )
                     .with_graceful_shutdown(shutdown_signal())
                     .await?;
                 tracing::info!("Server shutdown complete");

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -134,14 +134,14 @@ where
     graphql: Option<crate::graphql::VersionedGraphQL>,
     agent_runtime: Option<acton_reactive::prelude::ActorRuntime>,
     actor_extensions: Vec<Box<dyn crate::extensions::ActorExtensionSpawner>>,
-    /// Pre-built HTTP TLS config supplied by the caller. When set, `build()`
-    /// uses it verbatim and never reads `[tls]` cert/key files.
+    /// Caller-supplied HTTP TLS credentials. When set, `build()` uses them
+    /// verbatim and never reads `[tls]` cert/key files.
     #[cfg(feature = "tls")]
-    tls_config_override: Option<std::sync::Arc<tokio_rustls::rustls::ServerConfig>>,
-    /// Pre-built gRPC TLS config supplied by the caller. When set, `build()`
-    /// uses it verbatim and never reads `[grpc.tls]` cert/key files.
+    tls_config_override: Option<crate::tls::TlsConfigSource>,
+    /// Caller-supplied gRPC TLS credentials. When set, `build()` uses them
+    /// verbatim and never reads `[grpc.tls]` cert/key files.
     #[cfg(all(feature = "grpc", feature = "tls"))]
-    grpc_tls_config_override: Option<std::sync::Arc<tokio_rustls::rustls::ServerConfig>>,
+    grpc_tls_config_override: Option<crate::tls::TlsConfigSource>,
 }
 
 impl<T> ServiceBuilder<T>
@@ -180,12 +180,34 @@ where
     /// listener coming up, closing that time-of-check/time-of-use window.
     ///
     /// The override applies whenever it is set, regardless of what `[tls]` says.
+    ///
+    /// The credentials supplied here are **static**: the listener serves this
+    /// exact config for its whole life. To rotate certificates without a
+    /// restart, use [`with_tls_config_source`](Self::with_tls_config_source).
     #[cfg(feature = "tls")]
     pub fn with_tls_config(
         mut self,
         config: std::sync::Arc<tokio_rustls::rustls::ServerConfig>,
     ) -> Self {
-        self.tls_config_override = Some(config);
+        self.tls_config_override = Some(crate::tls::TlsConfigSource::from_server_config(config));
+        self
+    }
+
+    /// Supply reloadable HTTP TLS credentials.
+    ///
+    /// The rotatable form of [`with_tls_config`](Self::with_tls_config): it
+    /// carries the same time-of-check/time-of-use guarantee, and additionally
+    /// lets the application replace the certificate while the listener runs.
+    /// Keep a clone of the source and call
+    /// [`TlsConfigSource::reload`](crate::tls::TlsConfigSource::reload) after
+    /// the credential files change; the next handshake picks up the new config.
+    /// A failed reload is fail-closed and keeps the previous credentials
+    /// serving, so rotation can never take the listener down.
+    ///
+    /// The override applies whenever it is set, regardless of what `[tls]` says.
+    #[cfg(feature = "tls")]
+    pub fn with_tls_config_source(mut self, source: crate::tls::TlsConfigSource) -> Self {
+        self.tls_config_override = Some(source);
         self
     }
 
@@ -197,12 +219,32 @@ where
     ///
     /// The override applies whenever it is set, regardless of what `[grpc.tls]`
     /// says, and suppresses the fallback to the shared `[tls]` config.
+    ///
+    /// The credentials supplied here are **static**. To rotate them without a
+    /// restart, use
+    /// [`with_grpc_tls_config_source`](Self::with_grpc_tls_config_source).
     #[cfg(all(feature = "grpc", feature = "tls"))]
     pub fn with_grpc_tls_config(
         mut self,
         config: std::sync::Arc<tokio_rustls::rustls::ServerConfig>,
     ) -> Self {
-        self.grpc_tls_config_override = Some(config);
+        self.grpc_tls_config_override =
+            Some(crate::tls::TlsConfigSource::from_server_config(config));
+        self
+    }
+
+    /// Supply reloadable TLS credentials for the separate-port gRPC listener.
+    ///
+    /// The gRPC twin of
+    /// [`with_tls_config_source`](Self::with_tls_config_source), with the same
+    /// rotation and fail-closed semantics. Applies only to the dual-port gRPC
+    /// listener; in single-port mode the HTTP TLS source terminates both.
+    ///
+    /// The override applies whenever it is set, regardless of what `[grpc.tls]`
+    /// says, and suppresses the fallback to the shared `[tls]` config.
+    #[cfg(all(feature = "grpc", feature = "tls"))]
+    pub fn with_grpc_tls_config_source(mut self, source: crate::tls::TlsConfigSource) -> Self {
+        self.grpc_tls_config_override = Some(source);
         self
     }
 
@@ -1539,12 +1581,14 @@ where
         // where TLS was configured would silently invert the fail-safe direction.
         #[cfg(feature = "tls")]
         let tls_config = {
-            if let Some(sc) = self.tls_config_override.take() {
-                tracing::info!("TLS configured from caller-supplied ServerConfig");
-                Some(sc)
+            if let Some(source) = self.tls_config_override.take() {
+                tracing::info!("TLS configured from caller-supplied credentials");
+                Some(source)
             } else if let Some(ref tls_cfg) = config.tls {
                 if tls_cfg.enabled {
-                    match crate::tls::load_server_config(tls_cfg) {
+                    // A config-driven source remembers its paths, so the service
+                    // can rotate these credentials later without a restart.
+                    match crate::tls::TlsConfigSource::from_tls_config(tls_cfg) {
                         Ok(sc) => {
                             tracing::info!(
                                 "TLS configured (cert: {}, key: {})",
@@ -1578,13 +1622,13 @@ where
         // As with HTTP above, a failed load of an enabled section is fatal
         // rather than a silent downgrade to plaintext.
         #[cfg(all(feature = "grpc", feature = "tls"))]
-        let grpc_tls_config = if let Some(sc) = self.grpc_tls_config_override.take() {
-            tracing::info!("gRPC TLS configured from caller-supplied ServerConfig");
-            Some(sc)
+        let grpc_tls_config = if let Some(source) = self.grpc_tls_config_override.take() {
+            tracing::info!("gRPC TLS configured from caller-supplied credentials");
+            Some(source)
         } else {
             match config.grpc.as_ref().and_then(|g| g.tls.as_ref()) {
                 Some(grpc_tls) if grpc_tls.enabled => {
-                    match crate::tls::load_server_config(grpc_tls) {
+                    match crate::tls::TlsConfigSource::from_tls_config(grpc_tls) {
                         Ok(sc) => {
                             tracing::info!(
                                 "gRPC TLS configured (cert: {}, key: {})",
@@ -2091,11 +2135,11 @@ where
     #[cfg(feature = "grpc")]
     grpc_routes: Option<axum::Router>,
     #[cfg(feature = "tls")]
-    tls_config: Option<std::sync::Arc<tokio_rustls::rustls::ServerConfig>>,
-    /// Per-listener TLS config for the separate-port gRPC listener. Falls back
-    /// to `tls_config` (the HTTP TLS) when `[grpc.tls]` is not configured.
+    tls_config: Option<crate::tls::TlsConfigSource>,
+    /// Per-listener TLS credentials for the separate-port gRPC listener. Falls
+    /// back to `tls_config` (the HTTP TLS) when `[grpc.tls]` is not configured.
     #[cfg(all(feature = "grpc", feature = "tls"))]
-    grpc_tls_config: Option<std::sync::Arc<tokio_rustls::rustls::ServerConfig>>,
+    grpc_tls_config: Option<crate::tls::TlsConfigSource>,
     agent_runtime: Option<acton_reactive::prelude::ActorRuntime>,
     /// Fatal misconfiguration recorded during `build()`. `serve()` returns this
     /// before binding any listener, so a service that could not honour its
@@ -2195,12 +2239,17 @@ where
 
                         let grpc_handle = tokio::spawn(async move {
                             #[cfg(feature = "tls")]
-                            if let Some(ref server_config) = grpc_tls_config {
-                                let tls_listener = crate::tls::TlsListener::new(
+                            if let Some(ref tls_source) = grpc_tls_config {
+                                let tls_listener = crate::tls::TlsListener::with_config_source(
                                     grpc_listener,
-                                    server_config.clone(),
+                                    tls_source.clone(),
                                 );
-                                return axum::serve(tls_listener, grpc_app)
+                                return axum::serve(
+                                    tls_listener,
+                                    grpc_app.into_make_service_with_connect_info::<
+                                        crate::tls::TlsConnectInfo,
+                                    >(),
+                                )
                                     .with_graceful_shutdown(shutdown_signal())
                                     .await;
                             }
@@ -2210,18 +2259,22 @@ where
                                 .await
                         });
 
-                        // Run HTTP server (with optional TLS)
-                        // Note: the TLS path does not use ConnectInfo (orphan
-                        // rules forbid implementing `Connected` for `SocketAddr`
-                        // on a non-axum listener). For IP-based rate limiting
-                        // behind TLS, run behind a proxy and enable
-                        // `trust_forwarded_headers`.
+                        // Run HTTP server (with optional TLS). The TLS listener
+                        // exposes `TlsConnectInfo` (remote address plus any
+                        // verified client certificate) as connect-info.
                         #[cfg(feature = "tls")]
-                        if let Some(ref server_config) = self.tls_config {
-                            let tls_listener =
-                                crate::tls::TlsListener::new(http_listener, server_config.clone());
+                        if let Some(ref tls_source) = self.tls_config {
+                            let tls_listener = crate::tls::TlsListener::with_config_source(
+                                http_listener,
+                                tls_source.clone(),
+                            );
                             tracing::info!("TLS enabled (HTTPS) for both HTTP and gRPC");
-                            let http_result = axum::serve(tls_listener, self.app)
+                            let http_result = axum::serve(
+                                tls_listener,
+                                self.app.into_make_service_with_connect_info::<
+                                    crate::tls::TlsConnectInfo,
+                                >(),
+                            )
                                 .with_graceful_shutdown(shutdown_signal())
                                 .await;
                             let _ = grpc_handle.await;
@@ -2264,14 +2317,22 @@ where
                         // its own auth and Cedar layers through the merge)
                         let hybrid_service = grpc_routes.merge(self.app);
 
-                        // Note: the TLS path does not use ConnectInfo (orphan
-                        // rules; see comment in dual-port path above).
+                        // The TLS listener exposes `TlsConnectInfo` (remote
+                        // address plus any verified client certificate) as
+                        // connect-info.
                         #[cfg(feature = "tls")]
-                        if let Some(ref server_config) = self.tls_config {
-                            let tls_listener =
-                                crate::tls::TlsListener::new(listener, server_config.clone());
+                        if let Some(ref tls_source) = self.tls_config {
+                            let tls_listener = crate::tls::TlsListener::with_config_source(
+                                listener,
+                                tls_source.clone(),
+                            );
                             tracing::info!("TLS enabled (HTTPS) for hybrid HTTP+gRPC");
-                            axum::serve(tls_listener, hybrid_service)
+                            axum::serve(
+                                tls_listener,
+                                hybrid_service.into_make_service_with_connect_info::<
+                                    crate::tls::TlsConnectInfo,
+                                >(),
+                            )
                                 .with_graceful_shutdown(shutdown_signal())
                                 .await?;
 
@@ -2317,13 +2378,18 @@ where
 
         let listener = TcpListener::bind(&self.listener_addr).await?;
 
-        // Note: the TLS path does not use ConnectInfo (orphan rules;
-        // see comment in gRPC dual-port path above).
+        // The TLS listener exposes `TlsConnectInfo` (remote address plus any
+        // verified client certificate) as connect-info.
         #[cfg(feature = "tls")]
-        if let Some(ref server_config) = self.tls_config {
-            let tls_listener = crate::tls::TlsListener::new(listener, server_config.clone());
+        if let Some(ref tls_source) = self.tls_config {
+            let tls_listener =
+                crate::tls::TlsListener::with_config_source(listener, tls_source.clone());
             tracing::info!("TLS enabled (HTTPS)");
-            axum::serve(tls_listener, self.app)
+            axum::serve(
+                tls_listener,
+                self.app
+                    .into_make_service_with_connect_info::<crate::tls::TlsConnectInfo>(),
+            )
                 .with_graceful_shutdown(shutdown_signal())
                 .await?;
 
@@ -2530,6 +2596,8 @@ mod tests {
                 enabled: true,
                 cert_path: "/nonexistent/cert.pem".into(),
                 key_path: "/nonexistent/key.pem".into(),
+                client_ca_path: None,
+                client_auth_optional: false,
             }),
             ..Default::default()
         };
@@ -2571,6 +2639,8 @@ mod tests {
                 enabled: true,
                 cert_path: "/nonexistent/cert.pem".into(),
                 key_path: "/nonexistent/key.pem".into(),
+                client_ca_path: None,
+                client_auth_optional: false,
             }),
             port: 50051,
             reflection_enabled: false,
@@ -2606,6 +2676,8 @@ mod tests {
                 enabled: false,
                 cert_path: "/nonexistent/cert.pem".into(),
                 key_path: "/nonexistent/key.pem".into(),
+                client_ca_path: None,
+                client_auth_optional: false,
             }),
             ..Default::default()
         };
@@ -2631,6 +2703,8 @@ mod tests {
                 enabled: true,
                 cert_path: "/nonexistent/cert.pem".into(),
                 key_path: "/nonexistent/key.pem".into(),
+                client_ca_path: None,
+                client_auth_optional: false,
             }),
             ..Default::default()
         };
@@ -2860,6 +2934,8 @@ mod tests {
                 enabled: true,
                 cert_path: "/nonexistent/cert.pem".into(),
                 key_path: "/nonexistent/key.pem".into(),
+                client_ca_path: None,
+                client_auth_optional: false,
             }),
             ..base
         };

--- a/acton-service/src/tls.rs
+++ b/acton-service/src/tls.rs
@@ -2,35 +2,232 @@
 //!
 //! Provides a [`TlsListener`] that wraps a TCP listener with TLS termination,
 //! implementing [`axum::serve::Listener`] for seamless integration with axum's server.
+//!
+//! Credentials reach the listener through a [`TlsConfigSource`], a handle whose
+//! contents can be replaced while the listener is running so certificates can be
+//! rotated without dropping the socket.
 
 use std::io;
 use std::net::SocketAddr;
+use std::path::Path;
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
+use rustls_pki_types::CertificateDer;
 use tokio::net::{TcpListener, TcpStream};
-use tokio_rustls::rustls::ServerConfig;
+use tokio_rustls::rustls::server::danger::ClientCertVerifier;
+use tokio_rustls::rustls::server::WebPkiClientVerifier;
+use tokio_rustls::rustls::{RootCertStore, ServerConfig};
 use tokio_rustls::server::TlsStream;
 use tokio_rustls::TlsAcceptor;
 
 use crate::config::TlsConfig;
 use crate::error::Result;
 
-/// A TLS-enabled listener wrapping a [`TcpListener`] with a [`TlsAcceptor`].
+/// The credentials a TLS listener serves, replaceable while it runs.
+///
+/// A source holds the current [`ServerConfig`] behind an [`ArcSwap`], so
+/// [`load`](Self::load) is a cheap atomic read on the accept path and
+/// [`reload`](Self::reload) can install fresh credentials without rebinding the
+/// socket. Connections already established keep the configuration they
+/// handshook with; every subsequent handshake uses the newest one.
+///
+/// Cloning is cheap and every clone observes the same credentials: hand clones
+/// to the listener and keep one to drive rotation.
+///
+/// # Failure behaviour
+///
+/// A source built from a [`TlsConfig`] rereads those files on every reload. A
+/// failed reload is **fail-closed**: the last-good configuration stays
+/// installed, the error is logged at `ERROR` level and returned to the caller.
+/// A reload can never leave the listener without credentials or downgrade what
+/// it serves.
+///
+/// A source built from an already-loaded [`ServerConfig`] has no files to
+/// reread, so it is static and [`reload`](Self::reload) reports that rather
+/// than silently doing nothing.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let source = TlsConfigSource::from_tls_config(&tls_config)?;
+/// let listener = TlsListener::with_config_source(tcp, source.clone());
+///
+/// // Later, after the certificate files have been rewritten on disk:
+/// if let Err(e) = source.reload() {
+///     tracing::warn!("certificate rotation failed, still serving previous cert: {e}");
+/// }
+/// ```
+#[derive(Clone)]
+pub struct TlsConfigSource {
+    inner: Arc<TlsConfigSourceInner>,
+}
+
+struct TlsConfigSourceInner {
+    /// The configuration every new handshake uses.
+    current: ArcSwap<ServerConfig>,
+    /// The file paths a reload rereads. `None` for a static source.
+    origin: Option<TlsConfig>,
+}
+
+impl TlsConfigSource {
+    /// Create a static source from an already-built server configuration.
+    ///
+    /// The result never changes: [`reload`](Self::reload) has no files to read
+    /// and returns an error. Use [`from_tls_config`](Self::from_tls_config)
+    /// when the credentials must be rotatable.
+    #[must_use]
+    pub fn from_server_config(server_config: Arc<ServerConfig>) -> Self {
+        Self {
+            inner: Arc::new(TlsConfigSourceInner {
+                current: ArcSwap::new(server_config),
+                origin: None,
+            }),
+        }
+    }
+
+    /// Create a reloadable source by loading credentials from disk.
+    ///
+    /// Reads the certificate chain, private key and any client-CA bundle named
+    /// by `tls_config` through [`load_server_config`], and remembers those paths
+    /// so [`reload`](Self::reload) can reread them. Returns the load error if
+    /// the initial read fails, leaving no source to serve from.
+    pub fn from_tls_config(tls_config: &TlsConfig) -> Result<Self> {
+        let server_config = load_server_config(tls_config)?;
+        Ok(Self {
+            inner: Arc::new(TlsConfigSourceInner {
+                current: ArcSwap::new(server_config),
+                origin: Some(tls_config.clone()),
+            }),
+        })
+    }
+
+    /// The configuration new handshakes currently use.
+    ///
+    /// A cheap atomic load: this sits on the accept path and does no I/O.
+    #[must_use]
+    pub fn load(&self) -> Arc<ServerConfig> {
+        self.inner.current.load_full()
+    }
+
+    /// Whether [`reload`](Self::reload) can do anything for this source.
+    ///
+    /// `true` for a source built from a [`TlsConfig`], `false` for one built
+    /// from an already-loaded [`ServerConfig`].
+    #[must_use]
+    pub fn is_reloadable(&self) -> bool {
+        self.inner.origin.is_some()
+    }
+
+    /// The configuration this source reloads from, if it is reloadable.
+    #[must_use]
+    pub fn origin(&self) -> Option<&TlsConfig> {
+        self.inner.origin.as_ref()
+    }
+
+    /// Reread the credential files and install them for new handshakes.
+    ///
+    /// On success every subsequent handshake uses the new configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the source is static (nothing to reread), or when
+    /// the files fail to load or parse. In both cases the previously installed
+    /// configuration stays in place and keeps serving: a rotation that produced
+    /// an unusable certificate must not take the listener down with it. Failures
+    /// are also logged at `ERROR` level, because a service whose rotation has
+    /// silently stopped working will keep working until the certificate expires
+    /// and then fail all at once.
+    pub fn reload(&self) -> Result<()> {
+        let Some(ref origin) = self.inner.origin else {
+            let err = crate::error::Error::Internal(
+                "TLS credentials cannot be reloaded: this source was built from an \
+                 already-loaded ServerConfig and has no files to reread"
+                    .to_string(),
+            );
+            tracing::error!("{}", err);
+            return Err(err);
+        };
+
+        match load_server_config(origin) {
+            Ok(server_config) => {
+                self.inner.current.store(server_config);
+                tracing::info!(
+                    cert_path = %origin.cert_path.display(),
+                    key_path = %origin.key_path.display(),
+                    "TLS credentials reloaded; new handshakes use the new certificate"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                tracing::error!(
+                    cert_path = %origin.cert_path.display(),
+                    key_path = %origin.key_path.display(),
+                    error = %e,
+                    "TLS credential reload failed; continuing to serve the previous \
+                     certificate. New credentials will not take effect until a reload \
+                     succeeds."
+                );
+                Err(e)
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for TlsConfigSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `ServerConfig` carries key material, so describe the source by where
+        // it came from rather than by what it holds.
+        f.debug_struct("TlsConfigSource")
+            .field("reloadable", &self.is_reloadable())
+            .field("origin", &self.inner.origin)
+            .finish()
+    }
+}
+
+impl From<Arc<ServerConfig>> for TlsConfigSource {
+    fn from(server_config: Arc<ServerConfig>) -> Self {
+        Self::from_server_config(server_config)
+    }
+}
+
+/// A TLS-enabled listener wrapping a [`TcpListener`], terminating TLS with the
+/// credentials held by a [`TlsConfigSource`].
 ///
 /// Implements [`axum::serve::Listener`] so it can be used as a drop-in
 /// replacement for `TcpListener` when calling `axum::serve()`.
+///
+/// Each accepted connection reads the source's current configuration, so
+/// credentials swapped in by [`TlsConfigSource::reload`] apply to the next
+/// handshake without restarting the listener.
 pub struct TlsListener {
     tcp: TcpListener,
-    acceptor: TlsAcceptor,
+    config_source: TlsConfigSource,
 }
 
 impl TlsListener {
-    /// Create a new TLS listener from an existing TCP listener and server config.
+    /// Create a TLS listener serving one fixed server configuration.
+    ///
+    /// The credentials cannot be rotated. Use
+    /// [`with_config_source`](Self::with_config_source) with a source built by
+    /// [`TlsConfigSource::from_tls_config`] when they must be.
     pub fn new(tcp: TcpListener, server_config: Arc<ServerConfig>) -> Self {
-        Self {
-            tcp,
-            acceptor: TlsAcceptor::from(server_config),
-        }
+        Self::with_config_source(tcp, TlsConfigSource::from_server_config(server_config))
+    }
+
+    /// Create a TLS listener that reads its credentials from `config_source`.
+    ///
+    /// Every handshake uses whatever the source holds at that moment, so a
+    /// [`reload`](TlsConfigSource::reload) on a clone of the source rotates this
+    /// listener's certificate in place.
+    pub fn with_config_source(tcp: TcpListener, config_source: TlsConfigSource) -> Self {
+        Self { tcp, config_source }
+    }
+
+    /// The credential source this listener hands to each new handshake.
+    #[must_use]
+    pub fn config_source(&self) -> &TlsConfigSource {
+        &self.config_source
     }
 }
 
@@ -39,7 +236,7 @@ impl axum::serve::Listener for TlsListener {
     type Addr = SocketAddr;
 
     fn accept(&mut self) -> impl std::future::Future<Output = (Self::Io, Self::Addr)> + Send {
-        let acceptor = self.acceptor.clone();
+        let config_source = self.config_source.clone();
         let tcp = &mut self.tcp;
 
         async move {
@@ -54,6 +251,12 @@ impl axum::serve::Listener for TlsListener {
                         continue;
                     }
                 };
+
+                // Read the credentials per connection so a reload that happened
+                // since the last accept takes effect. Both the load and the
+                // acceptor construction are `Arc` clones, so this costs nothing
+                // measurable against the handshake that follows.
+                let acceptor = TlsAcceptor::from(config_source.load());
 
                 // Perform TLS handshake. On failure, log and try the next connection.
                 match acceptor.accept(stream).await {
@@ -72,13 +275,90 @@ impl axum::serve::Listener for TlsListener {
     }
 }
 
+/// Load a [`RootCertStore`] of client-CA certificates from a PEM bundle.
+///
+/// Every PEM-encoded certificate in the file is treated as a trust anchor for
+/// verifying client certificates during a mutual-TLS handshake. Returns an
+/// error if the file cannot be opened, cannot be parsed, or contains no
+/// certificates (an empty trust store would silently reject every client).
+pub fn load_client_ca_roots(path: &Path) -> Result<RootCertStore> {
+    use rustls_pki_types::pem::PemObject;
+
+    let ca_certs: Vec<CertificateDer<'static>> = CertificateDer::pem_file_iter(path)
+        .map_err(|e| {
+            crate::error::Error::Internal(format!(
+                "Failed to open client CA file '{}': {}",
+                path.display(),
+                e
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|e| {
+            crate::error::Error::Internal(format!(
+                "Failed to parse client CA certificates from '{}': {}",
+                path.display(),
+                e
+            ))
+        })?;
+
+    if ca_certs.is_empty() {
+        return Err(crate::error::Error::Internal(format!(
+            "Client CA file '{}' contains no certificates",
+            path.display()
+        )));
+    }
+
+    let mut roots = RootCertStore::empty();
+    for cert in ca_certs {
+        roots.add(cert).map_err(|e| {
+            crate::error::Error::Internal(format!(
+                "Failed to add client CA certificate from '{}' to trust store: {}",
+                path.display(),
+                e
+            ))
+        })?;
+    }
+
+    Ok(roots)
+}
+
+/// Build a rustls [`ClientCertVerifier`] from a set of trust anchors.
+///
+/// When `optional` is `true`, a client certificate is requested but not
+/// required: connections without one still complete, and a presented
+/// certificate is still verified. When `false`, a valid client certificate is
+/// mandatory and the handshake fails without one.
+pub fn build_client_verifier(
+    roots: RootCertStore,
+    optional: bool,
+) -> Result<Arc<dyn ClientCertVerifier>> {
+    // The crypto provider must be installed before the verifier builder runs,
+    // for the same reason as `ServerConfig::builder()` below.
+    crate::crypto::ensure_default_crypto_provider();
+
+    let mut builder = WebPkiClientVerifier::builder(Arc::new(roots));
+    if optional {
+        builder = builder.allow_unauthenticated();
+    }
+
+    builder.build().map_err(|e| {
+        crate::error::Error::Internal(format!(
+            "Failed to build client certificate verifier: {}",
+            e
+        ))
+    })
+}
+
 /// Load a rustls [`ServerConfig`] from PEM certificate and key files.
 ///
-/// Reads the certificate chain and private key from disk and constructs
-/// a server configuration with no client authentication required.
+/// Reads the certificate chain and private key from disk and constructs a
+/// server configuration. When [`TlsConfig::client_ca_path`] is set, the server
+/// is configured for mutual TLS: client certificates are verified against that
+/// CA bundle (required unless [`TlsConfig::client_auth_optional`] is set).
+/// Otherwise no client authentication is requested.
 pub fn load_server_config(tls_config: &TlsConfig) -> Result<Arc<ServerConfig>> {
     use rustls_pki_types::pem::PemObject;
-    use rustls_pki_types::{CertificateDer, PrivateKeyDer};
+    use rustls_pki_types::PrivateKeyDer;
     use tokio_rustls::rustls;
 
     // Read certificate chain
@@ -116,13 +396,435 @@ pub fn load_server_config(tls_config: &TlsConfig) -> Result<Arc<ServerConfig>> {
     // are compiled into the binary (common via transitive deps).
     crate::crypto::ensure_default_crypto_provider();
 
-    // Build server config
-    let config = ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(cert_chain, key)
-        .map_err(|e| {
-            crate::error::Error::Internal(format!("Failed to build TLS server config: {}", e))
-        })?;
+    // Select the client-authentication posture. A configured client CA bundle
+    // switches the listener into mutual-TLS mode; its absence preserves the
+    // prior server-only behaviour.
+    let builder = ServerConfig::builder();
+    let config = match tls_config.client_ca_path {
+        Some(ref ca_path) => {
+            let roots = load_client_ca_roots(ca_path)?;
+            let verifier = build_client_verifier(roots, tls_config.client_auth_optional)?;
+            builder.with_client_cert_verifier(verifier)
+        }
+        None => builder.with_no_client_auth(),
+    }
+    .with_single_cert(cert_chain, key)
+    .map_err(|e| {
+        crate::error::Error::Internal(format!("Failed to build TLS server config: {}", e))
+    })?;
 
     Ok(Arc::new(config))
+}
+
+/// A verified client certificate chain from a mutual-TLS handshake.
+///
+/// The chain is ordered leaf-first: [`PeerCertificates::leaf`] returns the
+/// client's end-entity certificate, followed by any intermediates. It is only
+/// present when the connection completed an mTLS handshake and the client
+/// presented a certificate that validated against the configured CA bundle.
+#[derive(Clone, Debug)]
+pub struct PeerCertificates(Arc<Vec<CertificateDer<'static>>>);
+
+impl PeerCertificates {
+    /// The full verified certificate chain, leaf first.
+    #[must_use]
+    pub fn as_slice(&self) -> &[CertificateDer<'static>] {
+        &self.0
+    }
+
+    /// The client's end-entity (leaf) certificate.
+    ///
+    /// The chain is guaranteed non-empty: a `PeerCertificates` is only
+    /// constructed from a non-empty rustls peer chain.
+    #[must_use]
+    pub fn leaf(&self) -> &CertificateDer<'static> {
+        &self.0[0]
+    }
+}
+
+/// Connection information for a TLS listener, carrying the peer's socket
+/// address and any verified client certificate chain.
+///
+/// Extract it from a handler with
+/// `axum::extract::ConnectInfo<acton_service::tls::TlsConnectInfo>`. The
+/// certificate chain is present only for connections that completed a
+/// mutual-TLS handshake with a valid client certificate.
+///
+/// This type supersedes the plain `SocketAddr` connect-info on TLS listeners,
+/// so TLS connections also expose a real remote address for rate limiting.
+#[derive(Clone, Debug)]
+pub struct TlsConnectInfo {
+    remote_addr: SocketAddr,
+    peer_certificates: Option<PeerCertificates>,
+}
+
+impl TlsConnectInfo {
+    /// The remote socket address of the connecting peer.
+    #[must_use]
+    pub fn remote_addr(&self) -> SocketAddr {
+        self.remote_addr
+    }
+
+    /// The verified client certificate chain, if the peer authenticated with
+    /// one during a mutual-TLS handshake.
+    #[must_use]
+    pub fn peer_certificates(&self) -> Option<&PeerCertificates> {
+        self.peer_certificates.as_ref()
+    }
+
+    /// Whether the peer presented a verified client certificate.
+    #[must_use]
+    pub fn is_mutually_authenticated(&self) -> bool {
+        self.peer_certificates.is_some()
+    }
+}
+
+impl axum::extract::connect_info::Connected<axum::serve::IncomingStream<'_, TlsListener>>
+    for TlsConnectInfo
+{
+    fn connect_info(stream: axum::serve::IncomingStream<'_, TlsListener>) -> Self {
+        let remote_addr = *stream.remote_addr();
+        let (_, connection) = stream.io().get_ref();
+        let peer_certificates = connection
+            .peer_certificates()
+            .filter(|chain| !chain.is_empty())
+            .map(|chain| PeerCertificates(Arc::new(chain.to_vec())));
+
+        Self {
+            remote_addr,
+            peer_certificates,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    /// A self-signed certificate plus its PEM-encoded private key, usable both
+    /// as a CA trust anchor and as a leaf server identity in tests.
+    struct TestCert {
+        cert_pem: String,
+        key_pem: String,
+        der: CertificateDer<'static>,
+    }
+
+    fn generate_cert(name: &str) -> TestCert {
+        let certified = rcgen::generate_simple_self_signed(vec![name.to_string()])
+            .expect("self-signed cert generation");
+        TestCert {
+            cert_pem: certified.cert.pem(),
+            key_pem: certified.signing_key.serialize_pem(),
+            der: certified.cert.der().clone(),
+        }
+    }
+
+    fn write_temp(contents: &str) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        file.write_all(contents.as_bytes()).expect("write temp");
+        file.flush().expect("flush temp");
+        file
+    }
+
+    #[test]
+    fn load_client_ca_roots_reads_a_valid_bundle() {
+        let ca = generate_cert("test-ca");
+        let file = write_temp(&ca.cert_pem);
+
+        let roots = load_client_ca_roots(file.path()).expect("valid CA bundle must load");
+
+        assert_eq!(
+            roots.len(),
+            1,
+            "the single CA certificate must become one trust anchor"
+        );
+    }
+
+    #[test]
+    fn load_client_ca_roots_rejects_a_missing_file() {
+        let err = load_client_ca_roots(Path::new("/nonexistent/ca.pem"))
+            .expect_err("a missing CA file must be an error, not an empty trust store");
+
+        assert!(
+            err.to_string().contains("Failed to open client CA file"),
+            "error must name the failure to open the file: {err}"
+        );
+    }
+
+    #[test]
+    fn load_client_ca_roots_rejects_a_file_without_certificates() {
+        // A syntactically valid PEM file that carries no certificates.
+        let file = write_temp("# no certificates here\n");
+
+        let err = load_client_ca_roots(file.path())
+            .expect_err("a CA file with no certificates must be an error");
+
+        assert!(
+            err.to_string().contains("contains no certificates"),
+            "error must explain that the bundle is empty: {err}"
+        );
+    }
+
+    #[test]
+    fn build_client_verifier_supports_required_and_optional_modes() {
+        let ca = generate_cert("test-ca");
+        let file = write_temp(&ca.cert_pem);
+
+        let required_roots = load_client_ca_roots(file.path()).expect("roots");
+        build_client_verifier(required_roots, false)
+            .expect("a verifier requiring client auth must build");
+
+        let optional_roots = load_client_ca_roots(file.path()).expect("roots");
+        build_client_verifier(optional_roots, true)
+            .expect("a verifier allowing unauthenticated clients must build");
+    }
+
+    #[test]
+    fn load_server_config_without_client_ca_requests_no_client_auth() {
+        let server = generate_cert("localhost");
+        let cert_file = write_temp(&server.cert_pem);
+        let key_file = write_temp(&server.key_pem);
+
+        let config = TlsConfig {
+            enabled: true,
+            cert_path: cert_file.path().to_path_buf(),
+            key_path: key_file.path().to_path_buf(),
+            client_ca_path: None,
+            client_auth_optional: false,
+        };
+
+        load_server_config(&config).expect("server-only TLS config must build");
+    }
+
+    #[test]
+    fn load_server_config_with_client_ca_builds_a_mutual_tls_config() {
+        let server = generate_cert("localhost");
+        let ca = generate_cert("client-ca");
+        let cert_file = write_temp(&server.cert_pem);
+        let key_file = write_temp(&server.key_pem);
+        let ca_file = write_temp(&ca.cert_pem);
+
+        let config = TlsConfig {
+            enabled: true,
+            cert_path: cert_file.path().to_path_buf(),
+            key_path: key_file.path().to_path_buf(),
+            client_ca_path: Some(ca_file.path().to_path_buf()),
+            client_auth_optional: true,
+        };
+
+        load_server_config(&config).expect("mutual-TLS config must build");
+    }
+
+    #[test]
+    fn load_server_config_surfaces_an_invalid_client_ca() {
+        let server = generate_cert("localhost");
+        let cert_file = write_temp(&server.cert_pem);
+        let key_file = write_temp(&server.key_pem);
+
+        let config = TlsConfig {
+            enabled: true,
+            cert_path: cert_file.path().to_path_buf(),
+            key_path: key_file.path().to_path_buf(),
+            client_ca_path: Some(PathBuf::from("/nonexistent/client-ca.pem")),
+            client_auth_optional: false,
+        };
+
+        load_server_config(&config)
+            .expect_err("an unreadable client CA must fail the whole config build");
+    }
+
+    /// Write cert and key PEM into named files under a directory the test owns,
+    /// so their contents can be rewritten in place to simulate a rotation.
+    fn write_credentials(dir: &Path, cert: &TestCert) -> TlsConfig {
+        let cert_path = dir.join("server.pem");
+        let key_path = dir.join("server.key");
+        std::fs::write(&cert_path, &cert.cert_pem).expect("write cert");
+        std::fs::write(&key_path, &cert.key_pem).expect("write key");
+
+        TlsConfig {
+            enabled: true,
+            cert_path,
+            key_path,
+            client_ca_path: None,
+            client_auth_optional: false,
+        }
+    }
+
+    #[test]
+    fn static_source_serves_the_config_it_was_built_from() {
+        let server = generate_cert("localhost");
+        let cert_file = write_temp(&server.cert_pem);
+        let key_file = write_temp(&server.key_pem);
+        let config = TlsConfig {
+            enabled: true,
+            cert_path: cert_file.path().to_path_buf(),
+            key_path: key_file.path().to_path_buf(),
+            client_ca_path: None,
+            client_auth_optional: false,
+        };
+        let server_config = load_server_config(&config).expect("config builds");
+
+        let source = TlsConfigSource::from_server_config(server_config.clone());
+
+        assert!(
+            Arc::ptr_eq(&source.load(), &server_config),
+            "a static source must hand back exactly the config it was given"
+        );
+        assert!(
+            !source.is_reloadable(),
+            "a source with no file origin is not reloadable"
+        );
+        assert!(source.origin().is_none());
+    }
+
+    #[test]
+    fn reload_on_a_static_source_is_an_error_and_keeps_the_config() {
+        let server = generate_cert("localhost");
+        let cert_file = write_temp(&server.cert_pem);
+        let key_file = write_temp(&server.key_pem);
+        let config = TlsConfig {
+            enabled: true,
+            cert_path: cert_file.path().to_path_buf(),
+            key_path: key_file.path().to_path_buf(),
+            client_ca_path: None,
+            client_auth_optional: false,
+        };
+        let server_config = load_server_config(&config).expect("config builds");
+        let source = TlsConfigSource::from_server_config(server_config.clone());
+
+        let err = source
+            .reload()
+            .expect_err("a static source has no files to reread");
+
+        assert!(
+            err.to_string().contains("cannot be reloaded"),
+            "the error must say the source is not reloadable: {err}"
+        );
+        assert!(
+            Arc::ptr_eq(&source.load(), &server_config),
+            "a rejected reload must leave the served config untouched"
+        );
+    }
+
+    #[test]
+    fn successful_reload_swaps_in_the_new_credentials() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let first = generate_cert("localhost");
+        let tls_config = write_credentials(dir.path(), &first);
+
+        let source = TlsConfigSource::from_tls_config(&tls_config).expect("initial load");
+        assert!(source.is_reloadable(), "a file-backed source is reloadable");
+        let before = source.load();
+
+        // Rotate: replace the files in place with a different key pair.
+        let second = generate_cert("localhost");
+        std::fs::write(&tls_config.cert_path, &second.cert_pem).expect("rewrite cert");
+        std::fs::write(&tls_config.key_path, &second.key_pem).expect("rewrite key");
+
+        source
+            .reload()
+            .expect("rereading valid credentials must succeed");
+
+        assert!(
+            !Arc::ptr_eq(&source.load(), &before),
+            "a successful reload must install a newly loaded config"
+        );
+    }
+
+    #[test]
+    fn failed_reload_preserves_the_last_good_credentials() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let good = generate_cert("localhost");
+        let tls_config = write_credentials(dir.path(), &good);
+
+        let source = TlsConfigSource::from_tls_config(&tls_config).expect("initial load");
+        let last_good = source.load();
+
+        // Simulate a half-written rotation: the cert file is no longer parseable.
+        std::fs::write(
+            &tls_config.cert_path,
+            "-----BEGIN CERTIFICATE-----\ntruncated",
+        )
+        .expect("corrupt cert");
+
+        let err = source
+            .reload()
+            .expect_err("an unparseable certificate must fail the reload");
+
+        assert!(
+            Arc::ptr_eq(&source.load(), &last_good),
+            "a failed reload must keep serving the last-good config, not drop it"
+        );
+        assert!(
+            !err.to_string().is_empty(),
+            "the failure must be reported to the caller: {err}"
+        );
+
+        // And the source recovers once the files are valid again.
+        let replacement = generate_cert("localhost");
+        std::fs::write(&tls_config.cert_path, &replacement.cert_pem).expect("rewrite cert");
+        std::fs::write(&tls_config.key_path, &replacement.key_pem).expect("rewrite key");
+        source.reload().expect("a later valid reload must succeed");
+        assert!(
+            !Arc::ptr_eq(&source.load(), &last_good),
+            "the recovered reload must install the new config"
+        );
+    }
+
+    #[test]
+    fn clones_of_a_source_observe_the_same_reload() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let first = generate_cert("localhost");
+        let tls_config = write_credentials(dir.path(), &first);
+
+        let source = TlsConfigSource::from_tls_config(&tls_config).expect("initial load");
+        let listener_side = source.clone();
+        let before = listener_side.load();
+
+        let second = generate_cert("localhost");
+        std::fs::write(&tls_config.cert_path, &second.cert_pem).expect("rewrite cert");
+        std::fs::write(&tls_config.key_path, &second.key_pem).expect("rewrite key");
+        source.reload().expect("reload");
+
+        assert!(
+            Arc::ptr_eq(&listener_side.load(), &source.load()),
+            "every clone must see the same installed config"
+        );
+        assert!(
+            !Arc::ptr_eq(&listener_side.load(), &before),
+            "the clone held by the listener must see the rotation"
+        );
+    }
+
+    #[test]
+    fn tls_connect_info_reports_absence_of_client_cert() {
+        let info = TlsConnectInfo {
+            remote_addr: "127.0.0.1:8443".parse().expect("addr"),
+            peer_certificates: None,
+        };
+
+        assert!(
+            !info.is_mutually_authenticated(),
+            "a connection without a client cert is not mutually authenticated"
+        );
+        assert!(info.peer_certificates().is_none());
+        assert_eq!(info.remote_addr(), "127.0.0.1:8443".parse().expect("addr"));
+    }
+
+    #[test]
+    fn tls_connect_info_exposes_the_verified_chain() {
+        let leaf = generate_cert("client-leaf");
+        let chain = PeerCertificates(Arc::new(vec![leaf.der.clone()]));
+        let info = TlsConnectInfo {
+            remote_addr: "10.0.0.5:9000".parse().expect("addr"),
+            peer_certificates: Some(chain),
+        };
+
+        assert!(info.is_mutually_authenticated());
+        let certs = info.peer_certificates().expect("chain present");
+        assert_eq!(certs.as_slice().len(), 1);
+        assert_eq!(certs.leaf(), &leaf.der, "the leaf must be the first cert");
+    }
 }


### PR DESCRIPTION
Closes #66 for the server side. The client-side identity helper is split out to #67.

## What this does

**1. Optional client certificate verification (mTLS)**

`TlsConfig` grows two `#[serde(default)]` fields, so every existing config parses unchanged:

- `client_ca_path: Option<PathBuf>` — a PEM CA bundle. When present, `load_server_config` builds with `WebPkiClientVerifier` over those roots instead of `with_no_client_auth()`. Absent means today's behaviour exactly.
- `client_auth_optional: bool` — defaults to `false` (a valid client cert is required). `true` requests but does not require one, still verifying any cert presented.

Per the issue's open question, enforcement is **implied by `client_ca_path` being set** rather than gated behind a separate `require_client_auth` flag, so there is no configured-but-unenforced misconfiguration state.

Because both the HTTP and gRPC TLS paths already funnel through `load_server_config`, this one choke point covers `[tls]` and `[grpc.tls]` alike.

**2. Verified peer identity in the request path**

New `TlsConnectInfo` (remote addr + optional verified chain) and `PeerCertificates` (leaf-first chain), extracted in a handler as `ConnectInfo<acton_service::tls::TlsConnectInfo>`. Services can bind a presented SAN to their own authorization decisions, per-caller allowlists, and revocation.

Side benefit: TLS listeners previously carried **no** connect-info at all — the old code comments claimed orphan rules forbade it, but that only blocked reusing the foreign `SocketAddr`; a local connect-info type is fine. TLS connections now expose a real remote address for IP-based rate limiting, which previously required running behind a proxy with `trust_forwarded_headers`.

**3. Hot-reloadable credentials**

`TlsConfigSource` holds the current `ServerConfig` behind an `ArcSwap`. `TlsListener` builds its `TlsAcceptor` per-accept from `source.load()` — an atomic read plus an `Arc` clone, no I/O on the accept path — so `reload()` installs new credentials without rebinding the socket. Established connections keep the config they handshook with; every later handshake uses the newest.

Reload is **fail-closed**, matching the existing precedent that a TLS load failure is fatal rather than a plaintext downgrade (#45): a failed reread keeps the last-good config installed, logs at ERROR with the paths, and returns the error. It can never leave the listener without credentials. A static source reports that it has no files to reread rather than silently succeeding.

`Debug` is hand-written to print the origin paths rather than the `ServerConfig`, so key material stays out of logs.

## API surface

`with_tls_config_source` / `with_grpc_tls_config_source` accept a `TlsConfigSource` so injected credentials can rotate. The existing `with_tls_config` / `with_grpc_tls_config` keep their exact signatures, internally becoming static sources, with rustdoc pointing at the `_source` variants for rotation. Config-driven `[tls]` / `[grpc.tls]` paths also build through `TlsConfigSource`, so file-configured TLS is reloadable too, not just injected credentials.

No breaking changes: additive config fields, additive public API, existing constructors preserved.

## Deliberately out of scope

- **Reload triggers.** File watching, mtime polling, and SIGHUP wiring are not here. `reload()` being callable is this PR's deliverable; picking a trigger is its own change. Note that config-driven TLS currently has no externally reachable trigger — the source lives inside `ActonService` — so the trigger work will need to decide whether to expose an accessor.
- **Client-side identity helper** — #67.
- **CRL / explicit denylist.** CA-bundle rotation covers v1 revocation given short-lived certs. `WebPkiClientVerifier` accepts CRLs, so an optional `client_crl_path` is a small additive follow-up.
- **Version bump.** Releases ship in separate `chore(release)` PRs in this repo.

## Verification

- `cargo nextest run --features full` — **691 passed, 0 failed** (686 on main, 5 new source/reload tests plus the earlier mTLS and config-serde tests).
- `cargo clippy --features full --all-targets -- -D warnings` — clean. Also clean for `tls`-only. **Zero** `allow(clippy::…)` directives added.
- New tests cover: valid/missing/empty CA bundles, required vs optional verifier modes, server config with and without a client CA, an unreadable CA failing the whole build, connect-info with and without a chain, successful reload swapping config, failed reload preserving last-good and then recovering, and clones observing the same reload.

## Note on scope beyond the diff

`cargo fmt --check` is not clean at baseline on this repo (examples, `background_worker.rs`, `governor_integration.rs`, ~20 spots in `service_builder.rs`). I left that alone to keep this PR focused; everything this branch adds is rustfmt-clean. Ten pre-existing rustdoc warnings on main are likewise untouched.