### PR TITLE
ci: apply path filtering to main pushes as well as pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,44 +36,67 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.event.after }}
+          PUSH_FORCED: ${{ github.event.forced }}
         run: |
           set -euo pipefail
 
-          # Only pull requests have a well-defined diff to inspect. Pushes to
-          # main and manual dispatches always run the full matrix.
-          if [ "$EVENT" != "pull_request" ]; then
+          # Branch protection does not require pull requests to be up to date
+          # with main before merging, so this push build is the safety net that
+          # catches two independently-green pull requests conflicting once
+          # combined. It is worth keeping, but only when code actually landed:
+          # a documentation merge would otherwise skip the matrix on the pull
+          # request and then run it in full here anyway.
+          if [ "$EVENT" = "push" ]; then
+            # A forced push or a brand-new branch has no usable previous commit
+            # to diff against, so fall back to running everything.
+            if [ "$PUSH_FORCED" = "true" ] || [ "$PUSH_BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              echo "Push has no reliable base to diff against; running the full matrix."
+              echo "code=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            files=$(git diff --name-only "$PUSH_BEFORE" "$PUSH_AFTER")
+          elif [ "$EVENT" != "pull_request" ]; then
+            # Manual dispatch is an explicit request to test everything.
             echo "Event '$EVENT' is not a pull request; running the full matrix."
             echo "code=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          marker=$(printf '%s\n%s' "$PR_TITLE" "$PR_BODY")
+          # The override markers live in the pull request title and body, so
+          # they only apply to pull requests. A push has already been through
+          # whatever the pull request decided.
+          if [ "$EVENT" = "pull_request" ]; then
+            marker=$(printf '%s\n%s' "$PR_TITLE" "$PR_BODY")
 
-          # `[full-ci]` is checked first so that forcing the matrix ON always
-          # beats forcing it off. The safe override wins ties.
-          if printf '%s' "$marker" | grep -qF '[full-ci]'; then
-            echo "Found [full-ci]; running the full matrix regardless of paths."
-            echo "code=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            # `[full-ci]` is checked first so that forcing the matrix ON always
+            # beats forcing it off. The safe override wins ties.
+            if printf '%s' "$marker" | grep -qF '[full-ci]'; then
+              echo "Found [full-ci]; running the full matrix regardless of paths."
+              echo "code=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            if printf '%s' "$marker" | grep -qF '[skip-matrix]'; then
+              # Skipping is a CI bypass, so it is limited to people who already
+              # have write access. For anyone else the marker is ignored rather
+              # than honoured, and the normal path rules decide.
+              case "$ASSOCIATION" in
+                OWNER|MEMBER|COLLABORATOR)
+                  echo "Found [skip-matrix] from $ASSOCIATION; skipping the Rust matrix."
+                  echo "code=false" >> "$GITHUB_OUTPUT"
+                  exit 0
+                  ;;
+                *)
+                  echo "::warning::Ignoring [skip-matrix] from $ASSOCIATION -- write access is required to skip CI."
+                  ;;
+              esac
+            fi
+
+            files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
           fi
 
-          if printf '%s' "$marker" | grep -qF '[skip-matrix]'; then
-            # Skipping is a CI bypass, so it is limited to people who already
-            # have write access. For anyone else the marker is ignored rather
-            # than honoured, and the normal path rules decide.
-            case "$ASSOCIATION" in
-              OWNER|MEMBER|COLLABORATOR)
-                echo "Found [skip-matrix] from $ASSOCIATION; skipping the Rust matrix."
-                echo "code=false" >> "$GITHUB_OUTPUT"
-                exit 0
-                ;;
-              *)
-                echo "::warning::Ignoring [skip-matrix] from $ASSOCIATION -- write access is required to skip CI."
-                ;;
-            esac
-          fi
-
-          files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
           echo "Changed files:"
           echo "$files" | sed 's/^/  /'
 


### PR DESCRIPTION
## The gap

Spotted after #79: every merge starts a second `Build & Test` run via the pre-existing `push: branches: [main]` trigger, and that run ignored the path filter because `changes` forced `code=true` for any non-PR event.

Net effect on the docs automation: #78 changed **one Markdoc page**, correctly skipped the matrix on the PR, then ran all five matrix jobs on the push to `main`. The saving was undone at the last step.

```
18:35:53 pull_request  docs/auto-sync-pr-71  -> matrix SKIPPED
18:36:11 push main     "docs: sync ... (#78)" -> matrix RAN IN FULL
```

## Why not just delete the push trigger

Branch protection uses `strict: false`, so PRs may merge without being up to date with `main`. The push build is the only thing that catches two independently-green PRs that conflict once combined. Keeping it, filtering it.

## Change

Push events now diff `github.event.before..after` through the same path rules. A forced push or a new branch (all-zero `before`) has no usable base and still runs everything.

Also fixes a latent bug introduced alongside it: the PR-range `git diff` ran unconditionally and would have clobbered the push range — and with empty PR SHAs it fails outright under `set -e`. The marker logic and PR diff are now scoped to `pull_request` events, where the title and body actually exist.

## Verification

The `detect` script was extracted from this workflow and run against a purpose-built git repo — real commits, real diffs, not mocks. 13 cases:

**Push (6):** docs-only → skip · rust → run · claude-workflow-only → skip · forced → run · new-branch/zero-SHA → run · dispatch → run

**PR regression (7):** docs-only → skip · rust → run · `[skip-matrix]` OWNER → skip · `[skip-matrix]` outsider → run · `[full-ci]` on docs → run · both markers → run · `"; rm -rf / #` title → run

All pass. This PR touches `build.yml`, which is deliberately excluded from the skip list, so it self-tests: the matrix should **run** here.