### PR TITLE
chore(release): prepare 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [acton-service-v0.31.0] - 2026-07-20
+
+Hardens the 0.30.0 mutual-TLS surface. The headline fix closes a
+pre-authentication denial of service on the TLS accept path; the rest are
+follow-ups from the same security review. No intentional breaking API changes,
+though `[tls]`/`[grpc.tls]` sections now reject unknown keys, so a config that
+carried a typo'd or stray field there will fail to parse instead of silently
+ignoring it.
+
+### Fixed
+
+- **tls**: The TLS handshake no longer runs inline on the `accept` path. It
+  previously completed inside the `axum::serve::Listener::accept` future with no
+  timeout, so handshakes were serialized listener-wide and a single peer that
+  connected but never sent a `ClientHello` parked the accept future forever,
+  blocking every new connection — an unauthenticated, pre-verification denial of
+  service that mutual TLS did not defend against. A background pump task now owns
+  the listener and spawns each handshake as its own task behind a
+  `tokio::time::timeout`, with completed streams handed back through a bounded
+  channel. Handshakes run concurrently again and the timeout is a per-connection
+  bound. Rotated credentials are still captured per handshake. (#94)
+
+### Added
+
+- **tls**: `handshake_timeout_secs` on `[tls]` and `[grpc.tls]` caps how long a
+  handshake may take before the connection is dropped (default 10s; `0` is
+  rejected at build time). (#94)
+- **tls**: Peer-IP rate limiting and request-context IP resolution now recover
+  the remote address from `TlsConnectInfo` as well as `ConnectInfo<SocketAddr>`,
+  so they work on directly-terminated TLS listeners without a fronting proxy.
+  (#95)
+
+### Changed
+
+- **tls**: `TlsConfig` now denies unknown fields, so a mistyped reload trigger
+  (for example `reload_interval_sec`) is reported at startup instead of silently
+  leaving rotation disarmed. (#95)
+- **tls**: The reload poll baseline is captured when the source loads its
+  credentials rather than when the poll task spawns, so a rotation that lands
+  during startup is picked up on the first tick instead of being missed until the
+  next one. (#95)
+- **tls**: Credential file reads on the poll tick and SIGHUP handler run on the
+  blocking pool, so a slow or networked secret mount cannot stall a runtime
+  worker. (#95)
+- **tls**: A `client_auth_optional = true` set without `client_ca_path` now logs
+  a warning at startup rather than being silently ignored. (#95)
+
+### Security
+
+- **client-tls**: The decoded DER private key in the outbound client identity is
+  zeroized on drop, closing a window where its bytes were freed un-wiped even
+  though the PEM copies were already zeroized. (#95)
+
 ## [acton-service-v0.30.0] - 2026-07-20
 
 The mutual-TLS release: inbound client-certificate verification, an outbound

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "acton-cli"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "acton-service",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["acton-service", "acton-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 authors = ["roland@govcraft.ai"]
 license = "MIT"

--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-acton-service = { path = "../acton-service", version = "0.30.0" }
+acton-service = { path = "../acton-service", version = "0.31.0" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/acton-docs/src/lib/version.ts
+++ b/acton-docs/src/lib/version.ts
@@ -2,4 +2,4 @@
  * Version information for acton-service
  * This should match the version in the root Cargo.toml workspace.package.version
  */
-export const VERSION = '0.30.0'
+export const VERSION = '0.31.0'

--- a/acton-docs/src/markdoc/config.js
+++ b/acton-docs/src/markdoc/config.js
@@ -4,7 +4,7 @@ import { siteConfig } from '../lib/config'
 
 // Extract version from workspace Cargo.toml
 // This should be kept in sync with the workspace version
-const ACTON_VERSION = '0.30.0'
+const ACTON_VERSION = '0.31.0'
 
 // Single source of truth mapping camelCase aliases to the real Cargo feature
 // lists. Used by both the `dep()` function and the `$dep.*` variables so a

--- a/acton-docs/src/markdoc/functions.js
+++ b/acton-docs/src/markdoc/functions.js
@@ -1,5 +1,5 @@
 // Markdoc functions for version management
-const ACTON_VERSION = '0.30.0'
+const ACTON_VERSION = '0.31.0'
 
 export const version = {
   transform() {


### PR DESCRIPTION
Release-prep for **0.31.0**, hardening the 0.30.0 mutual-TLS surface.

- Bump workspace version `0.30.0` → `0.31.0` (`cargo release version minor`; updates `Cargo.toml`, `Cargo.lock`, and acton-cli's dependency pin).
- CHANGELOG entry under `acton-service-v0.31.0` covering #94 and #95.
- Sync acton-docs version files (`version.ts`, `markdoc/config.js`, `markdoc/functions.js`).

## What's in 0.31.0

- **#94 (Fixed, high severity):** TLS handshake moved off the accept path — closes an unauthenticated pre-verification DoS where one stalled peer blocked all new connections. New `handshake_timeout_secs` (default 10s).
- **#95 (hardening follow-ups):** `TlsConnectInfo` peer-IP recovery in rate limiting/request context, DER key zeroize-on-drop, warn on ineffective `client_auth_optional`, `deny_unknown_fields` on `TlsConfig`, load-time reload baseline, `spawn_blocking` reload reads, corrected reload comment.

## Semver

Minor. New public `TlsConfig` fields plus `deny_unknown_fields` (which will now reject a previously-tolerated typo in `[tls]`/`[grpc.tls]`) — behavior-changing under 0.x, no intentional API breakage.

After merge: tag `acton-service-v0.31.0` (signed) and `cargo publish -p acton-service`.