### PR TITLE
fix(tls): gRPC-over-TLS end to end (#97, #98) + release 0.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [acton-service-v0.31.1] - 2026-07-20
+
+Makes gRPC-over-TLS work end to end. Two complementary bugs left an
+acton-service gRPC client unable to reach an acton-service gRPC TLS listener
+through tonic's TLS plumbing; both are fixed here. No API changes.
+
+### Fixed
+
+- **tls**: The TLS listener now advertises ALPN (`[h2, http/1.1]`).
+  `load_server_config` previously set no `alpn_protocols`, so the listener
+  answered no ALPN offer and strict gRPC clients — a `tonic` `ClientTlsConfig`
+  without `assume_http2`, grpcurl, or any non-Rust stack — failed with
+  `H2NotNegotiated`. Clients that offer no ALPN are unaffected. (#98)
+- **client-tls**: `ClientIdentitySource::grpc_channel` no longer fails the first
+  RPC with `HttpsUriWithoutTlsSupport`. With any tonic TLS feature compiled in
+  (which `crypto-aws-lc-rs`/`crypto-ring` always pull), tonic wrapped the custom
+  rotating connector in a scheme-inspecting connector that rejected the `https`
+  URI before the connector ran. The channel is now built through
+  `tonic::transport::Channel::new`, tonic's lower-level custom-connector entry
+  point, which skips that wrapper while preserving the endpoint's per-RPC
+  timeout, keep-alive, concurrency, HTTP/2 tuning and user agent.
+  `Endpoint::connect_timeout` is not honoured on this path (a tonic limitation);
+  the method's docs note the caller-side remedy. (#97)
+
 ## [acton-service-v0.31.0] - 2026-07-20
 
 Hardens the 0.30.0 mutual-TLS surface. The headline fix closes a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "acton-cli"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "acton-service",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["acton-service", "acton-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 authors = ["roland@govcraft.ai"]
 license = "MIT"

--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-acton-service = { path = "../acton-service", version = "0.31.0" }
+acton-service = { path = "../acton-service", version = "0.31.1" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/acton-docs/src/lib/version.ts
+++ b/acton-docs/src/lib/version.ts
@@ -2,4 +2,4 @@
  * Version information for acton-service
  * This should match the version in the root Cargo.toml workspace.package.version
  */
-export const VERSION = '0.31.0'
+export const VERSION = '0.31.1'

--- a/acton-docs/src/markdoc/config.js
+++ b/acton-docs/src/markdoc/config.js
@@ -4,7 +4,7 @@ import { siteConfig } from '../lib/config'
 
 // Extract version from workspace Cargo.toml
 // This should be kept in sync with the workspace version
-const ACTON_VERSION = '0.31.0'
+const ACTON_VERSION = '0.31.1'
 
 // Single source of truth mapping camelCase aliases to the real Cargo feature
 // lists. Used by both the `dep()` function and the `$dep.*` variables so a

--- a/acton-docs/src/markdoc/functions.js
+++ b/acton-docs/src/markdoc/functions.js
@@ -1,5 +1,5 @@
 // Markdoc functions for version management
-const ACTON_VERSION = '0.31.0'
+const ACTON_VERSION = '0.31.1'
 
 export const version = {
   transform() {

--- a/acton-service/src/client_tls.rs
+++ b/acton-service/src/client_tls.rs
@@ -887,9 +887,9 @@ impl ClientIdentitySource {
     /// exactly as on the HTTP path.
     ///
     /// Configure the [`Endpoint`](tonic::transport::Endpoint) before passing it
-    /// in — timeouts, keep-alive, concurrency limits and user agent are all the
-    /// caller's to set, and this method changes none of them. It supplies only
-    /// the transport:
+    /// in — per-RPC timeout, keep-alive, concurrency limits, HTTP/2 tuning and
+    /// user agent are all the caller's to set, and this method preserves them.
+    /// It supplies only the transport:
     ///
     /// ```rust,ignore
     /// let endpoint = tonic::transport::Endpoint::from_shared("https://peer.internal:8443")?
@@ -898,6 +898,17 @@ impl ClientIdentitySource {
     /// let channel = source.grpc_channel(endpoint)?;
     /// let client = MyServiceClient::new(channel);
     /// ```
+    ///
+    /// One endpoint setting is *not* honoured on this path:
+    /// [`connect_timeout`](tonic::transport::Endpoint::connect_timeout). `tonic`
+    /// only applies it inside its own connector wrapper, which this method
+    /// deliberately bypasses (that wrapper rejects an `https` URI outright unless
+    /// the endpoint carries a `tonic`-owned TLS config, so it cannot coexist with
+    /// this source's rotating connector). `tonic` exposes no way to read the
+    /// value back and re-apply it. A caller that needs to bound how long a stalled
+    /// peer may hold a pending connection should wrap the first RPC in
+    /// [`tokio::time::timeout`]; the per-RPC `timeout` above does not cover the
+    /// connect and handshake.
     ///
     /// ALPN is fixed to `h2` alone, because gRPC is defined over HTTP/2 only; a
     /// channel that negotiated `http/1.1` would connect and then fail every
@@ -933,7 +944,27 @@ impl ClientIdentitySource {
         let connector = RotatingTlsConnector {
             tls: Arc::new(self.tls_config_with_alpn(&GRPC_ALPN)),
         };
-        Ok(endpoint.connect_with_connector_lazy(connector))
+
+        // Build the lazy channel through `Channel::new` rather than
+        // `Endpoint::connect_with_connector_lazy`. The latter wraps every custom
+        // connector in tonic's `transport::channel::service::Connector`, and
+        // under the `_tls-any` feature (which our `crypto-aws-lc-rs` /
+        // `crypto-ring` features always turn on, via `tonic/tls-aws-lc` /
+        // `tonic/tls-ring`) that wrapper inspects the URI scheme itself: an
+        // `https` URI with no `endpoint.tls_config(...)` is rejected with
+        // `HttpsUriWithoutTlsSupport` *before* our connector is ever called, so
+        // the rotating channel could never connect in exactly its intended
+        // configuration. `Channel::new` is tonic's documented lower-level entry
+        // point for a custom connector; it applies the connector directly, with
+        // no scheme-inspecting wrapper, while still routing the endpoint's
+        // per-RPC timeout, user-agent, concurrency, HTTP/2 tuning and keep-alive
+        // through the same lazy connection stack. (The one setting it does not
+        // carry is `Endpoint::connect_timeout`, which tonic applies only inside
+        // that bypassed wrapper and exposes no getter for; see this method's
+        // docs.) `RotatingTlsConnector` then performs the real rustls handshake,
+        // reading the `https` host for SNI and defaulting to port 443, exactly as
+        // before.
+        Ok(tonic::transport::Channel::new(connector, endpoint))
     }
 
     /// A point-in-time gRPC TLS configuration built from this source's files.
@@ -2220,5 +2251,180 @@ mod tests {
             "and none of this rebuilt the HTTP client that shares the very same \
              rotating configuration"
         );
+    }
+
+    // --- End-to-end gRPC-over-TLS regressions (#97, #98) ------------------
+    //
+    // These drive a real generated `tonic` client through the actual
+    // `Endpoint`/`Channel` machinery against a live TLS listener whose
+    // credentials come from `load_server_config`. Earlier connector-only tests
+    // never touched tonic's `Endpoint::connect_*` wrapper (#97) nor the
+    // listener's ALPN (#98), which is exactly where both bugs lived.
+
+    #[cfg(feature = "grpc")]
+    mod ping_proto {
+        tonic::include_proto!("ping.v1");
+    }
+
+    #[cfg(feature = "grpc")]
+    #[derive(Clone, Default)]
+    struct PingImpl;
+
+    #[cfg(feature = "grpc")]
+    #[tonic::async_trait]
+    impl ping_proto::ping_service_server::PingService for PingImpl {
+        async fn ping(
+            &self,
+            request: tonic::Request<ping_proto::PingRequest>,
+        ) -> std::result::Result<tonic::Response<ping_proto::PongResponse>, tonic::Status> {
+            Ok(tonic::Response::new(ping_proto::PongResponse {
+                message: format!("pong: {}", request.into_inner().message),
+                timestamp: 0,
+            }))
+        }
+    }
+
+    /// Serve the ping gRPC service over a TLS listener built from `server_config`
+    /// (the output of `load_server_config`). Returns the bound address and the
+    /// server task, which the caller aborts when done.
+    #[cfg(feature = "grpc")]
+    async fn spawn_grpc_tls_server(
+        server_config: Arc<tokio_rustls::rustls::ServerConfig>,
+    ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        let tcp = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral port");
+        let addr = tcp.local_addr().expect("local addr");
+        let listener = crate::tls::TlsListener::new(tcp, server_config);
+
+        let routes = crate::grpc::server::GrpcServicesBuilder::new()
+            .add_service(ping_proto::ping_service_server::PingServiceServer::new(
+                PingImpl,
+            ))
+            .build(None);
+        let app = routes.into_axum_router();
+
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (addr, handle)
+    }
+
+    /// Write a CA-signed server leaf to disk and load it through
+    /// `load_server_config`, so the listener's config — ALPN included — is
+    /// exactly what production builds.
+    #[cfg(feature = "grpc")]
+    fn server_config_from_chain(
+        dir: &Path,
+        chain: &TestChain,
+    ) -> Arc<tokio_rustls::rustls::ServerConfig> {
+        let cert_path = dir.join("server.pem");
+        let key_path = dir.join("server.key");
+        std::fs::write(&cert_path, &chain.leaf_pem).expect("write server leaf");
+        std::fs::write(&key_path, &chain.leaf_key_pem).expect("write server key");
+
+        let tls_config = crate::config::TlsConfig {
+            enabled: true,
+            cert_path,
+            key_path,
+            client_ca_path: None,
+            client_auth_optional: false,
+            reload_interval_secs: None,
+            reload_on_sighup: false,
+            handshake_timeout_secs: None,
+        };
+        crate::tls::load_server_config(&tls_config).expect("server config loads")
+    }
+
+    /// Build a client identity that trusts only the test CA.
+    #[cfg(feature = "grpc")]
+    fn client_identity_trusting(dir: &Path, ca_pem: &str) -> ClientIdentityConfig {
+        let client_cert = generate_cert("test-client");
+        let mut identity = write_identity(dir, &client_cert);
+        let ca_path = dir.join("server-ca.pem");
+        std::fs::write(&ca_path, ca_pem).expect("write ca");
+        identity.root_ca_path = Some(ca_path);
+        identity.exclusive_roots = true;
+        identity
+    }
+
+    /// #97: a real generated client, connected through
+    /// [`ClientIdentitySource::grpc_channel`], must complete an RPC. Before the
+    /// fix this fails with `HttpsUriWithoutTlsSupport` on the first call, because
+    /// tonic's `_tls-any` connector wrapper rejects the `https` URI before the
+    /// rotating connector ever runs.
+    #[cfg(feature = "grpc")]
+    #[tokio::test]
+    async fn grpc_channel_completes_a_real_rpc_over_a_tls_listener() {
+        crate::crypto::ensure_default_crypto_provider();
+        let dir = tempfile::tempdir().expect("temp dir");
+        let chain = generate_server_chain();
+
+        let server_config = server_config_from_chain(dir.path(), &chain);
+        let (addr, server) = spawn_grpc_tls_server(server_config).await;
+
+        let identity = client_identity_trusting(dir.path(), &chain.ca_pem);
+        let source = ClientIdentitySource::from_config(&identity).expect("client identity source");
+
+        let endpoint =
+            tonic::transport::Endpoint::from_shared(format!("https://127.0.0.1:{}", addr.port()))
+                .expect("valid endpoint");
+        let channel = source
+            .grpc_channel(endpoint)
+            .expect("grpc_channel must build a channel for an https endpoint");
+
+        let mut client = ping_proto::ping_service_client::PingServiceClient::new(channel);
+        let response = client
+            .ping(ping_proto::PingRequest {
+                message: "hello".to_string(),
+            })
+            .await
+            .expect("the RPC must succeed over the rotating TLS channel");
+
+        assert_eq!(response.into_inner().message, "pong: hello");
+        server.abort();
+    }
+
+    /// #98: a strict `tonic` client — one built from the crate's own
+    /// `tonic_client_tls_config`, which does not set `assume_http2` — must
+    /// negotiate HTTP/2 against the listener. Before the fix the listener
+    /// advertises no ALPN, so the eager `connect()` fails with `H2NotNegotiated`.
+    #[cfg(feature = "grpc")]
+    #[tokio::test]
+    async fn a_strict_tonic_client_negotiates_h2_via_server_alpn() {
+        crate::crypto::ensure_default_crypto_provider();
+        let dir = tempfile::tempdir().expect("temp dir");
+        let chain = generate_server_chain();
+
+        let server_config = server_config_from_chain(dir.path(), &chain);
+        let (addr, server) = spawn_grpc_tls_server(server_config).await;
+
+        let identity = client_identity_trusting(dir.path(), &chain.ca_pem);
+        let source = ClientIdentitySource::from_config(&identity).expect("client identity source");
+        let tls = source
+            .tonic_client_tls_config_snapshot()
+            .expect("tonic client TLS config");
+
+        // Eager connect: tonic verifies the negotiated ALPN during the handshake,
+        // so this is where a listener without ALPN fails.
+        let channel =
+            tonic::transport::Endpoint::from_shared(format!("https://127.0.0.1:{}", addr.port()))
+                .expect("valid endpoint")
+                .tls_config(tls)
+                .expect("endpoint accepts the tonic TLS config")
+                .connect()
+                .await
+                .expect("a strict tonic client must negotiate h2 once the server advertises ALPN");
+
+        let mut client = ping_proto::ping_service_client::PingServiceClient::new(channel);
+        let response = client
+            .ping(ping_proto::PingRequest {
+                message: "strict".to_string(),
+            })
+            .await
+            .expect("the RPC over the strict tonic TLS channel must succeed");
+
+        assert_eq!(response.into_inner().message, "pong: strict");
+        server.abort();
     }
 }

--- a/acton-service/src/tls.rs
+++ b/acton-service/src/tls.rs
@@ -1208,6 +1208,18 @@ pub fn load_server_config(tls_config: &TlsConfig) -> Result<Arc<ServerConfig>> {
         crate::error::Error::Internal(format!("Failed to build TLS server config: {}", e))
     })?;
 
+    // Advertise ALPN so the listener answers a client's protocol offer during
+    // the handshake. Without this rustls selects nothing, and a strict gRPC
+    // client — a `tonic` `ClientTlsConfig` that does not set `assume_http2`,
+    // grpcurl, or any non-Rust stack — fails with `H2NotNegotiated` even though
+    // the listener genuinely serves HTTP/2. `[h2, http/1.1]` is correct for
+    // every listener this loads, the dedicated gRPC one included: it serves
+    // both (hyper auto-detects the protocol), rustls picks the best mutual
+    // protocol so h2 wins for a gRPC client, and a client that offers no ALPN is
+    // unaffected because protocol sniffing still applies.
+    let mut config = config;
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+
     Ok(Arc::new(config))
 }
 


### PR DESCRIPTION
Fixes two complementary gRPC-over-TLS bugs and ships the patch release in the same PR.

## The bugs

An acton-service gRPC **client** could not reach an acton-service gRPC **TLS listener** through tonic's TLS plumbing — two separate failures on the same path:

### #97 — `grpc_channel` fails with `HttpsUriWithoutTlsSupport`
Whenever a tonic TLS feature is compiled in (our `crypto-aws-lc-rs`/`crypto-ring` features always pull `tonic/tls-*`), tonic wraps a custom connector in a scheme-inspecting `Connector` that rejects an `https` URI **before** the custom connector runs — so the rotating channel never connected in its intended config.

**Fix:** build the lazy channel through `tonic::transport::Channel::new(connector, endpoint)` (tonic's documented lower-level custom-connector entry point), which applies the connector directly and skips that wrapper while preserving the endpoint's per-RPC timeout, keep-alive, concurrency, HTTP/2 tuning and user agent.

> Note: `Endpoint::connect_timeout` is **not** honoured on this path — tonic applies it only inside the bypassed wrapper and exposes no getter to re-apply it. This is now documented on `grpc_channel` with the caller-side remedy (`tokio::time::timeout` around the first RPC). Tracked as a follow-up for an internal connect/handshake bound.

### #98 — listener advertises no ALPN → `H2NotNegotiated`
`load_server_config` set no `alpn_protocols`, so the listener answered no ALPN offer and strict gRPC clients (tonic `ClientTlsConfig` without `assume_http2`, grpcurl, non-Rust stacks) failed the handshake.

**Fix:** advertise `[h2, http/1.1]` — correct for every listener this loads (dedicated gRPC included); ALPN-less clients are unaffected (sniffing still applies).

## Tests
Two end-to-end tests drive a **real generated tonic client** through `Endpoint`/`Channel` against a **live TLS listener** (not the connector in isolation, which is why CI missed these). Both were verified to **fail with the exact bug error before the fix and pass after** (reverted each fix locally: #97 → `HttpsUriWithoutTlsSupport`, #98 → `H2NotNegotiated`).

## Review
Independently adversarially reviewed: the `Channel::new` mechanism was confirmed against the tonic 0.14.6 source (it genuinely skips the scheme-checking wrapper), ALPN correctness confirmed, and both tests confirmed to exercise the real failing paths. The review surfaced the `connect_timeout` gap (addressed via docs) and a duplicated comment (removed).

## Release — 0.31.1 (patch)
Purely internal fixes, no API changes. Bundled into this PR: version bump, CHANGELOG under `acton-service-v0.31.1`, acton-docs version-file sync. After merge: tag `acton-service-v0.31.1` (signed) + `cargo publish -p acton-service`.

## Gates
- `cargo clippy --all-targets --features full` → 0 warnings
- `cargo clippy --no-default-features --features "full,crypto-ring"` → 0 warnings
- `cargo nextest run --features full` → 767 passed, 0 failed (2 new)
- `cargo test --doc --features full` (RUSTDOCFLAGS=-D warnings) → 104 passed
- `cargo fmt` clean; no clippy suppressions; no hand-edited deps

Closes #97
Closes #98