### PR TITLE
ci: skip the Rust matrix for changes that cannot affect the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,12 @@ jobs:
           EVENT: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Author-controlled text. Kept in the environment and never
+          # interpolated into the script, so a title like `"; rm -rf / #` is
+          # inert data rather than a command.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          ASSOCIATION: ${{ github.event.pull_request.author_association }}
         run: |
           set -euo pipefail
 
@@ -39,6 +45,32 @@ jobs:
             echo "Event '$EVENT' is not a pull request; running the full matrix."
             echo "code=true" >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+
+          marker=$(printf '%s\n%s' "$PR_TITLE" "$PR_BODY")
+
+          # `[full-ci]` is checked first so that forcing the matrix ON always
+          # beats forcing it off. The safe override wins ties.
+          if printf '%s' "$marker" | grep -qF '[full-ci]'; then
+            echo "Found [full-ci]; running the full matrix regardless of paths."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if printf '%s' "$marker" | grep -qF '[skip-matrix]'; then
+            # Skipping is a CI bypass, so it is limited to people who already
+            # have write access. For anyone else the marker is ignored rather
+            # than honoured, and the normal path rules decide.
+            case "$ASSOCIATION" in
+              OWNER|MEMBER|COLLABORATOR)
+                echo "Found [skip-matrix] from $ASSOCIATION; skipping the Rust matrix."
+                echo "code=false" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+              *)
+                echo "::warning::Ignoring [skip-matrix] from $ASSOCIATION -- write access is required to skip CI."
+                ;;
+            esac
           fi
 
           files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,66 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Changes that cannot affect compilation or test behaviour do not need the
+  # Rust matrix. Note that skipping a job makes its check disappear entirely
+  # rather than report success, and a required check that never reports blocks
+  # a PR forever -- so the single required check is `ci-gate` below, which
+  # always runs, and never these jobs directly.
+  changes:
+    name: detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.detect.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect whether any code changed
+        id: detect
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Only pull requests have a well-defined diff to inspect. Pushes to
+          # main and manual dispatches always run the full matrix.
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "Event '$EVENT' is not a pull request; running the full matrix."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "Changed files:"
+          echo "$files" | sed 's/^/  /'
+
+          # Anything not matched here counts as code and runs the matrix, so a
+          # new top-level directory fails safe by being tested. build.yml is
+          # deliberately absent from this list: a change to the build matrix
+          # should be exercised by the build matrix.
+          remaining=$(echo "$files" | grep -vE \
+            -e '^acton-docs/' \
+            -e '^[^/]*\.md$' \
+            -e '^\.remember/' \
+            -e '^LICENSE' \
+            -e '^\.gitignore$' \
+            -e '^\.github/(ISSUE_TEMPLATE/|PULL_REQUEST_TEMPLATE|dependabot\.yml|workflows/(claude|claude-code-review|deploy-docs|docs-sync-on-merge)\.yml)' \
+            || true)
+
+          if [ -z "$remaining" ]; then
+            echo "No code changed; skipping the Rust matrix."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Code changed; running the Rust matrix."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          fi
+
   aws-lc-rs:
     name: crypto-aws-lc-rs (default)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +91,8 @@ jobs:
 
   ring:
     name: crypto-ring (opt-in)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -58,6 +118,8 @@ jobs:
   # tests here are pure unit tests — no live services required.
   audit-storage:
     name: audit storage (${{ matrix.backend }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -80,3 +142,27 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: Nextest
         run: cargo nextest run -p acton-service ${{ matrix.features }}
+
+  # The single required status check. This always runs, so it always reports a
+  # conclusion -- including on documentation-only pull requests where every
+  # matrix job is skipped. Requiring the matrix jobs directly would deadlock
+  # those PRs, because a skipped job reports nothing at all.
+  ci-gate:
+    name: ci-gate
+    needs: [changes, aws-lc-rs, ring, audit-storage]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no required job failed
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$RESULTS"
+          # 'skipped' is a pass: it means this PR touched no code. Only real
+          # failures and cancellations block the merge.
+          if echo "$RESULTS" | grep -qE '"result": "(failure|cancelled)"'; then
+            echo "::error::A required build job failed or was cancelled."
+            exit 1
+          fi
+          echo "All required build jobs passed or were legitimately skipped."


### PR DESCRIPTION
## Why

Docs- and workflow-only PRs were running the full crypto + audit-storage matrix. PR #74 changed one workflow file and burned five jobs (~4m each) to prove nothing — the change never reaches the compiler.

## How

A `changes` job diffs the PR and classifies it; the matrix jobs gain `if: needs.changes.outputs.code == 'true'`.

Skipped as non-code: `acton-docs/**`, root-level `*.md`, `.remember/**`, `LICENSE*`, `.gitignore`, and the non-build workflows.

Two deliberate fail-safe choices:

- **`build.yml` is NOT in the skip list.** A change to the build matrix should be exercised by the build matrix.
- **Markdown is skipped only at the repo root.** Nothing uses `include_str!` on a `.md` today, but if someone later adds `#![doc = include_str!("../src/guide.md")]`, a broken doc-include fails the build — so deeper markdown still runs the matrix.

Anything unrecognised counts as code, so a new top-level directory fails safe by being tested.

## The `ci-gate` job — read before enabling branch protection

Skipping a job makes its status check **disappear entirely** rather than report success, and a required check that never reports leaves a PR pending forever. Requiring the five matrix jobs directly would therefore deadlock exactly the docs-only PRs that #74's automation generates.

`ci-gate` always runs, so it always reports. It treats `skipped` as a pass and fails on `failure`/`cancelled`.

**When enabling branch protection, require only `ci-gate` — not the matrix jobs.**

## Verification

Path classification was tested against 13 cases before commit, covering docs-only, mixed docs+Rust, `build.yml` self-test, auto-sync docs PRs, and the doc-include risk. All pass.

This PR touches only `build.yml`, so it self-tests: the matrix should **run** here, not skip.