### PR TITLE
ci: extend the docs sync to cover the root README

### DIFF
--- a/.github/workflows/docs-sync-on-merge.yml
+++ b/.github/workflows/docs-sync-on-merge.yml
@@ -1,6 +1,7 @@
 name: Docs Sync on Merge
 
-# When a PR merges to main, review what changed and update acton-docs to match,
+# When a PR merges to main, review what changed and update the documentation to
+# match -- both the acton-docs site and the root README --
 # shipping the result as its own PR that self-merges once CI is green.
 #
 # Loop guard: this workflow opens PRs, and those PRs merge, which would retrigger
@@ -93,8 +94,9 @@ jobs:
             --max-turns 150
           prompt: |
             A pull request just merged into `main` of Govcraft/acton-service.
-            Your job is to bring the documentation site in `acton-docs/` back in
-            sync with the code, and to do nothing at all if it is already in sync.
+            Your job is to bring the documentation back in sync with the code,
+            and to do nothing at all if it is already in sync. Two surfaces are
+            in scope: the `acton-docs/` site and the root `README.md`.
 
             The merged PR number is ${{ steps.pr.outputs.number }}.
 
@@ -105,8 +107,8 @@ jobs:
                 gh pr view ${{ steps.pr.outputs.number }} --json title,body,files
                 gh pr diff ${{ steps.pr.outputs.number }}
 
-            Ignore changes confined to `acton-docs/**` -- those are documentation
-            edits, not code changes that need documenting.
+            Ignore changes confined to `acton-docs/**` or `README.md` -- those
+            are documentation edits, not code changes that need documenting.
 
             ## Step 2 -- decide whether docs need updating
 
@@ -119,6 +121,17 @@ jobs:
             Docs do NOT need updating for internal refactors, test-only changes,
             dependency bumps with no user-visible effect, CI or tooling changes, or
             performance work that does not alter any documented contract.
+
+            Check BOTH surfaces against the change. They drift independently
+            and are frequently inconsistent with each other.
+
+            The root `README.md` (about 1000 lines) is the crate's front page on
+            GitHub and crates.io. It carries a feature summary, a quick start, an
+            installation snippet, a feature-flag table, and configuration
+            examples. Unlike the site it hardcodes version numbers rather than
+            using a template, so its `acton-service = "x.y"` snippets go stale
+            silently -- if the merged PR changed the workspace version, update
+            every such snippet.
 
             The documentation site layout:
               - `acton-docs/src/app/docs/<topic>/page.md` -- 56 Markdoc pages
@@ -156,8 +169,8 @@ jobs:
             Only if you actually edited files:
 
                 git checkout -b docs/auto-sync-pr-${{ steps.pr.outputs.number }}
-                git add acton-docs
-                git commit -m "docs: sync acton-docs with #${{ steps.pr.outputs.number }}"
+                git add acton-docs README.md
+                git commit -m "docs: sync docs and README with #${{ steps.pr.outputs.number }}"
                 git push -u origin docs/auto-sync-pr-${{ steps.pr.outputs.number }}
 
             The branch name prefix `docs/auto-sync-` is REQUIRED -- it is the loop
@@ -165,7 +178,10 @@ jobs:
             different prefix, and never commit to `main` directly.
 
             Follow the Conventional Commits spec, and stage ONLY paths under
-            `acton-docs/`. Never stage Rust sources, `Cargo.toml`, or workflows.
+            `acton-docs/` plus the root `README.md`. Never stage Rust sources,
+            `Cargo.toml`, or workflows. Use `git add` with those explicit paths
+            rather than `git add -A`, so an unrelated stray file cannot ride
+            along into the pull request.
 
             Then open the PR, explaining what changed in the code and why each doc
             edit follows from it, and linking the source PR:
@@ -173,7 +189,7 @@ jobs:
                 gh pr create \
                   --base main \
                   --head docs/auto-sync-pr-${{ steps.pr.outputs.number }} \
-                  --title "docs: sync acton-docs with #${{ steps.pr.outputs.number }}" \
+                  --title "docs: sync docs and README with #${{ steps.pr.outputs.number }}" \
                   --body "<your explanation here>"
 
             Finally, queue it to merge once CI passes:


### PR DESCRIPTION
## Why

The docs sync keeps `acton-docs/` current but ignores `README.md`, which is the crate's front page on GitHub and crates.io and drifts exactly the same way.

It has already drifted. The README advertises:

```toml
acton-service = "0.27"
```

in **four** places, while the workspace is at **0.29.0**. The site doesn't have this problem because it interpolates `{% version() %}` through a template; the README hardcodes the number, so it rots silently.

## Change

`README.md` becomes a second in-scope surface in the sync prompt, with an explicit note that the two drift independently and are often inconsistent with each other, plus specific guidance to update the version snippets when the merged PR changed the workspace version.

Staging becomes `git add acton-docs README.md` — still an explicit path list rather than `git add -A`, so a stray file cannot ride along into an auto-merging PR.

Commit and PR titles become "sync docs and README with #N". The `docs/auto-sync-` branch prefix is unchanged, since the loop guard depends on it.

## Safety check

`README.md` is **not** doc-included — the only `include_str!` in the tree is an HTML template inside a comment in `htmx/mod.rs`. So README edits cannot break doctests, and the existing rule that root markdown skips the Rust matrix stays sound.

## Related surface, not addressed here

`acton-service/src/lib.rs` carries a large `//!` crate-doc block duplicating the README's feature list and example. It drifts too, and unlike the README its ```rust,no_run blocks are compiled as doctests. Bringing it into scope means letting this workflow edit a `.rs` file, which is a bigger step — flagging it rather than doing it.