### PR TITLE
ci: run doctests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,13 @@ jobs:
         run: cargo clippy -p acton-service --all-targets --features full -- -D warnings
       - name: Nextest
         run: cargo nextest run -p acton-service --features full
+      # nextest does not run doctests, so without this step the examples in the
+      # rustdoc -- including the crate-level block that becomes the docs.rs
+      # front page -- are never compiled by CI. Run once here on the default
+      # crypto provider rather than on every leg: the examples do not vary by
+      # backend, and they add roughly twenty seconds.
+      - name: Doctests
+        run: cargo test --doc -p acton-service --features full
 
   ring:
     name: crypto-ring (opt-in)


### PR DESCRIPTION
## Gap

All three test legs use `cargo nextest run`, and **nextest does not run doctests**. The crate has:

```
test result: ok. 104 passed; 0 failed; 142 ignored
```

None of those 104 have ever run in CI. That includes the crate-level `//!` block in `acton-service/src/lib.rs`, which is the front page on docs.rs.

They pass today — verified locally against current `main` — so this adds coverage rather than fixing a break.

## Change

One `cargo test --doc -p acton-service --features full` step on the `crypto-aws-lc-rs` leg. Not on every leg: the examples don't vary by crypto backend, and it costs ~20s.

## Why now

Prerequisite for extending the docs-sync automation to maintain the `lib.rs` crate docs. That automation auto-merges without a human reading the diff, so an unrunnable example must fail CI rather than land silently on docs.rs.