### PR TITLE
fix(ci): give the docs sync enough turns and tools to finish

### DIFF
--- a/.github/workflows/docs-sync-on-merge.yml
+++ b/.github/workflows/docs-sync-on-merge.yml
@@ -83,9 +83,14 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
+          # Reviewing a diff against 56 documentation pages takes real
+          # exploration: a 40-turn budget was exhausted mid-edit, after the
+          # model had already written changes but before it could open a pull
+          # request. The read-only shell utilities are listed explicitly
+          # because anything missing is denied, and each denial burns a turn.
           claude_args: |
-            --allowedTools "Bash(gh:*),Bash(git:*),Bash(rg:*),Bash(ls:*),Bash(cat:*),Read,Edit,Write,Glob,Grep"
-            --max-turns 40
+            --allowedTools "Bash(gh:*),Bash(git:*),Bash(rg:*),Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sed:*),Bash(sort:*),Bash(uniq:*),Bash(cut:*),Bash(tr:*),Bash(test:*),Read,Edit,Write,Glob,Grep,TodoWrite"
+            --max-turns 150
           prompt: |
             A pull request just merged into `main` of Govcraft/acton-service.
             Your job is to bring the documentation site in `acton-docs/` back in
@@ -135,6 +140,18 @@ jobs:
             version in the root `Cargo.toml`. Do not bump versions speculatively.
 
             ## Step 3 -- ship the changes
+
+            Work within a finite turn budget. Survey efficiently: prefer a few
+            targeted greps over reading pages end to end, and stop searching
+            once you can justify the edits you intend to make. Editing a
+            handful of genuinely affected pages beats an exhaustive survey that
+            never reaches this step.
+
+            As soon as you have made your edits, commit, push, and open the
+            pull request BEFORE looking for anything further to improve. A run
+            that ends with edits on disk and no pull request has thrown all of
+            its work away. If more remains afterwards, say so in the PR body
+            rather than delaying the PR.
 
             Only if you actually edited files:
 


### PR DESCRIPTION
## What went wrong

First live run of the docs sync (manual dispatch against #71, a real mTLS code change) **failed**: [run 29767522164](https://github.com/Govcraft/acton-service/actions/runs/29767522164).

```
"permission_denials_count": 3
##[error]Execution failed: Reached maximum number of turns (40)
```

It was not stuck — it was working. Tool usage at the wall: 20 Bash, 7 Read, 4 Grep, 4 Glob, **4 Edit, 4 Write**. It had already written documentation changes and was cut off before `gh pr create`, so everything it did was discarded. Cost $1.90 to produce nothing.

## Fixes

1. **`--max-turns` 40 → 150.** Reviewing a diff against 56 Markdoc pages needs real exploration.
2. **Wider `--allowedTools`.** Anything not on the allowlist is denied, and each denial burns a turn. Added the read-only utilities (`find`, `head`, `tail`, `wc`, `sed`, `sort`, `uniq`, `cut`, `tr`, `test`) plus `TodoWrite`.
3. **Ship-before-polish.** The prompt now says to commit, push, and open the PR as soon as edits exist, rather than continuing to look for more work. A run ending with edits on disk and no PR throws all its work away.

## Incidental finding

The action's teardown calls `DELETE /installation/token`, which confirms it mints a **GitHub App installation token** rather than using the default `GITHUB_TOKEN`. That is the good case: App-created PRs *do* trigger workflows, so `ci-gate` should report on the generated docs PR and auto-merge should fire. Still to be confirmed by an actual generated PR.

## Cost note

At 150 turns a docs-sync run could plausibly cost ~$3-6 per merged code PR. Worth watching before leaving this on indefinitely.