### PR TITLE
docs: correct and extend the crate-level rustdoc

### DIFF
--- a/acton-service/src/lib.rs
+++ b/acton-service/src/lib.rs
@@ -6,10 +6,13 @@
 //! ## Features
 //!
 //! - **Multi-protocol**: HTTP (axum) + gRPC (tonic) + WebSocket on single port
-//! - **Middleware stack**: JWT auth, rate limiting, request tracking, panic recovery, body size limits
+//! - **Middleware stack**: PASETO v4 or JWT token auth, rate limiting, request tracking, panic recovery, body size limits
+//! - **Authorization**: Cedar policy engine across HTTP, gRPC, and GraphQL
 //! - **Resilience**: Circuit breaker, retry with backoff, bulkhead (concurrency limiting)
 //! - **Observability**: OpenTelemetry tracing, HTTP metrics, request ID propagation
-//! - **Connection pooling**: Database (YSQL), Redis, NATS JetStream
+//! - **Audit logging**: BLAKE3 hash-chained trails over PostgreSQL, Turso, SurrealDB, or ClickHouse
+//! - **TLS**: rustls listener with mutual TLS and restart-free credential rotation
+//! - **Connection pooling**: PostgreSQL, Redis, NATS JetStream
 //! - **Health checks**: Liveness and readiness probes
 //! - **Graceful shutdown**: Proper signal handling (SIGTERM, SIGINT)
 //!


### PR DESCRIPTION
Found while wiring the crate docs into the sync automation (#87).

## Two factual errors on the docs.rs front page

| Claim | Reality |
|---|---|
| `Connection pooling: Database (YSQL)` | `database = ["dep:sqlx"]`, and sqlx is built with the `postgres` feature. `YSQL` appears nowhere else in the crate. |
| `Middleware stack: JWT auth` | PASETO v4 is the default token format; JWT is opt-in behind the `jwt` feature. |

## Three subsystems the summary never picked up

Cedar authorization, BLAKE3 audit logging, and TLS/mTLS — all shipped, all absent from the front page.

## Verification

- Every changed line begins with `//!`; no code touched. Checked mechanically:
  ```
  git diff -U0 -- acton-service/src/lib.rs | grep '^[+-]' | grep -v '^[+-]//!'   # empty
  ```
- `cargo test --doc -p acton-service --features full` → 104 passed, 0 failed.

This is the same constraint the automation is now instructed to follow, applied by hand. Because it touches a `.rs` file, this PR runs the full matrix rather than the docs-only path — which is the intended behavior for crate-doc changes.