### PR TITLE
chore: format the workspace and fix broken intra-doc links

### DIFF
--- a/acton-cli/src/commands/service/add/graphql.rs
+++ b/acton-cli/src/commands/service/add/graphql.rs
@@ -21,9 +21,7 @@ pub async fn execute(version: String, cedar: bool, dry_run: bool) -> Result<()> 
     }
 
     if !src_path.exists() {
-        anyhow::bail!(
-            "src/ directory not found. Run this command from a service project root."
-        );
+        anyhow::bail!("src/ directory not found. Run this command from a service project root.");
     }
 
     if graphql_path.exists() {
@@ -34,11 +32,7 @@ pub async fn execute(version: String, cedar: bool, dry_run: bool) -> Result<()> 
     }
 
     utils::write_file(&graphql_path, &graphql::generate_module_with_cedar(cedar))?;
-    println!(
-        "{} created {}",
-        "✓".green().bold(),
-        graphql_path.display()
-    );
+    println!("{} created {}", "✓".green().bold(), graphql_path.display());
 
     if cargo_path.exists() {
         ensure_feature_in_cargo(&cargo_path, cedar)?;

--- a/acton-cli/src/commands/service/new.rs
+++ b/acton-cli/src/commands/service/new.rs
@@ -431,10 +431,7 @@ fn show_success(config: &ServiceConfig, project_path: &Path) {
             println!("  {} gRPC service", "✓".green());
         }
         if config.graphql {
-            println!(
-                "  {} GraphQL transport at /api/v1/graphql",
-                "✓".green()
-            );
+            println!("  {} GraphQL transport at /api/v1/graphql", "✓".green());
         }
         if let Some(db) = &config.database {
             println!("  {} {} database with connection pooling", "✓".green(), db);

--- a/acton-service/examples/graphql/graphql-basic.rs
+++ b/acton-service/examples/graphql/graphql-basic.rs
@@ -61,11 +61,7 @@ impl QueryV2 {
     /// Reads a "document". Under the `graphql-cedar` feature this is guarded
     /// by a Cedar policy: the subject must be allowed by an
     /// `Action::"readDocument"` policy on `Document::"<id>"`.
-    async fn document(
-        &self,
-        _ctx: &Context<'_>,
-        id: String,
-    ) -> async_graphql::Result<String> {
+    async fn document(&self, _ctx: &Context<'_>, id: String) -> async_graphql::Result<String> {
         #[cfg(feature = "graphql-cedar")]
         CedarResolverCheck::for_context(_ctx)?
             .with_action("readDocument")

--- a/acton-service/examples/grpc/single-port.rs
+++ b/acton-service/examples/grpc/single-port.rs
@@ -118,7 +118,9 @@ async fn main() -> Result<()> {
     // Build HTTP routes
     let http_routes = VersionedApiBuilder::new()
         .with_base_path("/api")
-        .add_version(ApiVersion::V1, |router| router.route("/hello", get(http_hello)))
+        .add_version(ApiVersion::V1, |router| {
+            router.route("/hello", get(http_hello))
+        })
         .build_routes();
 
     // Enable gRPC in single-port mode.

--- a/acton-service/examples/observability/test-prometheus-metrics.rs
+++ b/acton-service/examples/observability/test-prometheus-metrics.rs
@@ -47,9 +47,7 @@ async fn main() -> Result<()> {
 
     let routes = VersionedApiBuilder::new()
         .with_base_path("/api")
-        .add_version(ApiVersion::V1, |router| {
-            router.route("/hello", get(hello))
-        })
+        .add_version(ApiVersion::V1, |router| router.route("/hello", get(hello)))
         .build_routes();
 
     // ServiceBuilder automatically:

--- a/acton-service/src/agents/background_worker.rs
+++ b/acton-service/src/agents/background_worker.rs
@@ -540,7 +540,9 @@ mod tests {
             task_shutdown_timeout_secs: 5,
             cleanup_interval_secs: 0,
         };
-        let worker = BackgroundWorker::spawn(&mut runtime, &config).await.unwrap();
+        let worker = BackgroundWorker::spawn(&mut runtime, &config)
+            .await
+            .unwrap();
 
         let (tx, rx) = tokio::sync::watch::channel(false);
         let running_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -561,8 +563,7 @@ mod tests {
                     let running = running;
                     let max_obs = max_obs;
                     async move {
-                        let current =
-                            running.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                        let current = running.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
                         max_obs.fetch_max(current, std::sync::atomic::Ordering::SeqCst);
 
                         // Wait for signal to complete
@@ -594,7 +595,9 @@ mod tests {
     async fn test_cleanup_finished_tasks() {
         let mut runtime = ActonApp::launch_async().await;
         let config = BackgroundWorkerConfig::default();
-        let worker = BackgroundWorker::spawn(&mut runtime, &config).await.unwrap();
+        let worker = BackgroundWorker::spawn(&mut runtime, &config)
+            .await
+            .unwrap();
 
         // Submit tasks that complete immediately
         for i in 0..3 {
@@ -624,7 +627,9 @@ mod tests {
             task_shutdown_timeout_secs: 10,
             cleanup_interval_secs: 0,
         };
-        let worker = BackgroundWorker::spawn(&mut runtime, &config).await.unwrap();
+        let worker = BackgroundWorker::spawn(&mut runtime, &config)
+            .await
+            .unwrap();
 
         assert_eq!(worker.shutdown_timeout(), Duration::from_secs(10));
 

--- a/acton-service/src/agents/pool.rs
+++ b/acton-service/src/agents/pool.rs
@@ -1024,9 +1024,7 @@ impl ClickHousePoolAgent {
 
                     match result {
                         Ok(Ok(client)) => {
-                            self_handle
-                                .send(ClickHouseClientConnected { client })
-                                .await;
+                            self_handle.send(ClickHouseClientConnected { client }).await;
                         }
                         Ok(Err(e)) => {
                             self_handle

--- a/acton-service/src/audit/agent.rs
+++ b/acton-service/src/audit/agent.rs
@@ -485,8 +485,8 @@ async fn run_cleanup(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Mutex;
     use std::time::Duration;
 
     use async_trait::async_trait;

--- a/acton-service/src/audit/decorators.rs
+++ b/acton-service/src/audit/decorators.rs
@@ -24,9 +24,7 @@ use chrono::{DateTime, Utc};
 use crate::auth::api_keys::{ApiKey, ApiKeyStorage};
 #[cfg(feature = "oauth")]
 use crate::auth::oauth::provider::{OAuthProvider, OAuthTokens, OAuthUserInfo};
-use crate::auth::tokens::refresh::{
-    RefreshTokenData, RefreshTokenMetadata, RefreshTokenStorage,
-};
+use crate::auth::tokens::refresh::{RefreshTokenData, RefreshTokenMetadata, RefreshTokenStorage};
 use crate::error::Error;
 
 use super::event::{AuditEvent, AuditEventKind, AuditSeverity, AuditSource};
@@ -561,7 +559,14 @@ mod tests {
             ..RefreshTokenMetadata::default()
         };
         wrapped
-            .rotate("old_jti", "new_jti", "user_9", "fam_1", Utc::now(), &metadata)
+            .rotate(
+                "old_jti",
+                "new_jti",
+                "user_9",
+                "fam_1",
+                Utc::now(),
+                &metadata,
+            )
             .await
             .expect("rotate");
 

--- a/acton-service/src/audit/mod.rs
+++ b/acton-service/src/audit/mod.rs
@@ -46,10 +46,10 @@ pub use config::{AlertConfig, AuditConfig, SyslogConfig};
 pub use config_audit::{
     compute_config_fingerprint, drift_check_handler, redact_config, DriftCheckResult,
 };
-#[cfg(feature = "auth")]
-pub use decorators::{AuditedApiKeyStorage, AuditedRefreshStorage};
 #[cfg(feature = "oauth")]
 pub use decorators::AuditedOAuthProvider;
+#[cfg(feature = "auth")]
+pub use decorators::{AuditedApiKeyStorage, AuditedRefreshStorage};
 pub use event::{AuditEvent, AuditEventKind, AuditSeverity, AuditSource};
 pub use logger::AuditLogger;
 pub use middleware::{audit_layer, AuditRoute};

--- a/acton-service/src/audit/storage/clickhouse_impl.rs
+++ b/acton-service/src/audit/storage/clickhouse_impl.rs
@@ -190,12 +190,9 @@ impl From<AuditQueryRow> for AuditEvent {
             _ => AuditSeverity::Informational,
         };
 
-        let timestamp = DateTime::from_timestamp_millis(row.timestamp)
-            .unwrap_or_else(Utc::now);
+        let timestamp = DateTime::from_timestamp_millis(row.timestamp).unwrap_or_else(Utc::now);
 
-        let metadata = row
-            .metadata
-            .and_then(|m| serde_json::from_str(&m).ok());
+        let metadata = row.metadata.and_then(|m| serde_json::from_str(&m).ok());
 
         AuditEvent {
             id: row.id,
@@ -247,9 +244,7 @@ impl AuditStorage for ClickHouseAuditStorage {
             .query("SELECT ?fields FROM audit_events ORDER BY sequence DESC LIMIT 1")
             .fetch_all::<AuditQueryRow>()
             .await
-            .map_err(|e| {
-                Error::ClickHouse(format!("Failed to fetch latest audit event: {}", e))
-            })?;
+            .map_err(|e| Error::ClickHouse(format!("Failed to fetch latest audit event: {}", e)))?;
 
         Ok(rows.into_iter().next().map(Into::into))
     }
@@ -374,7 +369,11 @@ mod tests {
     #[test]
     fn test_insert_row_preserves_all_source_fields() {
         let ts = Utc.with_ymd_and_hms(2025, 6, 15, 10, 30, 0).unwrap();
-        let event = make_event(AuditEventKind::AuthLoginSuccess, AuditSeverity::Informational, ts);
+        let event = make_event(
+            AuditEventKind::AuthLoginSuccess,
+            AuditSeverity::Informational,
+            ts,
+        );
         let row = AuditInsertRow::from(&event);
 
         assert_eq!(row.id, event.id);
@@ -387,7 +386,11 @@ mod tests {
     #[test]
     fn test_insert_row_preserves_http_fields() {
         let ts = Utc::now();
-        let event = make_event(AuditEventKind::HttpRequest, AuditSeverity::Informational, ts);
+        let event = make_event(
+            AuditEventKind::HttpRequest,
+            AuditSeverity::Informational,
+            ts,
+        );
         let row = AuditInsertRow::from(&event);
 
         assert_eq!(row.method, Some("POST".to_string()));
@@ -399,7 +402,11 @@ mod tests {
     #[test]
     fn test_insert_row_timestamp_is_epoch_millis() {
         let ts = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
-        let event = make_event(AuditEventKind::HttpRequest, AuditSeverity::Informational, ts);
+        let event = make_event(
+            AuditEventKind::HttpRequest,
+            AuditSeverity::Informational,
+            ts,
+        );
         let row = AuditInsertRow::from(&event);
 
         assert_eq!(row.timestamp, ts.timestamp_millis());
@@ -433,7 +440,11 @@ mod tests {
     #[test]
     fn test_insert_row_serializes_metadata_as_json_string() {
         let ts = Utc::now();
-        let event = make_event(AuditEventKind::HttpRequest, AuditSeverity::Informational, ts);
+        let event = make_event(
+            AuditEventKind::HttpRequest,
+            AuditSeverity::Informational,
+            ts,
+        );
         let row = AuditInsertRow::from(&event);
 
         let metadata_str = row.metadata.unwrap();
@@ -445,7 +456,11 @@ mod tests {
     #[test]
     fn test_insert_row_handles_none_metadata() {
         let ts = Utc::now();
-        let mut event = make_event(AuditEventKind::HttpRequest, AuditSeverity::Informational, ts);
+        let mut event = make_event(
+            AuditEventKind::HttpRequest,
+            AuditSeverity::Informational,
+            ts,
+        );
         event.metadata = None;
         let row = AuditInsertRow::from(&event);
 
@@ -455,11 +470,18 @@ mod tests {
     #[test]
     fn test_insert_row_handles_none_hash() {
         let ts = Utc::now();
-        let mut event = make_event(AuditEventKind::HttpRequest, AuditSeverity::Informational, ts);
+        let mut event = make_event(
+            AuditEventKind::HttpRequest,
+            AuditSeverity::Informational,
+            ts,
+        );
         event.hash = None;
         let row = AuditInsertRow::from(&event);
 
-        assert_eq!(row.hash, "", "None hash should become empty string for ClickHouse non-nullable column");
+        assert_eq!(
+            row.hash, "",
+            "None hash should become empty string for ClickHouse non-nullable column"
+        );
     }
 
     #[test]
@@ -712,7 +734,7 @@ mod tests {
 
         assert_eq!(make_row(0).severity.as_syslog_severity(), 0); // Emergency
         assert_eq!(make_row(7).severity.as_syslog_severity(), 7); // Debug
-        // Out-of-range values should default to Informational (6)
+                                                                  // Out-of-range values should default to Informational (6)
         assert_eq!(make_row(255).severity.as_syslog_severity(), 6);
         assert_eq!(make_row(100).severity.as_syslog_severity(), 6);
     }

--- a/acton-service/src/audit/storage/lazy.rs
+++ b/acton-service/src/audit/storage/lazy.rs
@@ -252,11 +252,17 @@ mod tests {
         let storage = LazyAuditStorage::<MockStorage>::new(shared.clone());
 
         storage.ensure_ready().await.unwrap();
-        assert_eq!(storage.resolved.read().await.as_ref().unwrap().conn, "first");
+        assert_eq!(
+            storage.resolved.read().await.as_ref().unwrap().conn,
+            "first"
+        );
 
         // A later pool swap must not silently re-point an already-resolved chain.
         *shared.write().await = Some("second");
         storage.ensure_ready().await.unwrap();
-        assert_eq!(storage.resolved.read().await.as_ref().unwrap().conn, "first");
+        assert_eq!(
+            storage.resolved.read().await.as_ref().unwrap().conn,
+            "first"
+        );
     }
 }

--- a/acton-service/src/audit/storage/mod.rs
+++ b/acton-service/src/audit/storage/mod.rs
@@ -131,7 +131,8 @@ pub trait AuditStorage: Send + Sync {
     /// Confirm the backend is usable, performing any deferred setup.
     ///
     /// Backends built from an already-connected client are ready immediately.
-    /// Lazily-resolved backends (see [`lazy::LazyAuditStorage`]) return an error
+    /// Lazily-resolved backends (those built from a pool that connects in the
+    /// background) return an error
     /// until their connection pool finishes connecting; the audit agent polls
     /// this before initializing the hash chain so it resumes from the persisted
     /// sequence instead of restarting at zero.

--- a/acton-service/src/audit/storage/mod.rs
+++ b/acton-service/src/audit/storage/mod.rs
@@ -176,7 +176,10 @@ mod helper_tests {
 
     #[test]
     fn parse_custom_preserves_unprefixed_user_strings() {
-        assert_eq!(parse_custom_kind("billing.invoice.paid"), "billing.invoice.paid");
+        assert_eq!(
+            parse_custom_kind("billing.invoice.paid"),
+            "billing.invoice.paid"
+        );
     }
 
     #[test]
@@ -184,6 +187,9 @@ mod helper_tests {
         // The warn fires (verified manually / via tracing subscribers in
         // integration tests); we assert the returned string preserves the
         // original so operators can grep for it in their event store.
-        assert_eq!(parse_custom_kind("auth.token.invalid"), "auth.token.invalid");
+        assert_eq!(
+            parse_custom_kind("auth.token.invalid"),
+            "auth.token.invalid"
+        );
     }
 }

--- a/acton-service/src/audit/wiring.rs
+++ b/acton-service/src/audit/wiring.rs
@@ -34,9 +34,7 @@ pub(crate) struct AuditStorageHandles {
 /// database feature is enabled or no pool agent was spawned, in which case the
 /// audit agent runs with an in-memory chain plus syslog/tracing export.
 #[allow(unused_variables, unused_mut)]
-pub(crate) fn select_audit_storage(
-    handles: &AuditStorageHandles,
-) -> Option<Arc<dyn AuditStorage>> {
+pub(crate) fn select_audit_storage(handles: &AuditStorageHandles) -> Option<Arc<dyn AuditStorage>> {
     #[allow(unused_mut)]
     let mut storage: Option<Arc<dyn AuditStorage>> = None;
 

--- a/acton-service/src/auth/api_keys/mod.rs
+++ b/acton-service/src/auth/api_keys/mod.rs
@@ -21,9 +21,9 @@
 //! }
 //! ```
 
-use chrono::Utc;
 #[cfg(any(feature = "database", feature = "turso"))]
 use chrono::DateTime;
+use chrono::Utc;
 
 use crate::auth::password::PasswordHasher;
 use crate::error::Error;

--- a/acton-service/src/auth/key_rotation/key_metadata.rs
+++ b/acton-service/src/auth/key_rotation/key_metadata.rs
@@ -15,7 +15,7 @@ use std::str::FromStr;
 /// The cryptographic format of a signing key
 ///
 /// Determines which token generator and validator can use this key.
-/// Stored as a string in the database via [`Display`] and [`FromStr`].
+/// Stored as a string in the database via [`Display`](std::fmt::Display) and [`FromStr`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum KeyFormat {
     /// PASETO v4.local (symmetric encryption)
@@ -82,7 +82,7 @@ impl FromStr for KeyFormat {
 /// The lifecycle status of a signing key
 ///
 /// Keys progress through: `Active` -> `Draining` -> `Retired`.
-/// Stored as a string in the database via [`Display`] and [`FromStr`].
+/// Stored as a string in the database via [`Display`](std::fmt::Display) and [`FromStr`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum KeyStatus {
     /// Key is currently used for signing new tokens AND validating existing tokens.

--- a/acton-service/src/auth/tokens/paseto_generator.rs
+++ b/acton-service/src/auth/tokens/paseto_generator.rs
@@ -382,7 +382,9 @@ impl PasetoGenerator {
                 }
                 // All custom claim values are strings after normalize_custom_claims
                 let s = value.as_str().ok_or_else(|| {
-                    Error::Paseto(format!("Custom claim '{key}' is not a string after normalization"))
+                    Error::Paseto(format!(
+                        "Custom claim '{key}' is not a string after normalization"
+                    ))
                 })?;
                 let claim = CustomClaim::try_from((key.as_str(), s))
                     .map_err(|e| Error::Paseto(format!("Invalid '{key}' claim: {e}")))?;

--- a/acton-service/src/clickhouse_backend.rs
+++ b/acton-service/src/clickhouse_backend.rs
@@ -87,22 +87,18 @@ async fn try_create_client(config: &ClickHouseConfig) -> Result<clickhouse::Clie
     }
 
     // Verify connectivity with a simple query
-    client
-        .query("SELECT 1")
-        .execute()
-        .await
-        .map_err(|e| {
-            Error::ClickHouse(format!(
-                "Failed to connect to ClickHouse at '{}'\n\n\
+    client.query("SELECT 1").execute().await.map_err(|e| {
+        Error::ClickHouse(format!(
+            "Failed to connect to ClickHouse at '{}'\n\n\
                 Troubleshooting:\n\
                 1. Verify ClickHouse server is running\n\
                 2. Check HTTP interface is enabled (default port 8123)\n\
                 3. Verify credentials and database name\n\
                 4. Check network connectivity\n\n\
                 Error: {}",
-                config.url, e
-            ))
-        })?;
+            config.url, e
+        ))
+    })?;
 
     Ok(client)
 }
@@ -153,7 +149,12 @@ pub(crate) fn sanitize_url(url: &str) -> String {
 #[async_trait::async_trait]
 pub trait AnalyticsWriter<T>: Send + Sync
 where
-    T: clickhouse::Row + clickhouse::RowOwned + clickhouse::RowWrite + serde::Serialize + Send + Sync,
+    T: clickhouse::Row
+        + clickhouse::RowOwned
+        + clickhouse::RowWrite
+        + serde::Serialize
+        + Send
+        + Sync,
 {
     /// Get a reference to the ClickHouse client
     fn client(&self) -> &clickhouse::Client;

--- a/acton-service/src/config.rs
+++ b/acton-service/src/config.rs
@@ -1704,8 +1704,7 @@ mod tests {
             "key_path": "/etc/tls/key.pem"
         }"#;
 
-        let tls: TlsConfig =
-            serde_json::from_str(json).expect("minimal TLS config must parse");
+        let tls: TlsConfig = serde_json::from_str(json).expect("minimal TLS config must parse");
 
         assert!(
             tls.client_ca_path.is_none(),
@@ -1728,8 +1727,7 @@ mod tests {
             "client_auth_optional": true
         }"#;
 
-        let tls: TlsConfig =
-            serde_json::from_str(json).expect("mutual TLS config must parse");
+        let tls: TlsConfig = serde_json::from_str(json).expect("mutual TLS config must parse");
 
         assert_eq!(
             tls.client_ca_path.as_deref(),

--- a/acton-service/src/extensions.rs
+++ b/acton-service/src/extensions.rs
@@ -375,7 +375,11 @@ mod tests {
         // Both the original and clone should resolve the same handle
         let h1 = extensions.get::<CounterActor>().unwrap();
         let h2 = cloned.get::<CounterActor>().unwrap();
-        assert_eq!(h1.id(), h2.id(), "cloned extensions must share the same handles");
+        assert_eq!(
+            h1.id(),
+            h2.id(),
+            "cloned extensions must share the same handles"
+        );
 
         runtime.shutdown_all().await.unwrap();
     }
@@ -406,12 +410,19 @@ mod tests {
         let counter_entry = ActorExtensionEntry::<CounterActor>(PhantomData);
         let alpha_entry = ActorExtensionEntry::<AlphaActor>(PhantomData);
 
-        let (counter_tid, counter_handle) =
-            counter_entry.spawn(&supervisor_handle, &mut runtime).await.unwrap();
-        let (alpha_tid, alpha_handle) =
-            alpha_entry.spawn(&supervisor_handle, &mut runtime).await.unwrap();
+        let (counter_tid, counter_handle) = counter_entry
+            .spawn(&supervisor_handle, &mut runtime)
+            .await
+            .unwrap();
+        let (alpha_tid, alpha_handle) = alpha_entry
+            .spawn(&supervisor_handle, &mut runtime)
+            .await
+            .unwrap();
 
-        assert_ne!(counter_tid, alpha_tid, "different actor types must have different TypeIds");
+        assert_ne!(
+            counter_tid, alpha_tid,
+            "different actor types must have different TypeIds"
+        );
 
         let mut map = HashMap::new();
         map.insert(counter_tid, counter_handle);
@@ -616,12 +627,16 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         // Broadcast via the broker
-        broker.broadcast(GlobalNotification {
-            payload: "test-1".into(),
-        }).await;
-        broker.broadcast(GlobalNotification {
-            payload: "test-2".into(),
-        }).await;
+        broker
+            .broadcast(GlobalNotification {
+                payload: "test-1".into(),
+            })
+            .await;
+        broker
+            .broadcast(GlobalNotification {
+                payload: "test-2".into(),
+            })
+            .await;
 
         // Allow messages to propagate
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -671,12 +686,18 @@ mod tests {
 
         // Allow after_start to fire
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        assert!(STARTED.load(Ordering::SeqCst), "after_start should have fired");
+        assert!(
+            STARTED.load(Ordering::SeqCst),
+            "after_start should have fired"
+        );
 
         // Stop the actor
         handle.stop().await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        assert!(STOPPED.load(Ordering::SeqCst), "before_stop should have fired");
+        assert!(
+            STOPPED.load(Ordering::SeqCst),
+            "before_stop should have fired"
+        );
 
         runtime.shutdown_all().await.unwrap();
     }

--- a/acton-service/src/extensions.rs
+++ b/acton-service/src/extensions.rs
@@ -1,10 +1,10 @@
 //! Actor-backed extensions for custom application state
 //!
-//! This module provides the [`ActorExtension`] trait and supporting types for adding
+//! This module provides the [`ActorExtension`](crate::extensions::ActorExtension) trait and supporting types for adding
 //! custom runtime state to your application. All extensions are backed by supervised
 //! acton-reactive actors, providing:
 //!
-//! - **Supervision**: Automatic restart on failure via configurable [`RestartPolicy`]
+//! - **Supervision**: Automatic restart on failure via configurable [`RestartPolicy`](acton_reactive::prelude::RestartPolicy)
 //! - **Broker subscriptions**: Subscribe to framework-wide broadcast events
 //! - **Observability**: Built-in tracing instrumentation from the actor runtime
 //! - **No mutexes**: State is encapsulated in actors, accessed via message passing
@@ -62,7 +62,8 @@ type SpawnFuture<'a> =
 /// Trait for defining actor-backed extensions.
 ///
 /// Implement this trait on an `#[acton_actor]` struct to register it as a
-/// supervised extension via [`ServiceBuilder::with_actor`].
+/// supervised extension via
+/// [`ServiceBuilder::with_actor`](crate::service_builder::ServiceBuilder::with_actor).
 ///
 /// The [`configure`](ActorExtension::configure) method receives a mutable reference
 /// to the actor builder, where you register message handlers and lifecycle hooks:
@@ -128,7 +129,9 @@ impl<A: ActorExtension> ActorExtensionSpawner for ActorExtensionEntry<A> {
 
 /// Immutable container mapping actor extension types to their handles.
 ///
-/// Constructed during [`ServiceBuilder::build()`] and stored on [`AppState`].
+/// Constructed during
+/// [`ServiceBuilder::build()`](crate::service_builder::ServiceBuilder::build) and stored on
+/// [`AppState`](crate::state::AppState).
 /// Clone is cheap (Arc ref-count bump). When no actor extensions are registered,
 /// the inner map is never allocated.
 #[derive(Clone, Default)]

--- a/acton-service/src/graphql/builder.rs
+++ b/acton-service/src/graphql/builder.rs
@@ -23,7 +23,9 @@ use super::service::ActonGraphQL;
 /// Type-erased GraphQL executor. The `Schema<Q, M, S>` generics are erased
 /// here so the registry can hold heterogeneous schemas keyed by version.
 pub(crate) type ErasedExecutor = Arc<
-    dyn Fn(async_graphql::BatchRequest) -> futures::future::BoxFuture<'static, async_graphql::BatchResponse>
+    dyn Fn(
+            async_graphql::BatchRequest,
+        ) -> futures::future::BoxFuture<'static, async_graphql::BatchResponse>
         + Send
         + Sync,
 >;

--- a/acton-service/src/graphql/mod.rs
+++ b/acton-service/src/graphql/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module integrates [`async-graphql`](https://docs.rs/async-graphql) as a
 //! third sibling transport next to HTTP (Axum) and gRPC (Tonic). Schemas are
-//! mounted by [`ServiceBuilder::with_versioned_graphql`] underneath the same
+//! mounted by [`ServiceBuilder::with_versioned_graphql`](crate::service_builder::ServiceBuilder::with_versioned_graphql) underneath the same
 //! versioned Axum router used for REST endpoints, so they inherit the full
 //! middleware stack — authentication, tracing, rate limiting, CORS, and
 //! everything else.
@@ -10,7 +10,7 @@
 //! # Versioning
 //!
 //! GraphQL endpoints are versioned per-path. A schema registered for
-//! [`ApiVersion::V1`] is mounted at `/{base}/v1/graphql`, V2 at
+//! [`ApiVersion::V1`](crate::versioning::ApiVersion::V1) is mounted at `/{base}/v1/graphql`, V2 at
 //! `/{base}/v2/graphql`, and so on. This matches the framework's existing
 //! path-based versioning ([`VersionedApiBuilder`](crate::versioning::VersionedApiBuilder)).
 //!

--- a/acton-service/src/graphql/mount.rs
+++ b/acton-service/src/graphql/mount.rs
@@ -50,12 +50,13 @@ pub fn build_router(
 
         let with_deprecation = if let Some(deprecation) = entry.deprecation {
             // Apply per-version deprecation headers + warning log.
-            let layered = Router::<()>::new()
-                .route(&path, method_router)
-                .layer(middleware::from_fn(move |req, next: Next| {
-                    let deprecation = deprecation.clone();
-                    async move { apply_deprecation_headers(req, next, deprecation).await }
-                }));
+            let layered =
+                Router::<()>::new()
+                    .route(&path, method_router)
+                    .layer(middleware::from_fn(move |req, next: Next| {
+                        let deprecation = deprecation.clone();
+                        async move { apply_deprecation_headers(req, next, deprecation).await }
+                    }));
             layered
         } else {
             Router::<()>::new().route(&path, method_router)

--- a/acton-service/src/graphql/service.rs
+++ b/acton-service/src/graphql/service.rs
@@ -158,8 +158,6 @@ fn inject_data(
     };
     match batch {
         BatchRequest::Single(single) => BatchRequest::Single(inject(single)),
-        BatchRequest::Batch(batch) => {
-            BatchRequest::Batch(batch.into_iter().map(inject).collect())
-        }
+        BatchRequest::Batch(batch) => BatchRequest::Batch(batch.into_iter().map(inject).collect()),
     }
 }

--- a/acton-service/src/grpc/middleware.rs
+++ b/acton-service/src/grpc/middleware.rs
@@ -292,8 +292,9 @@ impl GrpcRateLimitLayer {
         // Replenish one token every period/requests, with bucket capacity
         // burst_size — the same quota shape as the HTTP-side governor.
         let requests = u64::from(config.requests_per_period.max(1));
-        let replenish_interval =
-            std::time::Duration::from_millis((config.period().as_millis() as u64 / requests).max(1));
+        let replenish_interval = std::time::Duration::from_millis(
+            (config.period().as_millis() as u64 / requests).max(1),
+        );
         let burst = NonZeroU32::new(config.burst_size.max(1)).expect("max(1) is non-zero");
         let quota = governor::Quota::with_period(replenish_interval)
             .expect("replenish interval is non-zero")

--- a/acton-service/src/lib.rs
+++ b/acton-service/src/lib.rs
@@ -228,6 +228,7 @@ pub mod prelude {
     #[cfg(feature = "cache")]
     pub use crate::middleware::{RedisTokenRevocation, TokenRevocation};
 
+    pub use crate::extensions::{ActorExtension, ActorExtensions};
     #[cfg(feature = "jwt")]
     pub use crate::middleware::JwtAuth;
     pub use crate::responses::{
@@ -235,7 +236,6 @@ pub mod prelude {
     };
     pub use crate::server::Server;
     pub use crate::service_builder::{ActonService, ServiceBuilder, VersionedRoutes};
-    pub use crate::extensions::{ActorExtension, ActorExtensions};
     pub use crate::state::{AppState, AppStateBuilder};
     pub use crate::versioning::{
         extract_version_from_path, versioned_router, ApiVersion, DeprecationInfo,

--- a/acton-service/src/middleware/cedar.rs
+++ b/acton-service/src/middleware/cedar.rs
@@ -1089,10 +1089,7 @@ mod tests {
             type Error = Infallible;
             type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
 
-            fn poll_ready(
-                &mut self,
-                _cx: &mut TaskContext<'_>,
-            ) -> Poll<Result<(), Self::Error>> {
+            fn poll_ready(&mut self, _cx: &mut TaskContext<'_>) -> Poll<Result<(), Self::Error>> {
                 Poll::Ready(Ok(()))
             }
 
@@ -1131,10 +1128,7 @@ mod tests {
             let authz = test_authz("permit(principal, action, resource);", true).await;
             let mut svc = CedarAuthzLayer::new(authz).layer(TestSvc);
             let resp = svc
-                .call(grpc_request(
-                    "/test.v1.TestService/Do",
-                    Some(test_claims()),
-                ))
+                .call(grpc_request("/test.v1.TestService/Do", Some(test_claims())))
                 .await
                 .unwrap();
             assert_eq!(resp.body(), "ok");
@@ -1146,10 +1140,7 @@ mod tests {
             let authz = test_authz("", true).await;
             let mut svc = CedarAuthzLayer::new(authz).layer(TestSvc);
             let resp = svc
-                .call(grpc_request(
-                    "/test.v1.TestService/Do",
-                    Some(test_claims()),
-                ))
+                .call(grpc_request("/test.v1.TestService/Do", Some(test_claims())))
                 .await
                 .unwrap();
             // tonic Code::PermissionDenied == 7

--- a/acton-service/src/middleware/governor.rs
+++ b/acton-service/src/middleware/governor.rs
@@ -231,8 +231,7 @@ impl GovernorRateLimit {
         );
 
         // Check rate limit and get result for headers
-        let result = match rate_limit.check_rate_limit(&method, &path, claims.as_ref(), client_ip)
-        {
+        let result = match rate_limit.check_rate_limit(&method, &path, claims.as_ref(), client_ip) {
             Ok(result) => result,
             Err(e) => {
                 // Mirror the Redis rate limiter: rejections are audit-visible

--- a/acton-service/src/middleware/jwt.rs
+++ b/acton-service/src/middleware/jwt.rs
@@ -157,7 +157,10 @@ impl JwtAuth {
             || path == "/ready"
             || path.starts_with("/swagger-ui")
             || path.starts_with("/api-docs")
-            || auth.public_paths.iter().any(|p| path.starts_with(p.as_str()))
+            || auth
+                .public_paths
+                .iter()
+                .any(|p| path.starts_with(p.as_str()))
         {
             return Ok(next.run(request).await);
         }

--- a/acton-service/src/middleware/paseto.rs
+++ b/acton-service/src/middleware/paseto.rs
@@ -170,7 +170,10 @@ impl PasetoAuth {
             || path == "/ready"
             || path.starts_with("/swagger-ui")
             || path.starts_with("/api-docs")
-            || auth.public_paths.iter().any(|p| path.starts_with(p.as_str()))
+            || auth
+                .public_paths
+                .iter()
+                .any(|p| path.starts_with(p.as_str()))
         {
             return Ok(next.run(request).await);
         }
@@ -287,7 +290,10 @@ impl PasetoAuth {
     fn parse_string_or_array(value: &serde_json::Value) -> Vec<String> {
         // Direct array
         if let Some(arr) = value.as_array() {
-            return arr.iter().filter_map(|v| v.as_str().map(String::from)).collect();
+            return arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
         }
         // Stringified JSON array
         if let Some(s) = value.as_str() {

--- a/acton-service/src/middleware/resilience.rs
+++ b/acton-service/src/middleware/resilience.rs
@@ -11,18 +11,18 @@
 use std::convert::Infallible;
 use std::time::Duration;
 
+use axum::error_handling::HandleErrorLayer;
 use axum::http::StatusCode;
 use axum::response::Response;
-use axum::error_handling::HandleErrorLayer;
 use axum::Router;
 
 use tower::{BoxError, ServiceBuilder};
 
 pub use tower_resilience_bulkhead::BulkheadLayer;
+use tower_resilience_circuitbreaker::classifier::FnClassifier;
 pub use tower_resilience_circuitbreaker::{
     CircuitBreakerConfigBuilder, CircuitBreakerLayer, CircuitState,
 };
-use tower_resilience_circuitbreaker::classifier::FnClassifier;
 
 /// Failure classification used by [`ResilienceConfig::http_circuit_breaker_layer`].
 ///
@@ -175,9 +175,7 @@ impl ResilienceConfig {
     /// [`apply_resilience`], which wires that up for you.
     ///
     /// [`Router`]: axum::Router
-    pub fn http_circuit_breaker_layer(
-        &self,
-    ) -> Option<CircuitBreakerLayer<HttpFailureClassifier>> {
+    pub fn http_circuit_breaker_layer(&self) -> Option<CircuitBreakerLayer<HttpFailureClassifier>> {
         if !self.circuit_breaker_enabled {
             return None;
         }

--- a/acton-service/src/observability.rs
+++ b/acton-service/src/observability.rs
@@ -25,9 +25,7 @@ use {
 };
 
 #[cfg(feature = "_metrics")]
-use {
-    opentelemetry::metrics::MeterProvider as _, opentelemetry_sdk::metrics::SdkMeterProvider,
-};
+use {opentelemetry::metrics::MeterProvider as _, opentelemetry_sdk::metrics::SdkMeterProvider};
 
 #[cfg(feature = "otel-metrics")]
 use {
@@ -203,7 +201,9 @@ pub(crate) fn init_otlp_tracer(
 /// Extracted so it can be composed as one reader among several on a single
 /// [`SdkMeterProvider`] in [`init_meter_provider`].
 #[cfg(feature = "otel-metrics")]
-fn otlp_metric_reader(otlp_config: &crate::config::OtlpConfig) -> Result<PeriodicReader<MetricExporter>> {
+fn otlp_metric_reader(
+    otlp_config: &crate::config::OtlpConfig,
+) -> Result<PeriodicReader<MetricExporter>> {
     // Build OTLP metric exporter with Tonic gRPC transport
     let mut exporter_builder = MetricExporter::builder().with_tonic();
 
@@ -224,8 +224,10 @@ fn otlp_metric_reader(otlp_config: &crate::config::OtlpConfig) -> Result<Periodi
 
 /// Build the Prometheus pull exporter (a metric reader) and its backing registry.
 #[cfg(feature = "prometheus-metrics")]
-fn prometheus_metric_reader() -> Result<(opentelemetry_prometheus::PrometheusExporter, prometheus::Registry)>
-{
+fn prometheus_metric_reader() -> Result<(
+    opentelemetry_prometheus::PrometheusExporter,
+    prometheus::Registry,
+)> {
     let registry = prometheus::Registry::new();
     let exporter = opentelemetry_prometheus::exporter()
         .with_registry(registry.clone())
@@ -632,7 +634,10 @@ mod tests {
         let registry = prometheus::Registry::new();
         let bytes = encode_registry(&registry).expect("encoding an empty registry should succeed");
         // Empty registry produces no metric families, hence no bytes.
-        assert!(bytes.is_empty(), "empty registry should encode to no output");
+        assert!(
+            bytes.is_empty(),
+            "empty registry should encode to no output"
+        );
     }
 
     #[test]

--- a/acton-service/src/openapi.rs
+++ b/acton-service/src/openapi.rs
@@ -384,7 +384,6 @@ pub mod graphql {
         let versions: Vec<ApiVersion> = graphql.versions().collect();
         add_graphql_paths(openapi, graphql.base_path(), &versions)
     }
-
 }
 
 /// OpenAPI security scheme helpers

--- a/acton-service/src/pool_health.rs
+++ b/acton-service/src/pool_health.rs
@@ -347,7 +347,10 @@ mod tests {
     #[test]
     fn test_pool_health_summary_default_is_healthy() {
         let summary = PoolHealthSummary::new();
-        assert!(summary.is_healthy(), "Empty summary with no backends should be healthy");
+        assert!(
+            summary.is_healthy(),
+            "Empty summary with no backends should be healthy"
+        );
     }
 
     #[cfg(feature = "clickhouse")]

--- a/acton-service/src/server.rs
+++ b/acton-service/src/server.rs
@@ -114,8 +114,8 @@ impl Server {
                     tls_listener,
                     app.into_make_service_with_connect_info::<crate::tls::TlsConnectInfo>(),
                 )
-                    .with_graceful_shutdown(shutdown_signal())
-                    .await?;
+                .with_graceful_shutdown(shutdown_signal())
+                .await?;
                 tracing::info!("Server shutdown complete");
                 return Ok(());
             }
@@ -125,8 +125,8 @@ impl Server {
             listener,
             app.into_make_service_with_connect_info::<SocketAddr>(),
         )
-            .with_graceful_shutdown(shutdown_signal())
-            .await?;
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
 
         tracing::info!("Server shutdown complete");
 

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -254,7 +254,7 @@ where
     /// [`build()`](Self::build). It must implement [`ActorExtension`](crate::extensions::ActorExtension),
     /// which requires configuring message handlers via the `configure` method.
     ///
-    /// Access the actor's handle in request handlers via [`AppState::actor::<A>()`](crate::AppState::actor).
+    /// Access the actor's handle in request handlers via [`AppState::actor::<A>()`](crate::state::AppState::actor).
     ///
     /// # Example
     ///

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -267,9 +267,10 @@ where
     ///     .await?;
     /// ```
     pub fn with_actor<A: crate::extensions::ActorExtension>(mut self) -> Self {
-        self.actor_extensions.push(Box::new(
-            crate::extensions::ActorExtensionEntry::<A>(std::marker::PhantomData),
-        ));
+        self.actor_extensions
+            .push(Box::new(crate::extensions::ActorExtensionEntry::<A>(
+                std::marker::PhantomData,
+            )));
         self
     }
 
@@ -353,10 +354,7 @@ where
     ///     .build();
     /// ```
     #[cfg(feature = "graphql")]
-    pub fn with_versioned_graphql(
-        mut self,
-        graphql: crate::graphql::VersionedGraphQL,
-    ) -> Self {
+    pub fn with_versioned_graphql(mut self, graphql: crate::graphql::VersionedGraphQL) -> Self {
         self.graphql = Some(graphql);
         self
     }
@@ -771,10 +769,7 @@ where
                                     clickhouse_agent_handle = Some(handle);
                                 }
                                 Err(e) => {
-                                    tracing::warn!(
-                                        "Failed to spawn ClickHouse pool agent: {}",
-                                        e
-                                    );
+                                    tracing::warn!("Failed to spawn ClickHouse pool agent: {}", e);
                                 }
                             }
                         }
@@ -984,17 +979,12 @@ where
                                         Some(worker)
                                     }
                                     Err(e) => {
-                                        tracing::error!(
-                                            "Failed to spawn background worker: {}",
-                                            e
-                                        );
+                                        tracing::error!("Failed to spawn background worker: {}", e);
                                         None
                                     }
                                 }
                             } else {
-                                tracing::warn!(
-                                    "No agent runtime available for background worker"
-                                );
+                                tracing::warn!("No agent runtime available for background worker");
                                 None
                             }
                         })
@@ -1040,8 +1030,8 @@ where
                         let runtime = self.init_agent_runtime();
 
                         // Spawn the extensions supervisor
-                        let supervisor = runtime
-                            .new_actor::<crate::extensions::ExtensionsSupervisorState>();
+                        let supervisor =
+                            runtime.new_actor::<crate::extensions::ExtensionsSupervisorState>();
                         let supervisor_handle = supervisor.start().await;
                         tracing::info!("Extensions supervisor spawned");
 
@@ -1053,10 +1043,7 @@ where
                                     handles.insert(type_id, handle);
                                 }
                                 Err(e) => {
-                                    tracing::error!(
-                                        "Failed to spawn actor extension: {}",
-                                        e
-                                    );
+                                    tracing::error!("Failed to spawn actor extension: {}", e);
                                 }
                             }
                         }
@@ -1078,9 +1065,7 @@ where
                     crate::extensions::ActorExtensions::default()
                 }
                 None => {
-                    tracing::warn!(
-                        "No tokio runtime available, skipping actor extension spawning"
-                    );
+                    tracing::warn!("No tokio runtime available, skipping actor extension spawning");
                     crate::extensions::ActorExtensions::default()
                 }
             }
@@ -1219,10 +1204,8 @@ where
                 );
 
                 #[cfg(feature = "prometheus-metrics")]
-                let health_router = health_router.route(
-                    "/metrics",
-                    get(crate::observability::metrics_handler),
-                );
+                let health_router =
+                    health_router.route("/metrics", get(crate::observability::metrics_handler));
 
                 // Use fallback_service to include the versioned routes
                 let router_with_health = health_router.fallback_service(router);
@@ -1317,11 +1300,7 @@ where
         // endpoints inherit auth, tracing, CORS, etc.
         #[cfg(feature = "graphql")]
         let app = if let Some(graphql) = self.graphql.take() {
-            let graphql_enabled = config
-                .graphql
-                .as_ref()
-                .map(|g| g.enabled)
-                .unwrap_or(true);
+            let graphql_enabled = config.graphql.as_ref().map(|g| g.enabled).unwrap_or(true);
             if graphql_enabled {
                 match crate::graphql::mount::build_router(
                     graphql,
@@ -1349,8 +1328,8 @@ where
         // activates TLS independently of the `[tls]` section, so both sources
         // count — otherwise HSTS would be dropped on encrypted connections.
         #[cfg(feature = "tls")]
-        let tls_active = self.tls_config_override.is_some()
-            || config.tls.as_ref().is_some_and(|t| t.enabled);
+        let tls_active =
+            self.tls_config_override.is_some() || config.tls.as_ref().is_some_and(|t| t.enabled);
         #[cfg(not(feature = "tls"))]
         let tls_active = false;
 
@@ -1477,9 +1456,8 @@ where
         // "POST /api/v1/uploads" match as documented.
         #[cfg(feature = "governor")]
         if config.rate_limit.auto_apply {
-            let gov = crate::middleware::governor::GovernorRateLimit::new(
-                config.rate_limit.clone(),
-            );
+            let gov =
+                crate::middleware::governor::GovernorRateLimit::new(config.rate_limit.clone());
             tracing::debug!("Auto-applying governor rate-limit middleware");
             app = app.layer(axum::middleware::from_fn_with_state(
                 gov,
@@ -1571,8 +1549,7 @@ where
             app = app.layer(axum::Extension(logger.clone()));
         }
 
-        let listener_addr =
-            std::net::SocketAddr::new(config.service.bind, config.service.port);
+        let listener_addr = std::net::SocketAddr::new(config.service.bind, config.service.port);
 
         // Resolve the HTTP TLS config. A `[tls]` section with `enabled = true`
         // is the operator's explicit statement of intended posture, so a load
@@ -2297,8 +2274,8 @@ where
                             self.app
                                 .into_make_service_with_connect_info::<std::net::SocketAddr>(),
                         )
-                            .with_graceful_shutdown(shutdown_signal())
-                            .await;
+                        .with_graceful_shutdown(shutdown_signal())
+                        .await;
 
                         // Wait for gRPC server
                         let _ = grpc_handle.await;
@@ -2349,12 +2326,11 @@ where
 
                         axum::serve(
                             listener,
-                            hybrid_service.into_make_service_with_connect_info::<
-                                std::net::SocketAddr,
-                            >(),
+                            hybrid_service
+                                .into_make_service_with_connect_info::<std::net::SocketAddr>(),
                         )
-                            .with_graceful_shutdown(shutdown_signal())
-                            .await?;
+                        .with_graceful_shutdown(shutdown_signal())
+                        .await?;
                     }
 
                     tracing::info!("Server shutdown complete");
@@ -2390,8 +2366,8 @@ where
                 self.app
                     .into_make_service_with_connect_info::<crate::tls::TlsConnectInfo>(),
             )
-                .with_graceful_shutdown(shutdown_signal())
-                .await?;
+            .with_graceful_shutdown(shutdown_signal())
+            .await?;
 
             tracing::info!("Server shutdown complete");
 
@@ -2411,8 +2387,8 @@ where
             self.app
                 .into_make_service_with_connect_info::<std::net::SocketAddr>(),
         )
-            .with_graceful_shutdown(shutdown_signal())
-            .await?;
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
 
         tracing::info!("Server shutdown complete");
 
@@ -2502,9 +2478,7 @@ mod tests {
         use crate::prelude::ServiceBuilder;
 
         let config = Config::<()>::default();
-        let service = ServiceBuilder::new()
-            .with_config(config)
-            .build();
+        let service = ServiceBuilder::new().with_config(config).build();
 
         // state() should be accessible and background_worker() returns None
         // when not configured
@@ -2550,7 +2524,9 @@ mod tests {
 
         let message = error.to_string();
         assert!(
-            message.contains("refusing to start rather than serving routes without policy enforcement"),
+            message.contains(
+                "refusing to start rather than serving routes without policy enforcement"
+            ),
             "error must explain the refusal, got: {message}"
         );
     }
@@ -2683,7 +2659,10 @@ mod tests {
         };
 
         assert!(
-            ServiceBuilder::new().with_config(config).try_build().is_ok(),
+            ServiceBuilder::new()
+                .with_config(config)
+                .try_build()
+                .is_ok(),
             "an explicitly disabled TLS section must not block startup"
         );
     }
@@ -2985,9 +2964,7 @@ mod tests {
             .expect("health request");
 
         assert!(
-            response
-                .headers()
-                .contains_key("strict-transport-security"),
+            response.headers().contains_key("strict-transport-security"),
             "HSTS must be sent when an injected config puts the listener on TLS"
         );
     }

--- a/acton-service/src/state.rs
+++ b/acton-service/src/state.rs
@@ -412,7 +412,7 @@ where
     /// Get the [`ActorHandle`] for a registered actor extension.
     ///
     /// Actor extensions are custom actors registered via
-    /// [`ServiceBuilder::with_actor`](crate::ServiceBuilder::with_actor).
+    /// [`ServiceBuilder::with_actor`](crate::service_builder::ServiceBuilder::with_actor).
     /// They run under a framework-managed supervisor with configurable restart policies.
     ///
     /// # Example

--- a/acton-service/src/state.rs
+++ b/acton-service/src/state.rs
@@ -556,8 +556,7 @@ where
         if self.clickhouse().await.is_some() {
             if let Some(ch_config) = &self.config.clickhouse {
                 summary.clickhouse = Some(crate::pool_health::ClickHouseHealth::from_config(
-                    ch_config,
-                    true, // connected
+                    ch_config, true, // connected
                 ));
             }
         }
@@ -934,8 +933,7 @@ mod tests {
         #[tokio::test]
         async fn test_clickhouse_state_survives_clone() {
             let mut state = AppState::<()>::default();
-            let client = clickhouse::Client::default()
-                .with_url("http://localhost:8123");
+            let client = clickhouse::Client::default().with_url("http://localhost:8123");
             let storage = std::sync::Arc::new(tokio::sync::RwLock::new(Some(client)));
             state.set_clickhouse_client_storage(storage);
 

--- a/acton-service/tests/governor_integration.rs
+++ b/acton-service/tests/governor_integration.rs
@@ -37,10 +37,7 @@ fn build_app(config: RateLimitConfig, auto_apply: bool) -> Router {
 
     if auto_apply {
         let gov = GovernorRateLimit::new(config);
-        app.layer(from_fn_with_state(
-            gov,
-            GovernorRateLimit::middleware,
-        ))
+        app.layer(from_fn_with_state(gov, GovernorRateLimit::middleware))
     } else {
         app
     }

--- a/acton-service/tests/resilience_router.rs
+++ b/acton-service/tests/resilience_router.rs
@@ -61,10 +61,7 @@ async fn healthy_router_passes_requests_through() {
 #[tokio::test]
 async fn breaker_opens_after_sustained_5xx() {
     let app = apply_resilience(
-        Router::new().route(
-            "/boom",
-            get(|| async { StatusCode::INTERNAL_SERVER_ERROR }),
-        ),
+        Router::new().route("/boom", get(|| async { StatusCode::INTERNAL_SERVER_ERROR })),
         &trip_fast_config(),
     );
 


### PR DESCRIPTION
Repo hygiene only. **No behaviour changes** — no logic, no public API, no config, no dependency, and no version fields touched.

Split out of #68, which deliberately left these alone to stay reviewable.

## Two commits, deliberately separate

**1. `docs: fix broken intra-doc links`** (6 files, +15/−11)

Takes `cargo doc` from 12 rustdoc warnings to zero. Nearly all were links assuming a crate-root re-export that does not exist: `ServiceBuilder`, `AppState`, and `ActorExtension` are only re-exported through the `prelude` module, so `crate::ServiceBuilder` never resolved. Fixed to full module paths (`crate::service_builder::ServiceBuilder`, `crate::state::AppState`, `crate::versioning::ApiVersion`, `acton_reactive::prelude::RestartPolicy`).

Two judgement calls worth a look:

- `audit/storage/mod.rs` linked public docs to the **private** `lazy::LazyAuditStorage`. Rather than widen visibility just to satisfy a doc link, the reference became descriptive prose: "Lazily-resolved backends (those built from a pool that connects in the background)". No documentation was dropped.
- In `key_metadata.rs`, `Display` needed an explicit `std::fmt::Display` target but `FromStr` is left bare — it is already in scope, and qualifying it produced *new* `redundant explicit link target` warnings. The asymmetry is intentional.

**2. `style: apply rustfmt across the workspace`** (37 files, +237/−213)

Pure `cargo fmt --all` output, no hand edits. Kept as its own commit so the mechanical churn does not bury the doc fixes above — review commit 1 on its own and commit 2 can be taken on faith from `cargo fmt --all --check`.

## Verification

| Gate | Before | After |
|---|---|---|
| `cargo fmt --all --check` | 37 files differ | clean |
| `cargo doc --no-deps --features full` | 12 warnings | 0 |
| `cargo clippy --features full --all-targets -- -D warnings` | clean | clean |
| `cargo nextest run --features full` | 691 passed | 691 passed |

Zero new `allow(clippy::…)` directives; the 6 pre-existing ones are untouched.

Note that the remaining `warning: acton-service@0.29.0: Compiled ping.proto …` lines in build output are build-script `cargo:warning` messages, not lints or rustdoc warnings, and are unaffected by this PR.