### PR TITLE
chore(release): prepare 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [acton-service-v0.30.0] - 2026-07-20
+
+The mutual-TLS release: inbound client-certificate verification, an outbound
+client identity, and in-place rotation of every credential the framework
+touches — server certificates, client identities, and the trust anchors both
+are verified against — with no socket rebind, no connection-pool loss, and no
+restart. There are no breaking changes; every addition is opt-in.
+
+### Added
+
+- **tls**: Optional client-certificate verification for inbound TLS. Setting
+  `client_ca_path` on `[tls]` or `[grpc.tls]` verifies peers against that CA
+  bundle with `WebPkiClientVerifier`; `client_auth_optional = true` admits
+  connections without a certificate while still rejecting invalid ones.
+  Verified peer certificates reach handlers through the new `TlsConnectInfo`
+  connect-info type, which also gives TLS listeners a real remote address for
+  the first time. Absent a CA bundle, behaviour is unchanged. (#68)
+- **tls**: `TlsConfigSource`, an `ArcSwap`-backed server-credential handle
+  read per handshake, so `reload()` installs rotated certificates without
+  rebinding the socket. Installed via `with_tls_config_source` /
+  `with_grpc_tls_config_source`; the existing setters keep their signatures
+  as static sources. Reload is fail-closed: a failed read keeps the
+  last-good credentials serving, logs at ERROR, and returns the error. (#68)
+- **tls**: Four ways to trigger a server-credential reload, layered on one
+  shared implementation: `ServiceBuilder::with_tls_reload(hook)` hands the
+  hook a `TlsReloadHandle` over every reloadable source;
+  `ActonService::tls_config_source()` / `grpc_tls_config_source()` are
+  unopinionated accessors for callers whose lifecycle does not fit a
+  callback; `reload_interval_secs` opts into a poll that fingerprints file
+  contents (never mtimes, which `cp -p` preserves) and reloads only on
+  change, with failed ticks keeping the baseline so half-written
+  certificates self-heal; and `reload_on_sighup` reloads every reloadable
+  source from one Unix signal handler, without touching the SIGINT/SIGTERM
+  shutdown path. The standalone `Server::serve` path builds a reloadable
+  source and installs the same config-driven triggers. When `[grpc.tls]` is
+  absent the gRPC listener shares the `[tls]` source, and the handle
+  deduplicates that case (`TlsConfigSource::ptr_eq` is public). (#79)
+- **client-tls**: A client-side mutual-TLS identity for outbound calls, the
+  outbound mirror of `[tls]`. `ClientIdentityConfig` names the certificate,
+  key, and optional peer-CA bundle (`root_ca_path`, additive to the webpki
+  roots unless `exclusive_roots` pins trust to the bundle alone), and the
+  new `client_tls` module turns it into a rustls `ClientConfig`, a
+  `reqwest::Identity` or `ClientBuilder`, or a tonic `ClientTlsConfig`.
+  Every entry point validates eagerly — including an explicit `keys_match`
+  check — so a parseable-but-mismatched pair fails at configuration time
+  rather than on the first live handshake, and the concatenated PEM buffer
+  reqwest requires is zeroized on drop. (#71)
+- **client-tls**: `ClientIdentitySource`, a rotatable outbound identity that
+  swaps in place: rustls consults a `ResolvesClientCert` resolver once per
+  handshake, so `reload()` is a pointer store and nothing above the TLS
+  layer is rebuilt. `client()` returns one stable `reqwest::Client` for the
+  source's lifetime — caching it is correct, the connection pool survives a
+  rotation, and `grpc_channel(Endpoint)` builds a tonic channel that rotates
+  the same way. A reload rereads everything the config names, identity and
+  peer trust anchors together, all-or-nothing: a new certificate alongside
+  an unreadable CA bundle installs neither, and any failure keeps the
+  last-good credentials, logs at ERROR, and returns the error. (#71, #90)
+
 ## [acton-service-v0.29.0] - 2026-07-19
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "acton-cli"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "acton-service",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["acton-service", "acton-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 authors = ["roland@govcraft.ai"]
 license = "MIT"

--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-acton-service = { path = "../acton-service", version = "0.29.0" }
+acton-service = { path = "../acton-service", version = "0.30.0" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/acton-docs/src/lib/version.ts
+++ b/acton-docs/src/lib/version.ts
@@ -2,4 +2,4 @@
  * Version information for acton-service
  * This should match the version in the root Cargo.toml workspace.package.version
  */
-export const VERSION = '0.29.0'
+export const VERSION = '0.30.0'

--- a/acton-docs/src/markdoc/config.js
+++ b/acton-docs/src/markdoc/config.js
@@ -4,7 +4,7 @@ import { siteConfig } from '../lib/config'
 
 // Extract version from workspace Cargo.toml
 // This should be kept in sync with the workspace version
-const ACTON_VERSION = '0.29.0'
+const ACTON_VERSION = '0.30.0'
 
 // Single source of truth mapping camelCase aliases to the real Cargo feature
 // lists. Used by both the `dep()` function and the `$dep.*` variables so a

--- a/acton-docs/src/markdoc/functions.js
+++ b/acton-docs/src/markdoc/functions.js
@@ -1,5 +1,5 @@
 // Markdoc functions for version management
-const ACTON_VERSION = '0.29.0'
+const ACTON_VERSION = '0.30.0'
 
 export const version = {
   transform() {


### PR DESCRIPTION
Release prep for **0.30.0** — the mutual-TLS release. No breaking changes; every addition is opt-in.

Ships #68 (inbound client-certificate verification, `TlsConnectInfo`, `TlsConfigSource`), #79 (four reload triggers over one shared installer, standalone `Server` included), #71 (outbound client identity helpers, eager validation), and #90 (in-place per-handshake client rotation, rotating gRPC channels).

- Workspace version 0.29.0 → 0.30.0
- CHANGELOG entries for the four feature PRs under `acton-service-v0.30.0`
- acton-docs version constants synced (`version.ts`, `markdoc/config.js`, `markdoc/functions.js`)

After merge: signed tag `acton-service-v0.30.0` on the merge commit, then `cargo publish -p acton-service`.

https://claude.ai/code/session_01Au1BLmZmaEwjj4vQWfU3Jm