### PR TITLE
fix(tls): move handshake off the accept path + 0.30.0 TLS hardening (#94, #95)

### DIFF
--- a/acton-service/src/client_tls.rs
+++ b/acton-service/src/client_tls.rs
@@ -39,7 +39,7 @@ use tokio_rustls::rustls::client::danger::{
 use tokio_rustls::rustls::client::{ResolvesClientCert, WebPkiServerVerifier};
 use tokio_rustls::rustls::sign::CertifiedKey;
 use tokio_rustls::rustls::{ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme};
-use zeroize::Zeroizing;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::config::ClientIdentityConfig;
 use crate::error::{Error, Result};
@@ -83,6 +83,17 @@ pub(crate) struct IdentityMaterial {
     chain: Vec<CertificateDer<'static>>,
     /// The parsed private key.
     key: PrivateKeyDer<'static>,
+}
+
+impl Drop for IdentityMaterial {
+    fn drop(&mut self) {
+        // The PEM copies are already `Zeroizing`, but the *decoded* DER private
+        // key is not: `rustls_pki_types::PrivateKeyDer` implements `Zeroize` yet
+        // not `ZeroizeOnDrop`, so without this its key bytes would be freed onto
+        // a heap page without being wiped. Wipe it explicitly. `cert_pem` and
+        // `chain` are public certificate material and need no wiping.
+        self.key.zeroize();
+    }
 }
 
 impl std::fmt::Debug for IdentityMaterial {
@@ -808,8 +819,16 @@ impl ClientIdentitySource {
         let origin = &self.inner.origin;
         match self.prepare_reload() {
             Ok((key, verifier)) => {
-                // Both stores happen only after both loads succeeded, so no
-                // observer can see a new certificate paired with stale anchors.
+                // The presented identity and the peer trust anchors live in two
+                // separate `ArcSwap`s, stored one after the other, so a handshake
+                // that runs between these two stores can observe the new
+                // certificate paired with the old anchors (or, after the first
+                // store, the reverse). That is deliberately left unsynchronised:
+                // each value is individually valid, and which certificate this
+                // client presents is orthogonal to which CAs it trusts in the
+                // peer, so any pairing of an old-or-new identity with old-or-new
+                // anchors is a correct handshake. A lock spanning both stores
+                // would buy nothing but contention on the handshake path.
                 self.inner.resolver.store(key);
                 self.inner.verifier.store(verifier);
                 tracing::info!(

--- a/acton-service/src/config.rs
+++ b/acton-service/src/config.rs
@@ -988,6 +988,18 @@ pub struct TlsConfig {
     /// during startup and otherwise ignored.
     #[serde(default = "default_false")]
     pub reload_on_sighup: bool,
+
+    /// Maximum time to wait for a TLS handshake to complete, in seconds, before
+    /// the connection is dropped. Caps pre-handshake stalls from unauthenticated
+    /// peers (a peer that connects but never completes the handshake). `None`
+    /// (the default) uses the built-in default of
+    /// [`DEFAULT_HANDSHAKE_TIMEOUT`](crate::tls::DEFAULT_HANDSHAKE_TIMEOUT)
+    /// seconds.
+    ///
+    /// A value of `0` is rejected at build time: it would fail every handshake
+    /// instantly.
+    #[serde(default)]
+    pub handshake_timeout_secs: Option<u64>,
 }
 
 /// Client-side mutual-TLS identity (requires `tls` feature)

--- a/acton-service/src/config.rs
+++ b/acton-service/src/config.rs
@@ -930,6 +930,13 @@ impl Default for GraphQLConfig {
 /// Certificates are loaded at startup from PEM files.
 #[cfg(feature = "tls")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+// Reject unknown keys in `[tls]` and `[grpc.tls]`. A typo like
+// `reload_interval_sec` (missing the `s`) would otherwise be silently ignored
+// and quietly disarm certificate rotation; deny_unknown_fields turns it into a
+// loud parse error at startup instead. Safe here because `TlsConfig` is embedded
+// as a plain `Option<TlsConfig>`, never `#[serde(flatten)]`ed (which is the one
+// case that would misbehave with this attribute).
+#[serde(deny_unknown_fields)]
 pub struct TlsConfig {
     /// Enable TLS (default: true when section is present)
     #[serde(default = "default_true")]
@@ -1849,6 +1856,28 @@ mod tests {
         assert!(
             tls.client_auth_optional,
             "the optional client-auth flag must round-trip from configuration"
+        );
+    }
+
+    /// A typo in a `[tls]` key must fail to parse rather than be silently
+    /// ignored: `reload_interval_sec` (missing the trailing `s`) would otherwise
+    /// quietly disarm certificate rotation. `deny_unknown_fields` turns it into a
+    /// startup error.
+    #[cfg(feature = "tls")]
+    #[test]
+    fn tls_config_rejects_an_unknown_field() {
+        let json = r#"{
+            "enabled": true,
+            "cert_path": "/etc/tls/cert.pem",
+            "key_path": "/etc/tls/key.pem",
+            "reload_interval_sec": 300
+        }"#;
+
+        let err = serde_json::from_str::<TlsConfig>(json)
+            .expect_err("a misspelled TLS key must be rejected, not silently dropped");
+        assert!(
+            err.to_string().contains("reload_interval_sec"),
+            "the parse error must name the offending key: {err}"
         );
     }
 

--- a/acton-service/src/middleware/governor.rs
+++ b/acton-service/src/middleware/governor.rs
@@ -7,7 +7,7 @@
 use std::time::Duration;
 
 #[cfg(feature = "governor")]
-use std::net::{IpAddr, SocketAddr};
+use std::net::IpAddr;
 #[cfg(feature = "governor")]
 use std::num::NonZeroU32;
 #[cfg(feature = "governor")]
@@ -16,7 +16,7 @@ use std::sync::Arc;
 #[cfg(feature = "governor")]
 use axum::{
     body::Body,
-    extract::{ConnectInfo, OriginalUri, Request, State},
+    extract::{OriginalUri, Request, State},
     http::{header::HeaderValue, HeaderName},
     middleware::Next,
     response::Response,
@@ -220,10 +220,12 @@ impl GovernorRateLimit {
             .unwrap_or_else(|| request.uri().path().to_string());
 
         let claims = request.extensions().get::<Claims>().cloned();
-        let connect_info = request
-            .extensions()
-            .get::<ConnectInfo<SocketAddr>>()
-            .map(|ci| ci.0);
+        // Resolve the peer address from whichever connect-info the listener
+        // installed: `ConnectInfo<SocketAddr>` on plain TCP, or
+        // `ConnectInfo<TlsConnectInfo>` on a directly-terminated TLS listener.
+        // Without the TLS fallback, per-IP rate limiting silently no-ops on a
+        // TLS listener that has no fronting proxy.
+        let connect_info = super::request_context::connect_info_remote_addr(request.extensions());
         let client_ip = extract_client_ip(
             request.headers(),
             connect_info.as_ref(),

--- a/acton-service/src/middleware/request_context.rs
+++ b/acton-service/src/middleware/request_context.rs
@@ -82,10 +82,10 @@ fn header_string(headers: &HeaderMap, name: &str) -> Option<String> {
 /// 1. If `trust_forwarded_headers` is true:
 ///    - The first parseable IP in `X-Forwarded-For` (comma-separated, left-most).
 ///    - The single IP in `X-Real-IP`.
-/// 2. The direct TCP peer from `ConnectInfo<SocketAddr>`.
+/// 2. The direct TCP peer resolved by [`connect_info_remote_addr`], which
+///    covers both plain-TCP and TLS listeners.
 ///
-/// Returns `None` when no IP can be resolved. TLS serve paths do not install
-/// `ConnectInfo`, so the fallback is genuinely optional.
+/// Returns `None` when no IP can be resolved.
 pub(crate) fn extract_client_ip(
     headers: &HeaderMap,
     connect_info: Option<&SocketAddr>,
@@ -111,6 +111,30 @@ pub(crate) fn extract_client_ip(
     }
 
     connect_info.map(|sa| sa.ip())
+}
+
+/// The peer socket address from whichever connect-info the listener installed.
+///
+/// axum populates `ConnectInfo<SocketAddr>` on a plain-TCP listener and
+/// `ConnectInfo<TlsConnectInfo>` on a TLS listener — the latter supersedes the
+/// plain `SocketAddr` so a directly-terminated TLS peer still exposes a real
+/// address. Extractors that only looked for `ConnectInfo<SocketAddr>` therefore
+/// saw nothing on a TLS listener, silently disabling peer-IP rate limiting and
+/// request-context IP resolution unless a fronting proxy set forwarded headers.
+/// Checking both makes those work on direct TLS termination too.
+///
+/// The plain-`SocketAddr` form is checked first: on a non-TLS listener it is the
+/// only one present, and the TLS branch compiles away entirely without the `tls`
+/// feature.
+pub(crate) fn connect_info_remote_addr(extensions: &http::Extensions) -> Option<SocketAddr> {
+    if let Some(connect_info) = extensions.get::<ConnectInfo<SocketAddr>>() {
+        return Some(connect_info.0);
+    }
+    #[cfg(feature = "tls")]
+    if let Some(connect_info) = extensions.get::<ConnectInfo<crate::tls::TlsConnectInfo>>() {
+        return Some(connect_info.0.remote_addr());
+    }
+    None
 }
 
 /// Build an [`AuditSource`](crate::audit::event::AuditSource) from a request,
@@ -152,10 +176,7 @@ pub(crate) fn audit_source_from_headers(headers: &HeaderMap) -> crate::audit::ev
 /// Use with [`axum::middleware::from_fn`]. See the module docs for the ordering
 /// this requires.
 pub async fn request_context_middleware(mut request: Request, next: Next) -> Response {
-    let connect_info = request
-        .extensions()
-        .get::<ConnectInfo<SocketAddr>>()
-        .map(|ci| ci.0);
+    let connect_info = connect_info_remote_addr(request.extensions());
     let context = RequestContext::resolve(request.headers(), connect_info.as_ref());
     request.extensions_mut().insert(context);
     next.run(request).await
@@ -303,6 +324,29 @@ mod tests {
         assert_eq!(
             ctx.ip.map(|ip| ip.to_string()).as_deref(),
             Some("198.51.100.42")
+        );
+    }
+
+    #[test]
+    fn connect_info_remote_addr_reads_the_plain_socket_addr() {
+        let addr = peer([198, 51, 100, 42], 51234);
+        let mut extensions = http::Extensions::new();
+        extensions.insert(ConnectInfo(addr));
+
+        assert_eq!(
+            connect_info_remote_addr(&extensions),
+            Some(addr),
+            "a plain-TCP listener's ConnectInfo<SocketAddr> must be read directly"
+        );
+    }
+
+    #[test]
+    fn connect_info_remote_addr_is_none_without_any_connect_info() {
+        let extensions = http::Extensions::new();
+        assert_eq!(
+            connect_info_remote_addr(&extensions),
+            None,
+            "no connect-info of either kind must resolve to no address"
         );
     }
 

--- a/acton-service/src/server.rs
+++ b/acton-service/src/server.rs
@@ -66,6 +66,15 @@ impl Server {
             None => None,
         };
 
+        // Resolve the handshake timeout the same way: a zero is a refusal to
+        // start, reported before any listener binds. An absent section uses the
+        // built-in default.
+        #[cfg(feature = "tls")]
+        let tls_handshake_timeout = match self.config.tls.as_ref().filter(|t| t.enabled) {
+            Some(tls_cfg) => crate::tls::validate_handshake_timeout(tls_cfg, "[tls]")?,
+            None => crate::tls::DEFAULT_HANDSHAKE_TIMEOUT,
+        };
+
         // Log middleware configuration
         self.log_middleware_config();
 
@@ -154,7 +163,8 @@ impl Server {
                     tls_config.reload_on_sighup,
                 );
 
-                let tls_listener = crate::tls::TlsListener::with_config_source(listener, source);
+                let tls_listener = crate::tls::TlsListener::with_config_source(listener, source)
+                    .with_handshake_timeout(tls_handshake_timeout);
                 tracing::info!("TLS enabled (HTTPS)");
                 axum::serve(
                     tls_listener,
@@ -362,6 +372,7 @@ mod tests {
                 client_auth_optional: false,
                 reload_interval_secs: Some(0),
                 reload_on_sighup: false,
+                handshake_timeout_secs: None,
             }),
             ..Default::default()
         };

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -1751,6 +1751,44 @@ where
             None => None,
         };
 
+        // Resolve the per-listener handshake timeout. Validation happens here,
+        // alongside the reload-interval validation above, so a zero is reported
+        // by `try_build()` / `serve()` before anything binds. A validation
+        // failure records the startup error and falls back to the default so the
+        // remaining build steps have a usable value to carry.
+        #[cfg(feature = "tls")]
+        let tls_handshake_timeout = match config.tls.as_ref().filter(|t| t.enabled) {
+            Some(tls_cfg) => match crate::tls::validate_handshake_timeout(tls_cfg, "[tls]") {
+                Ok(timeout) => timeout,
+                Err(err) => {
+                    tracing::error!("{}", err);
+                    record_startup_error(&mut startup_error, err);
+                    crate::tls::DEFAULT_HANDSHAKE_TIMEOUT
+                }
+            },
+            None => crate::tls::DEFAULT_HANDSHAKE_TIMEOUT,
+        };
+
+        // The gRPC listener's handshake timeout. A present, enabled `[grpc.tls]`
+        // is authoritative; an absent section inherits the HTTP `[tls]` timeout,
+        // mirroring how it inherits the HTTP credentials above. A disabled
+        // section serves plaintext, so its value is never used.
+        #[cfg(all(feature = "grpc", feature = "tls"))]
+        let grpc_tls_handshake_timeout = match config.grpc.as_ref().and_then(|g| g.tls.as_ref()) {
+            Some(grpc_tls) if grpc_tls.enabled => {
+                match crate::tls::validate_handshake_timeout(grpc_tls, "[grpc.tls]") {
+                    Ok(timeout) => timeout,
+                    Err(err) => {
+                        tracing::error!("{}", err);
+                        record_startup_error(&mut startup_error, err);
+                        crate::tls::DEFAULT_HANDSHAKE_TIMEOUT
+                    }
+                }
+            }
+            Some(_) => crate::tls::DEFAULT_HANDSHAKE_TIMEOUT,
+            None => tls_handshake_timeout,
+        };
+
         // Either section asking for SIGHUP installs the one handler that
         // reloads every listener; see `crate::tls::spawn_sighup_reload`.
         #[cfg(feature = "tls")]
@@ -1853,6 +1891,10 @@ where
             tls_reload_interval,
             #[cfg(all(feature = "grpc", feature = "tls"))]
             grpc_tls_reload_interval,
+            #[cfg(feature = "tls")]
+            tls_handshake_timeout,
+            #[cfg(all(feature = "grpc", feature = "tls"))]
+            grpc_tls_handshake_timeout,
             #[cfg(feature = "tls")]
             tls_reload_on_sighup,
             agent_runtime: self.agent_runtime,
@@ -2269,6 +2311,13 @@ where
     /// Validated poll period for the gRPC credentials, from `[grpc.tls]`.
     #[cfg(all(feature = "grpc", feature = "tls"))]
     grpc_tls_reload_interval: Option<std::time::Duration>,
+    /// Validated per-handshake timeout for the HTTP listener, from `[tls]`.
+    #[cfg(feature = "tls")]
+    tls_handshake_timeout: std::time::Duration,
+    /// Validated per-handshake timeout for the separate-port gRPC listener,
+    /// from `[grpc.tls]` (inheriting `[tls]` when that section is absent).
+    #[cfg(all(feature = "grpc", feature = "tls"))]
+    grpc_tls_handshake_timeout: std::time::Duration,
     /// Whether either TLS section asked for `SIGHUP`-driven reloading.
     #[cfg(feature = "tls")]
     tls_reload_on_sighup: bool,
@@ -2496,6 +2545,8 @@ where
                         // per-listener TLS, falling back to the HTTP TLS config).
                         #[cfg(feature = "tls")]
                         let grpc_tls_config = self.grpc_tls_config.clone();
+                        #[cfg(feature = "tls")]
+                        let grpc_tls_handshake_timeout = self.grpc_tls_handshake_timeout;
 
                         let grpc_handle = tokio::spawn(async move {
                             #[cfg(feature = "tls")]
@@ -2503,7 +2554,8 @@ where
                                 let tls_listener = crate::tls::TlsListener::with_config_source(
                                     grpc_listener,
                                     tls_source.clone(),
-                                );
+                                )
+                                .with_handshake_timeout(grpc_tls_handshake_timeout);
                                 return axum::serve(
                                     tls_listener,
                                     grpc_app.into_make_service_with_connect_info::<
@@ -2527,7 +2579,8 @@ where
                             let tls_listener = crate::tls::TlsListener::with_config_source(
                                 http_listener,
                                 tls_source.clone(),
-                            );
+                            )
+                            .with_handshake_timeout(self.tls_handshake_timeout);
                             tracing::info!("TLS enabled (HTTPS) for both HTTP and gRPC");
                             let http_result = axum::serve(
                                 tls_listener,
@@ -2585,7 +2638,8 @@ where
                             let tls_listener = crate::tls::TlsListener::with_config_source(
                                 listener,
                                 tls_source.clone(),
-                            );
+                            )
+                            .with_handshake_timeout(self.tls_handshake_timeout);
                             tracing::info!("TLS enabled (HTTPS) for hybrid HTTP+gRPC");
                             axum::serve(
                                 tls_listener,
@@ -2642,7 +2696,8 @@ where
         #[cfg(feature = "tls")]
         if let Some(ref tls_source) = self.tls_config {
             let tls_listener =
-                crate::tls::TlsListener::with_config_source(listener, tls_source.clone());
+                crate::tls::TlsListener::with_config_source(listener, tls_source.clone())
+                    .with_handshake_timeout(self.tls_handshake_timeout);
             tracing::info!("TLS enabled (HTTPS)");
             axum::serve(
                 tls_listener,
@@ -2859,6 +2914,7 @@ mod tests {
             client_auth_optional: false,
             reload_interval_secs: None,
             reload_on_sighup: false,
+            handshake_timeout_secs: None,
         }
     }
 
@@ -3124,6 +3180,7 @@ mod tests {
                 client_auth_optional: false,
                 reload_interval_secs: None,
                 reload_on_sighup: false,
+                handshake_timeout_secs: None,
             }),
             ..Default::default()
         };
@@ -3169,6 +3226,7 @@ mod tests {
                 client_auth_optional: false,
                 reload_interval_secs: None,
                 reload_on_sighup: false,
+                handshake_timeout_secs: None,
             }),
             port: 50051,
             reflection_enabled: false,
@@ -3208,6 +3266,7 @@ mod tests {
                 client_auth_optional: false,
                 reload_interval_secs: None,
                 reload_on_sighup: false,
+                handshake_timeout_secs: None,
             }),
             ..Default::default()
         };
@@ -3240,6 +3299,7 @@ mod tests {
                 client_auth_optional: false,
                 reload_interval_secs: None,
                 reload_on_sighup: false,
+                handshake_timeout_secs: None,
             }),
             ..Default::default()
         };
@@ -3473,6 +3533,7 @@ mod tests {
                 client_auth_optional: false,
                 reload_interval_secs: None,
                 reload_on_sighup: false,
+                handshake_timeout_secs: None,
             }),
             ..base
         };

--- a/acton-service/src/tls.rs
+++ b/acton-service/src/tls.rs
@@ -103,6 +103,13 @@ struct TlsConfigSourceInner {
     current: ArcSwap<ServerConfig>,
     /// The file paths a reload rereads. `None` for a static source.
     origin: Option<TlsConfig>,
+    /// A content fingerprint of the credential files as they were when this
+    /// source loaded them, captured at build time. `None` for a static source
+    /// or when the files could not be hashed at load. Seeds the reload poll's
+    /// baseline so a rotation that lands between this load and the poll task
+    /// being spawned is caught on the first tick rather than missed until the
+    /// next rotation.
+    initial_fingerprint: Option<u64>,
 }
 
 impl TlsConfigSource {
@@ -117,6 +124,7 @@ impl TlsConfigSource {
             inner: Arc::new(TlsConfigSourceInner {
                 current: ArcSwap::new(server_config),
                 origin: None,
+                initial_fingerprint: None,
             }),
         }
     }
@@ -128,11 +136,20 @@ impl TlsConfigSource {
     /// so [`reload`](Self::reload) can reread them. Returns the load error if
     /// the initial read fails, leaving no source to serve from.
     pub fn from_tls_config(tls_config: &TlsConfig) -> Result<Self> {
+        // Fingerprint the files *before* loading them, so the recorded baseline
+        // can only be as old as — never newer than — the credentials actually
+        // installed. A rotation during startup then reads as "the files differ
+        // from the baseline" on the first poll tick and is picked up, instead of
+        // being masked by a baseline captured after the rotation. A read failure
+        // here leaves the baseline unset, which makes the first successful tick
+        // reconcile.
+        let initial_fingerprint = fingerprint_credentials(tls_config).ok();
         let server_config = load_server_config(tls_config)?;
         Ok(Self {
             inner: Arc::new(TlsConfigSourceInner {
                 current: ArcSwap::new(server_config),
                 origin: Some(tls_config.clone()),
+                initial_fingerprint,
             }),
         })
     }
@@ -158,6 +175,16 @@ impl TlsConfigSource {
     #[must_use]
     pub fn origin(&self) -> Option<&TlsConfig> {
         self.inner.origin.as_ref()
+    }
+
+    /// The fingerprint of the credential files at the moment this source loaded
+    /// them, captured at build time.
+    ///
+    /// `None` for a static source, or when the files could not be hashed at
+    /// load. Seeds the reload poll's baseline so a rotation between this load and
+    /// the poll task being spawned is detected on the first tick.
+    pub(crate) fn initial_fingerprint(&self) -> Option<u64> {
+        self.inner.initial_fingerprint
     }
 
     /// Whether two handles are clones of the same source.
@@ -517,19 +544,21 @@ pub(crate) fn reload_tick(
 /// The returned task runs until it is aborted. It holds only a clone of the
 /// source, so it never keeps a listener alive.
 ///
-/// The first tick establishes a baseline from the files as they are now, so a
-/// service that starts and never rotates does no reloading at all.
+/// The baseline is the fingerprint the source captured when it *loaded* its
+/// credentials (not when this task spawns), so a rotation that lands during the
+/// rest of startup — after the load, before this task exists — is caught on the
+/// first tick rather than mistaken for the baseline. A service that starts and
+/// never rotates still does no reloading at all.
 pub(crate) fn spawn_reload_poll(
     source: TlsConfigSource,
     listener: TlsListenerKind,
     period: Duration,
 ) -> tokio::task::JoinHandle<()> {
-    // Seed the baseline from the files the source was just built from. A read
-    // failure here leaves it unset, so the first successful tick establishes it
-    // — reloading once, redundantly, rather than missing a rotation.
-    let mut last_seen = source
-        .origin()
-        .and_then(|o| fingerprint_credentials(o).ok());
+    // Seed the baseline from the load-time fingerprint the source recorded. A
+    // source whose files could not be hashed at load carries `None`, so the
+    // first successful tick establishes it — reloading once, redundantly, rather
+    // than missing a rotation.
+    let mut last_seen = source.initial_fingerprint();
 
     tracing::info!(
         listener = listener.as_str(),
@@ -549,9 +578,29 @@ pub(crate) fn spawn_reload_poll(
 
         loop {
             ticker.tick().await;
-            if let ReloadTick::Reloaded { fingerprint } = reload_tick(&source, listener, last_seen)
+            // The tick reads and hashes the credential files with blocking
+            // `std::fs`. Run it on the blocking pool so a slow or networked
+            // secret mount stalls only a blocking thread, never a runtime worker
+            // that is also driving live connections. The tick stays fail-closed:
+            // it installs new credentials only on a clean read-and-load.
+            let source_for_tick = source.clone();
+            match tokio::task::spawn_blocking(move || {
+                reload_tick(&source_for_tick, listener, last_seen)
+            })
+            .await
             {
-                last_seen = Some(fingerprint);
+                Ok(ReloadTick::Reloaded { fingerprint }) => last_seen = Some(fingerprint),
+                Ok(_) => {}
+                // The tick never panics by construction; a `JoinError` here would
+                // mean the blocking thread was cancelled or panicked. Log and
+                // retry next tick rather than letting the poll task die and take
+                // rotation down silently.
+                Err(e) => tracing::error!(
+                    listener = listener.as_str(),
+                    error = %e,
+                    "TLS reload poll tick did not run to completion; \
+                     retrying on the next tick"
+                ),
             }
         }
     })
@@ -586,10 +635,20 @@ pub(crate) fn spawn_sighup_reload(handle: TlsReloadHandle) -> Result<tokio::task
     Ok(tokio::spawn(async move {
         while hangup.recv().await.is_some() {
             tracing::info!("received SIGHUP; reloading TLS credentials");
-            // Outcomes are logged per listener by `reload_all`. A failure keeps
-            // the previous credentials serving and the handler installed, so a
-            // later SIGHUP after fixing the files still works.
-            let _ = handle.reload_all();
+            // `reload_all` rereads the credential files with blocking `std::fs`;
+            // run it on the blocking pool so a slow secret mount cannot stall a
+            // runtime worker while the signal is handled. Outcomes are logged per
+            // listener by `reload_all`, and a failure keeps the previous
+            // credentials serving and the handler installed, so a later SIGHUP
+            // after fixing the files still works.
+            let reload_handle = handle.clone();
+            if let Err(e) = tokio::task::spawn_blocking(move || reload_handle.reload_all()).await {
+                tracing::error!(
+                    error = %e,
+                    "SIGHUP TLS reload did not run to completion; \
+                     the next SIGHUP will retry"
+                );
+            }
         }
     }))
 }
@@ -1127,7 +1186,22 @@ pub fn load_server_config(tls_config: &TlsConfig) -> Result<Arc<ServerConfig>> {
             let verifier = build_client_verifier(roots, tls_config.client_auth_optional)?;
             builder.with_client_cert_verifier(verifier)
         }
-        None => builder.with_no_client_auth(),
+        None => {
+            // `client_auth_optional` only governs how a *configured* client-CA
+            // bundle is enforced. Without `client_ca_path` there is no bundle,
+            // so no client certificate is ever requested and the flag does
+            // nothing. Warn rather than reject: rejecting would turn a harmless
+            // leftover setting into a startup failure, but silence would let an
+            // operator believe optional mutual TLS is armed when it is not.
+            if tls_config.client_auth_optional {
+                tracing::warn!(
+                    "client_auth_optional = true has no effect without client_ca_path: \
+                     no client certificate is requested and none is verified. Set \
+                     client_ca_path to enable mutual TLS, or remove client_auth_optional."
+                );
+            }
+            builder.with_no_client_auth()
+        }
     }
     .with_single_cert(cert_chain, key)
     .map_err(|e| {
@@ -1534,6 +1608,88 @@ mod tests {
         assert!(
             !Arc::ptr_eq(&listener_side.load(), &before),
             "the clone held by the listener must see the rotation"
+        );
+    }
+
+    /// A rotation that lands *during startup* — after the source loaded its
+    /// credentials but before the poll task is spawned — must still be caught on
+    /// the first tick. The baseline is captured at load time, so the rotated
+    /// files fingerprint differently from it and the first tick reconciles.
+    /// Seeding the baseline at spawn time instead would record the post-rotation
+    /// files as "already seen" and miss the rotation until the next one.
+    #[test]
+    fn a_startup_rotation_is_detected_from_the_load_time_baseline() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let first = generate_cert("localhost");
+        let tls_config = write_credentials(dir.path(), &first);
+
+        // The source loads `first` and records its fingerprint at load time.
+        let source = TlsConfigSource::from_tls_config(&tls_config).expect("initial load");
+        let baseline = source
+            .initial_fingerprint()
+            .expect("a file-backed source fingerprints its files at load time");
+        let before = source.load();
+
+        // A rotation lands before any poll task exists.
+        let second = generate_cert("localhost");
+        std::fs::write(&tls_config.cert_path, &second.cert_pem).expect("rewrite cert");
+        std::fs::write(&tls_config.key_path, &second.key_pem).expect("rewrite key");
+
+        // The very first tick, seeded from the load-time baseline, must catch it.
+        let tick = reload_tick(&source, TlsListenerKind::Http, source.initial_fingerprint());
+        let ReloadTick::Reloaded { fingerprint } = tick else {
+            panic!("a rotation between load and the first poll must be detected, got {tick:?}");
+        };
+        assert_ne!(
+            fingerprint, baseline,
+            "the reconciling reload must observe a fingerprint different from the baseline"
+        );
+        assert!(
+            !Arc::ptr_eq(&source.load(), &before),
+            "the startup rotation must now be the config the listener serves"
+        );
+    }
+
+    /// A non-atomic rotation caught mid-flight — the cert file already holds the
+    /// new leaf while the key file still holds the old key — must be rejected by
+    /// the key/cert consistency check inside `load_server_config`, leaving the
+    /// last-good credentials serving, and must self-heal once the key catches up.
+    /// This pins the behaviour so a future rustls or loader change cannot silently
+    /// weaken it into installing a mismatched pair.
+    #[test]
+    fn a_cert_read_with_a_mismatched_key_is_rejected_and_self_heals() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let first = generate_cert("localhost");
+        let tls_config = write_credentials(dir.path(), &first);
+        let source = TlsConfigSource::from_tls_config(&tls_config).expect("initial load");
+        let last_good = source.load();
+
+        // Rewrite only the cert: the key file still holds `first`'s key, so the
+        // pair no longer matches.
+        let second = generate_cert("localhost");
+        std::fs::write(&tls_config.cert_path, &second.cert_pem).expect("rewrite cert only");
+
+        let err = source.reload().expect_err(
+            "a new certificate paired with the old key must be rejected, not installed",
+        );
+        assert!(
+            !err.to_string().is_empty(),
+            "the mismatch must be reported to the caller: {err}"
+        );
+        assert!(
+            Arc::ptr_eq(&source.load(), &last_good),
+            "the mismatched pair must leave the last-good credentials serving"
+        );
+
+        // The writer finishes: the key file catches up. The next reload sees a
+        // matching pair and succeeds.
+        std::fs::write(&tls_config.key_path, &second.key_pem).expect("finish key");
+        source
+            .reload()
+            .expect("a matching new certificate and key must reload cleanly");
+        assert!(
+            !Arc::ptr_eq(&source.load(), &last_good),
+            "the completed rotation must now be serving"
         );
     }
 
@@ -2262,6 +2418,53 @@ mod tests {
         good_client
             .await
             .expect("the healthy client task must not panic");
+    }
+
+    /// The rate-limit and request-context extractors must recover the peer
+    /// address from `ConnectInfo<TlsConnectInfo>` on a TLS listener, not only
+    /// from the plain `ConnectInfo<SocketAddr>` that plain-TCP listeners install.
+    /// Constructed here because `TlsConnectInfo`'s fields are private to this
+    /// module.
+    #[test]
+    fn connect_info_remote_addr_recovers_the_peer_from_tls_connect_info() {
+        use axum::extract::ConnectInfo;
+
+        let addr: SocketAddr = "203.0.113.7:8443".parse().expect("addr");
+        let mut extensions = axum::http::Extensions::new();
+        extensions.insert(ConnectInfo(TlsConnectInfo {
+            remote_addr: addr,
+            peer_certificates: None,
+        }));
+
+        assert_eq!(
+            crate::middleware::request_context::connect_info_remote_addr(&extensions),
+            Some(addr),
+            "a TLS listener's connect-info must still yield the peer address"
+        );
+    }
+
+    /// `client_auth_optional` without `client_ca_path` is a no-op that must be
+    /// tolerated (warned, not rejected): the server config still builds so the
+    /// listener serves rather than refusing to start over a leftover setting.
+    #[test]
+    fn client_auth_optional_without_a_ca_still_builds() {
+        let server = generate_cert("localhost");
+        let cert_file = write_temp(&server.cert_pem);
+        let key_file = write_temp(&server.key_pem);
+
+        let config = TlsConfig {
+            enabled: true,
+            cert_path: cert_file.path().to_path_buf(),
+            key_path: key_file.path().to_path_buf(),
+            client_ca_path: None,
+            client_auth_optional: true,
+            reload_interval_secs: None,
+            reload_on_sighup: false,
+            handshake_timeout_secs: None,
+        };
+
+        load_server_config(&config)
+            .expect("an ineffective client_auth_optional must warn, not fail the build");
     }
 
     #[test]

--- a/acton-service/src/tls.rs
+++ b/acton-service/src/tls.rs
@@ -49,6 +49,7 @@ use std::time::Duration;
 use arc_swap::ArcSwap;
 use rustls_pki_types::CertificateDer;
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc;
 use tokio_rustls::rustls::server::danger::ClientCertVerifier;
 use tokio_rustls::rustls::server::WebPkiClientVerifier;
 use tokio_rustls::rustls::{RootCertStore, ServerConfig};
@@ -618,6 +619,46 @@ impl Drop for TlsReloadTasks {
     }
 }
 
+/// Default cap on how long a single TLS handshake may take before its
+/// connection is dropped, used when `handshake_timeout_secs` is unset.
+///
+/// Ten seconds is comfortably longer than a healthy handshake — which is a
+/// couple of round-trips and completes in milliseconds on a LAN, and in well
+/// under a second even across a slow link — yet short enough that a peer which
+/// completes the TCP connect and then stalls (the pre-authentication denial of
+/// service this bound exists to cap) frees its handshake task promptly instead
+/// of holding it open indefinitely. Operators who terminate TLS behind a proxy
+/// with its own, longer client timeout can raise it via `handshake_timeout_secs`.
+pub const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Validate a section's `handshake_timeout_secs` into a handshake deadline.
+///
+/// `section` names the config section for the diagnostic, so an operator with
+/// both `[tls]` and `[grpc.tls]` configured learns which one to fix.
+///
+/// An unset value resolves to [`DEFAULT_HANDSHAKE_TIMEOUT`]. Callers run this
+/// *before* binding a listener, so a rejected value refuses to start rather than
+/// failing handshakes once traffic arrives — the same posture as
+/// [`validate_reload_interval`].
+///
+/// # Errors
+///
+/// A timeout of `0` is rejected. Taken literally it would elapse before the
+/// handshake could make any progress, failing every connection instantly, so it
+/// can only be a misconfiguration.
+pub(crate) fn validate_handshake_timeout(tls_cfg: &TlsConfig, section: &str) -> Result<Duration> {
+    match tls_cfg.handshake_timeout_secs {
+        None => Ok(DEFAULT_HANDSHAKE_TIMEOUT),
+        Some(0) => Err(crate::error::Error::Internal(format!(
+            "{section} sets handshake_timeout_secs = 0, which would elapse before any \
+             handshake could complete and so fail every connection. Omit the field to use \
+             the default of {} seconds, or set a positive number of seconds.",
+            DEFAULT_HANDSHAKE_TIMEOUT.as_secs()
+        ))),
+        Some(secs) => Ok(Duration::from_secs(secs)),
+    }
+}
+
 /// Validate a section's `reload_interval_secs` into a poll period.
 ///
 /// `section` names the config section for the diagnostic, so an operator with
@@ -749,9 +790,100 @@ pub(crate) fn install_reload_triggers(
 /// Each accepted connection reads the source's current configuration, so
 /// credentials swapped in by [`TlsConfigSource::reload`] apply to the next
 /// handshake without restarting the listener.
+///
+/// # Handshakes run off the accept path
+///
+/// A background *pump* task owns the TCP listener, accepts connections, and runs
+/// each TLS handshake in its own [`tokio::spawn`] task bounded by
+/// [`handshake_timeout`](Self::with_handshake_timeout). Completed streams reach
+/// [`accept`](axum::serve::Listener::accept) through a bounded channel, so one
+/// peer that connects but never sends a ClientHello cannot serialize behind the
+/// accept future and block every other connection — it merely occupies its own
+/// handshake task until the timeout drops it. The pump is spawned lazily on the
+/// first `accept()` call and aborted when the listener is dropped.
 pub struct TlsListener {
-    tcp: TcpListener,
+    /// Shared so the pump task can `accept()` on its own clone while
+    /// [`local_addr`](axum::serve::Listener::local_addr) still reads this one.
+    tcp: Arc<TcpListener>,
     config_source: TlsConfigSource,
+    handshake_timeout: Duration,
+    /// Receiving end of the pump's completed-handshake channel. `None` until the
+    /// first `accept()` lazily spawns the pump.
+    rx: Option<mpsc::Receiver<(TlsStream<TcpStream>, SocketAddr)>>,
+    /// The pump task, kept so `Drop` can abort it rather than let it outlive the
+    /// listener holding the socket open.
+    pump: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for TlsListener {
+    fn drop(&mut self) {
+        if let Some(pump) = self.pump.take() {
+            pump.abort();
+        }
+    }
+}
+
+/// Bounded capacity of the channel carrying completed handshakes to `accept()`.
+///
+/// axum leaves only a small number of accepts outstanding at once, so 1024 is
+/// far more headroom than it ever uses while still bounding how many completed
+/// `TlsStream`s can queue if the serve loop stalls. When it does fill, the
+/// pump's `tx.send().await` parks — applying backpressure to further handshakes
+/// rather than buffering without limit.
+const HANDSHAKE_CHANNEL_CAPACITY: usize = 1024;
+
+/// The background task that owns the listener, accepts TCP connections, and runs
+/// each TLS handshake concurrently in its own task so no single stalled peer can
+/// block the others. Completed streams are sent back to `accept()` over `tx`.
+async fn handshake_pump(
+    tcp: Arc<TcpListener>,
+    config_source: TlsConfigSource,
+    handshake_timeout: Duration,
+    tx: mpsc::Sender<(TlsStream<TcpStream>, SocketAddr)>,
+) {
+    loop {
+        // Accept a TCP connection. Preserve the previous error behaviour: log
+        // and pause briefly so a transient accept failure (e.g. fd exhaustion)
+        // does not spin this loop.
+        let (stream, addr) = match tcp.accept().await {
+            Ok(pair) => pair,
+            Err(e) => {
+                tracing::error!("TCP accept error: {}", e);
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+        };
+
+        // Snapshot the credentials at accept time (an `Arc` clone). A rotation
+        // that lands mid-handshake therefore never changes this connection's
+        // configuration, preserving the per-connection rotation semantics.
+        let acceptor = TlsAcceptor::from(config_source.load());
+        let tx = tx.clone();
+
+        // Each handshake runs in its own task, bounded by the timeout, so a peer
+        // that never sends a ClientHello occupies only its own task and cannot
+        // block accepting or handshaking any other connection.
+        tokio::spawn(async move {
+            match tokio::time::timeout(handshake_timeout, acceptor.accept(stream)).await {
+                Ok(Ok(tls_stream)) => {
+                    // A send error means `accept()` and its receiver are gone —
+                    // the listener was dropped — so this connection is moot.
+                    let _ = tx.send((tls_stream, addr)).await;
+                }
+                Ok(Err(e)) => {
+                    tracing::warn!("TLS handshake failed from {}: {}", addr, e);
+                }
+                Err(_elapsed) => {
+                    tracing::warn!(
+                        "TLS handshake from {} did not complete within {:?}; dropping the \
+                         connection",
+                        addr,
+                        handshake_timeout
+                    );
+                }
+            }
+        });
+    }
 }
 
 impl TlsListener {
@@ -760,6 +892,9 @@ impl TlsListener {
     /// The credentials cannot be rotated. Use
     /// [`with_config_source`](Self::with_config_source) with a source built by
     /// [`TlsConfigSource::from_tls_config`] when they must be.
+    ///
+    /// The handshake timeout defaults to [`DEFAULT_HANDSHAKE_TIMEOUT`]; override
+    /// it with [`with_handshake_timeout`](Self::with_handshake_timeout).
     pub fn new(tcp: TcpListener, server_config: Arc<ServerConfig>) -> Self {
         Self::with_config_source(tcp, TlsConfigSource::from_server_config(server_config))
     }
@@ -769,8 +904,28 @@ impl TlsListener {
     /// Every handshake uses whatever the source holds at that moment, so a
     /// [`reload`](TlsConfigSource::reload) on a clone of the source rotates this
     /// listener's certificate in place.
+    ///
+    /// The handshake timeout defaults to [`DEFAULT_HANDSHAKE_TIMEOUT`]; override
+    /// it with [`with_handshake_timeout`](Self::with_handshake_timeout).
     pub fn with_config_source(tcp: TcpListener, config_source: TlsConfigSource) -> Self {
-        Self { tcp, config_source }
+        Self {
+            tcp: Arc::new(tcp),
+            config_source,
+            handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
+            rx: None,
+            pump: None,
+        }
+    }
+
+    /// Set how long a single TLS handshake may take before it is dropped.
+    ///
+    /// Bounds the pre-handshake stall an unauthenticated peer can impose on its
+    /// own handshake task. Defaults to [`DEFAULT_HANDSHAKE_TIMEOUT`] when not
+    /// called.
+    #[must_use]
+    pub fn with_handshake_timeout(mut self, timeout: Duration) -> Self {
+        self.handshake_timeout = timeout;
+        self
     }
 
     /// The credential source this listener hands to each new handshake.
@@ -785,36 +940,37 @@ impl axum::serve::Listener for TlsListener {
     type Addr = SocketAddr;
 
     fn accept(&mut self) -> impl std::future::Future<Output = (Self::Io, Self::Addr)> + Send {
-        let config_source = self.config_source.clone();
-        let tcp = &mut self.tcp;
+        // Lazily start the background pump on the first accept. Spawning here
+        // rather than in the constructor keeps `new`/`with_config_source`
+        // non-async and means no task and no socket ownership exist until axum
+        // actually begins serving.
+        if self.rx.is_none() {
+            let (tx, rx) = mpsc::channel(HANDSHAKE_CHANNEL_CAPACITY);
+            let pump = tokio::spawn(handshake_pump(
+                Arc::clone(&self.tcp),
+                self.config_source.clone(),
+                self.handshake_timeout,
+                tx,
+            ));
+            self.rx = Some(rx);
+            self.pump = Some(pump);
+        }
+
+        let rx = self
+            .rx
+            .as_mut()
+            .expect("the pump receiver was just installed");
 
         async move {
-            loop {
-                // Accept a TCP connection using the tokio TcpListener method (not
-                // the axum Listener trait method, which handles errors internally).
-                let (stream, addr) = match TcpListener::accept(tcp).await {
-                    Ok((stream, addr)) => (stream, addr),
-                    Err(e) => {
-                        tracing::error!("TCP accept error: {}", e);
-                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                        continue;
-                    }
-                };
-
-                // Read the credentials per connection so a reload that happened
-                // since the last accept takes effect. Both the load and the
-                // acceptor construction are `Arc` clones, so this costs nothing
-                // measurable against the handshake that follows.
-                let acceptor = TlsAcceptor::from(config_source.load());
-
-                // Perform TLS handshake. On failure, log and try the next connection.
-                match acceptor.accept(stream).await {
-                    Ok(tls_stream) => return (tls_stream, addr),
-                    Err(e) => {
-                        tracing::warn!("TLS handshake failed from {}: {}", addr, e);
-                        continue;
-                    }
-                }
+            match rx.recv().await {
+                Some(conn) => conn,
+                // The pump loops forever holding a `tx`, so the channel can only
+                // close if the pump task itself is gone — unreachable in normal
+                // operation. Returning would hand axum a bogus connection and
+                // busy-loop its serve loop, so park this future forever instead;
+                // a graceful shutdown drops the whole listener rather than
+                // relying on `accept()` to resolve.
+                None => std::future::pending().await,
             }
         }
     }
@@ -1160,6 +1316,7 @@ mod tests {
             client_auth_optional: false,
             reload_interval_secs: None,
             reload_on_sighup: false,
+            handshake_timeout_secs: None,
         };
 
         load_server_config(&config).expect("server-only TLS config must build");
@@ -1181,6 +1338,7 @@ mod tests {
             client_auth_optional: true,
             reload_interval_secs: None,
             reload_on_sighup: false,
+            handshake_timeout_secs: None,
         };
 
         load_server_config(&config).expect("mutual-TLS config must build");
@@ -1200,6 +1358,7 @@ mod tests {
             client_auth_optional: false,
             reload_interval_secs: None,
             reload_on_sighup: false,
+            handshake_timeout_secs: None,
         };
 
         load_server_config(&config)
@@ -1222,6 +1381,7 @@ mod tests {
             client_auth_optional: false,
             reload_interval_secs: None,
             reload_on_sighup: false,
+            handshake_timeout_secs: None,
         }
     }
 
@@ -1238,6 +1398,7 @@ mod tests {
             client_auth_optional: false,
             reload_interval_secs: None,
             reload_on_sighup: false,
+            handshake_timeout_secs: None,
         };
         let server_config = load_server_config(&config).expect("config builds");
 
@@ -1267,6 +1428,7 @@ mod tests {
             client_auth_optional: false,
             reload_interval_secs: None,
             reload_on_sighup: false,
+            handshake_timeout_secs: None,
         };
         let server_config = load_server_config(&config).expect("config builds");
         let source = TlsConfigSource::from_server_config(server_config.clone());
@@ -1525,6 +1687,7 @@ mod tests {
             client_auth_optional: false,
             reload_interval_secs: None,
             reload_on_sighup: false,
+            handshake_timeout_secs: None,
         };
         let source =
             TlsConfigSource::from_server_config(load_server_config(&config).expect("config"));
@@ -1776,6 +1939,44 @@ mod tests {
     }
 
     #[test]
+    fn a_zero_handshake_timeout_is_rejected() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut tls_config = write_credentials(dir.path(), &generate_cert("localhost"));
+        tls_config.handshake_timeout_secs = Some(0);
+
+        let err = validate_handshake_timeout(&tls_config, "[tls]")
+            .expect_err("a zero handshake timeout would fail every connection and must be refused");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("handshake_timeout_secs = 0"),
+            "the error must name the setting: {message}"
+        );
+        assert!(
+            message.contains("[tls]"),
+            "the error must name the section so an operator knows which to fix: {message}"
+        );
+    }
+
+    #[test]
+    fn an_absent_or_positive_handshake_timeout_resolves_to_a_duration() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut tls_config = write_credentials(dir.path(), &generate_cert("localhost"));
+
+        assert_eq!(
+            validate_handshake_timeout(&tls_config, "[tls]").expect("absent is valid"),
+            DEFAULT_HANDSHAKE_TIMEOUT,
+            "omitting the field uses the built-in default"
+        );
+
+        tls_config.handshake_timeout_secs = Some(5);
+        assert_eq!(
+            validate_handshake_timeout(&tls_config, "[tls]").expect("positive is valid"),
+            Duration::from_secs(5)
+        );
+    }
+
+    #[test]
     fn an_absent_or_positive_poll_interval_is_accepted() {
         let dir = tempfile::tempdir().expect("temp dir");
         let mut tls_config = write_credentials(dir.path(), &generate_cert("localhost"));
@@ -1903,6 +2104,164 @@ mod tests {
             !rendered.contains("BEGIN"),
             "Debug must not render PEM material: {rendered}"
         );
+    }
+
+    /// A client-side verifier that accepts any server certificate, borrowing
+    /// only the signature checks from the installed crypto provider. The
+    /// handshake-off-the-accept-path test cares that a real handshake completes,
+    /// not that the self-signed test certificate chains to a trusted root, so
+    /// trust verification is deliberately bypassed here.
+    #[derive(Debug)]
+    struct AcceptAnyServerCert {
+        provider: Arc<tokio_rustls::rustls::crypto::CryptoProvider>,
+    }
+
+    impl tokio_rustls::rustls::client::danger::ServerCertVerifier for AcceptAnyServerCert {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _server_name: &rustls_pki_types::ServerName<'_>,
+            _ocsp_response: &[u8],
+            _now: rustls_pki_types::UnixTime,
+        ) -> std::result::Result<
+            tokio_rustls::rustls::client::danger::ServerCertVerified,
+            tokio_rustls::rustls::Error,
+        > {
+            Ok(tokio_rustls::rustls::client::danger::ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &tokio_rustls::rustls::DigitallySignedStruct,
+        ) -> std::result::Result<
+            tokio_rustls::rustls::client::danger::HandshakeSignatureValid,
+            tokio_rustls::rustls::Error,
+        > {
+            tokio_rustls::rustls::crypto::verify_tls12_signature(
+                message,
+                cert,
+                dss,
+                &self.provider.signature_verification_algorithms,
+            )
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &tokio_rustls::rustls::DigitallySignedStruct,
+        ) -> std::result::Result<
+            tokio_rustls::rustls::client::danger::HandshakeSignatureValid,
+            tokio_rustls::rustls::Error,
+        > {
+            tokio_rustls::rustls::crypto::verify_tls13_signature(
+                message,
+                cert,
+                dss,
+                &self.provider.signature_verification_algorithms,
+            )
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<tokio_rustls::rustls::SignatureScheme> {
+            self.provider
+                .signature_verification_algorithms
+                .supported_schemes()
+        }
+    }
+
+    /// The core regression for issue #94: a peer that completes the TCP connect
+    /// and then never sends a ClientHello must not block a healthy handshake
+    /// behind it. With handshakes run inline on the accept path, the silent peer
+    /// held the single accept future for the whole handshake timeout and stalled
+    /// every new connection — a pre-authentication denial of service.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_stalled_handshake_does_not_block_a_healthy_one() {
+        use axum::serve::Listener as _;
+
+        crate::crypto::ensure_default_crypto_provider();
+
+        // Server credentials with no client-certificate requirement.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let server_cert = generate_cert("localhost");
+        let tls_config = write_credentials(dir.path(), &server_cert);
+        let source = TlsConfigSource::from_tls_config(&tls_config).expect("server config loads");
+
+        let tcp = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral port");
+        let addr = tcp.local_addr().expect("local addr");
+
+        // Long enough that "the healthy handshake finished first" is unambiguous
+        // and that, if the silent peer ever did block the accept path, this test
+        // would clearly hang rather than pass by luck.
+        let handshake_timeout = Duration::from_secs(30);
+        let mut listener =
+            TlsListener::with_config_source(tcp, source).with_handshake_timeout(handshake_timeout);
+
+        // 1) The silent peer. Held in scope for the whole test so its socket
+        // stays open. The pump is spawned lazily on the first `accept()` below,
+        // so this connection is guaranteed to sit ahead of the healthy one in
+        // the accept backlog.
+        let _silent = tokio::net::TcpStream::connect(addr)
+            .await
+            .expect("the silent peer completes the TCP connect");
+
+        // 2) A healthy client that completes a real handshake, driven on its own
+        // task so it runs concurrently with the accept below.
+        let provider = tokio_rustls::rustls::crypto::CryptoProvider::get_default()
+            .expect("a crypto provider is installed")
+            .clone();
+        let client_config = tokio_rustls::rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(AcceptAnyServerCert { provider }))
+            .with_no_client_auth();
+
+        let good_client = tokio::spawn(async move {
+            let stream = tokio::net::TcpStream::connect(addr)
+                .await
+                .expect("the healthy peer connects");
+            let _tls = tokio_rustls::TlsConnector::from(Arc::new(client_config))
+                .connect(
+                    rustls_pki_types::ServerName::try_from("localhost").expect("valid name"),
+                    stream,
+                )
+                .await
+                .expect("the healthy handshake must complete");
+            // Hold the client end open briefly so the server side settles.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+
+        // The healthy connection must reach `accept()` far inside the silent
+        // peer's timeout. A generous 5s outer bound catches a regression (an
+        // inline handshake would hold `accept()` for the full 30s) without
+        // making the test flaky on a slow machine.
+        let started = std::time::Instant::now();
+        let accepted = tokio::time::timeout(Duration::from_secs(5), listener.accept())
+            .await
+            .expect("the healthy handshake must be delivered without waiting on the silent peer");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "the healthy handshake was delivered in {elapsed:?}, which suggests it queued \
+             behind the silent peer instead of running concurrently"
+        );
+
+        // A real TLS stream reached us: prove it by reading its negotiated state
+        // is available (the connection is established, not a bare TCP socket).
+        let (_stream, peer_addr) = accepted;
+        assert_eq!(
+            peer_addr.ip(),
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            "the delivered connection is the loopback healthy client"
+        );
+
+        good_client
+            .await
+            .expect("the healthy client task must not panic");
     }
 
     #[test]

--- a/config.example.toml
+++ b/config.example.toml
@@ -30,6 +30,7 @@ environment = "dev"  # dev, staging, production
 # key_path = "./certs/grpc.key"
 # reload_interval_secs = 300             # poll these files; see [tls] below
 # reload_on_sighup = true                # reloads BOTH listeners, not just gRPC
+# handshake_timeout_secs = 10            # drop a stalled handshake after N s; see [tls]
 
 # ============================================================================
 # TOKEN AUTHENTICATION ([token] section with format = "paseto" or "jwt")
@@ -194,6 +195,14 @@ referrer_policy = "strict-origin-when-cross-origin"
 # rotated only half the surfaces would be confusing during an incident.
 # Unix only; configured elsewhere it warns at startup and is ignored.
 # reload_on_sighup = true
+#
+# --- Handshake timeout ------------------------------------------------------
+# Maximum time to wait for a TLS handshake to complete before dropping the
+# connection. Caps pre-handshake stalls from unauthenticated peers: a peer that
+# completes the TCP connect but never sends a ClientHello cannot hold a slot
+# open. Each handshake runs concurrently, so one stalled peer never blocks the
+# others. Omit to use the default of 10 seconds; 0 is rejected at startup.
+# handshake_timeout_secs = 10
 #
 # For triggers the framework does not model (a Vault lease renewal, a watch on
 # a ConfigMap, an admin endpoint), register a callback with


### PR DESCRIPTION
Two TLS commits from the 0.30.0 security review, same subsystem.

## #94 — TLS handshake off the accept path (high severity)

`TlsListener::accept` ran the handshake inline inside the `axum::serve::Listener::accept` future, so handshakes were serialized listener-wide with no timeout. A peer that completed the TCP connect but never sent a ClientHello parked the accept future forever and blocked **all** new connections — an unauthenticated, pre-verification DoS (mTLS does not protect against it; the stall precedes cert verification).

- A background pump task owns the listener and spawns each handshake as its own task, wrapped in `tokio::time::timeout`. Completed `TlsStream`s flow back to `accept()` through a bounded mpsc channel (one per call), restoring concurrent handshakes and making the timeout a per-connection bound.
- Per-handshake `config_source.load()` is captured at accept time, so in-place cert rotation (#90) is preserved.
- New `handshake_timeout_secs` on `[tls]`/`[grpc.tls]` (default 10s, `0` rejected at build), threaded through both serve paths.
- Regression test: a silent peer no longer blocks a healthy handshake.

## #95 — hardening follow-ups (low severity)

- **Reload baseline:** fingerprint captured inside `from_tls_config` at load time, so a rotation landing between load and poll-spawn is caught on the first tick.
- **Connect-info:** `governor` + `request_context` extractors fall back to `ConnectInfo<TlsConnectInfo>`, so per-IP rate limiting works on direct TLS termination without a proxy.
- **Zeroize** the decoded DER private key on `IdentityMaterial` drop.
- **Warn** on `client_auth_optional` without `client_ca_path` (previously a silent no-op).
- **`deny_unknown_fields`** on `TlsConfig` so a reload-trigger typo errors instead of silently disarming rotation.
- **Doc fix:** the outbound resolver/verifier are two separate `ArcSwap`s; a handshake between the swaps can observe a mixed pairing (harmless — corrected the comment, no lock).
- **`spawn_blocking`** for the poll-tick and SIGHUP credential reads so a slow secret mount can't stall a runtime worker.
- Test pinning the mixed-read rotation self-heal (rustls rejects new-cert + old-key).

## Release

Minor bump — **0.31.0**. New public `TlsConfig` fields and `deny_unknown_fields` are behavior-changing under 0.x. No version files touched (this repo bumps in a dedicated release-prep PR).

## Gates
- `cargo clippy --all-targets --features full` → 0 warnings
- `cargo clippy --no-default-features --features "full,crypto-ring"` → 0 warnings
- `cargo nextest run --features full` → 765 passed, 0 failed
- `cargo test --doc --features full` (RUSTDOCFLAGS=-D warnings) → 104 passed
- `cargo fmt` clean; no clippy suppressions; no hand-edited deps

Closes #94
Closes #95