### PR TITLE
docs: list arc-swap among the tls feature dependencies

### DIFF
--- a/acton-docs/src/app/docs/feature-flags/page.md
+++ b/acton-docs/src/app/docs/feature-flags/page.md
@@ -692,7 +692,7 @@ Rustls-based HTTPS listener for terminating TLS directly in the service, plus a
 **When to use**: Serving HTTPS without a TLS-terminating proxy in front, and/or
 calling peers that require mutual TLS
 
-**Dependencies**: tokio-rustls, rustls-pki-types, zeroize, webpki-roots
+**Dependencies**: tokio-rustls, rustls-pki-types, arc-swap, zeroize, webpki-roots
 
 **Provides**:
 - TLS-enabled server listener


### PR DESCRIPTION
Found while spot-checking the output of the automated docs sync (#78).

`acton-service/Cargo.toml`:

```toml
tls = ["dep:tokio-rustls", "dep:rustls-pki-types", "dep:arc-swap", "dep:zeroize", "dep:webpki-roots"]
```

The feature reference listed every dependency except `arc-swap`, which backs the hot-reloadable credential handling. Incomplete rather than wrong, but worth correcting.

Doubles as the first live exercise of the `docs-build` job from #82: this PR touches only `acton-docs/**`, so the Rust matrix should **skip** while `docs build` **runs** and gates the merge.