### PR TITLE
fix(audit): full-coverage chain hash, recomputable export, gated drift endpoint, untrusted forwarded headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [acton-service-v0.31.2] - 2026-07-24
+
+Hardens the audit trail for deployments that treat the exported stream as the
+audit record. Three fixes, found while wiring the `audit` feature into a
+downstream admin plane: the chain hash ignored half the event, the drift
+endpoint mounted itself unauthenticated, and the audit source IP trusted
+client-supplied headers. No breaking API changes; two new config keys, both
+default-off.
+
+### Fixed
+
+- **audit**: The chain hash now covers the whole event. The legacy scheme
+  omitted `metadata`, source IP, user agent, request ID, and duration — a
+  tampered role list or forged origin verified as intact. New events seal
+  under a self-describing `v2:`-prefixed hash with length-framed fields;
+  the version travels inside the hash string itself, so storage schemas are
+  unchanged and chains spanning the upgrade verify per event. Metadata is
+  hashed as canonical recursively-key-sorted JSON, stable across
+  `preserve_order` feature unification and JSON-normalizing stores. A
+  mid-chain downgrade forgery is caught by the successor's `previous_hash`.
+- **audit**: The syslog export now emits every hash input (event id,
+  canonical RFC 3339 timestamp, kind, severity, service, user agent,
+  canonical metadata, previous hash), so a chain rebuilt from exported lines
+  alone recomputes and verifies — required when syslog is the only durable
+  store. `AuditEventKind::from_wire` provides the Display-inverse a verifier
+  needs; a round-trip test pins export → parse → verify.
+- **audit**: `GET /admin/config/drift` is no longer mounted unconditionally.
+  It carries no authentication and sits on the outer router, outside any
+  route-level middleware, so compiling the `audit` feature in exposed config
+  fingerprints and drift sections to any caller. It now mounts only when the
+  new `[audit] drift_endpoint_enabled` flag (default `false`) is set.
+- **middleware**: The request context no longer hardcodes trust in
+  `X-Forwarded-For` / `X-Real-IP` when resolving the client IP that audit
+  events record. Trust is now `[service] trust_forwarded_headers` (default
+  `false`: the direct TCP/TLS peer wins, so a direct client cannot falsify
+  its recorded origin). The header-only fallback used by hand-assembled
+  routers records no IP at all rather than a spoofable one. Rate limiting
+  keeps its own independent flag.
+
 ## [acton-service-v0.31.1] - 2026-07-20
 
 Makes gRPC-over-TLS work end to end. Two complementary bugs left an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "acton-cli"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "acton-service",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.3"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
 dependencies = [
  "cssparser",
  "html5ever",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["acton-service", "acton-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.31.1"
+version = "0.31.2"
 edition = "2021"
 authors = ["roland@govcraft.ai"]
 license = "MIT"

--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-acton-service = { path = "../acton-service", version = "0.31.1" }
+acton-service = { path = "../acton-service", version = "0.31.2" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/acton-docs/src/lib/version.ts
+++ b/acton-docs/src/lib/version.ts
@@ -2,4 +2,4 @@
  * Version information for acton-service
  * This should match the version in the root Cargo.toml workspace.package.version
  */
-export const VERSION = '0.31.1'
+export const VERSION = '0.31.2'

--- a/acton-docs/src/markdoc/config.js
+++ b/acton-docs/src/markdoc/config.js
@@ -4,7 +4,7 @@ import { siteConfig } from '../lib/config'
 
 // Extract version from workspace Cargo.toml
 // This should be kept in sync with the workspace version
-const ACTON_VERSION = '0.31.1'
+const ACTON_VERSION = '0.31.2'
 
 // Single source of truth mapping camelCase aliases to the real Cargo feature
 // lists. Used by both the `dep()` function and the `$dep.*` variables so a

--- a/acton-docs/src/markdoc/functions.js
+++ b/acton-docs/src/markdoc/functions.js
@@ -1,5 +1,5 @@
 // Markdoc functions for version management
-const ACTON_VERSION = '0.31.1'
+const ACTON_VERSION = '0.31.2'
 
 export const version = {
   transform() {

--- a/acton-service/src/audit/chain.rs
+++ b/acton-service/src/audit/chain.rs
@@ -4,10 +4,38 @@
 //! plus the previous event's hash, forming an ordered chain. Any modification to
 //! a past event invalidates all subsequent hashes.
 //!
+//! # Hash versions
+//!
+//! The hash string is self-describing: a `v2:` prefix marks the current
+//! scheme; an unprefixed hash is the legacy v1 scheme. The version travels
+//! with the hash itself — through storage columns, syslog export, and
+//! archives — so mixed-version chains verify without any schema change, and
+//! [`verify_chain`] dispatches per event.
+//!
+//! - **v1** (legacy): covered sequence, previous hash, id, timestamp, kind,
+//!   severity, service name, method, path, status code, and subject —
+//!   concatenated without framing. Metadata, source IP, user agent, request
+//!   ID, and duration were *not* covered.
+//! - **v2**: covers every event field, each framed with a presence tag and a
+//!   little-endian length prefix so field boundaries are unambiguous.
+//!   Metadata is hashed as canonical JSON (recursively key-sorted), which
+//!   stays byte-stable across serializers that preserve insertion order and
+//!   across stores that re-normalize JSON.
+//!
+//! A forged downgrade (rewriting a v2 event and stamping it with an
+//! unprefixed v1 hash) is caught by the next event's `previous_hash`, which
+//! stores the original prefixed string. The final event of a chain has no
+//! successor, so its version — like its existence — is only as trustworthy
+//! as the chain tail ever is; anchoring the head externally is what bounds
+//! truncation, not the hash scheme.
+//!
 //! `AuditChain` is intentionally NOT `Send`/`Sync` — it is owned exclusively by
 //! the `AuditAgent` actor, which processes events sequentially.
 
 use super::event::AuditEvent;
+
+/// Prefix marking a hash computed under the v2 (full-coverage) scheme.
+const HASH_V2_PREFIX: &str = "v2:";
 
 /// BLAKE3 hash chain state
 ///
@@ -70,41 +98,103 @@ impl AuditChain {
         self.previous_hash.as_deref()
     }
 
-    /// Compute the BLAKE3 hash for an event
-    ///
-    /// The hash covers: sequence, previous_hash, id, timestamp, kind, severity,
-    /// service_name, method, path, status_code, and source.subject.
-    /// This makes the hash deterministic and verifiable.
+    /// Compute the current (v2) hash for an event.
     fn compute_hash(&self, event: &AuditEvent) -> String {
-        let mut hasher = blake3::Hasher::new();
-
-        hasher.update(event.sequence.to_le_bytes().as_ref());
-
-        if let Some(ref prev) = event.previous_hash {
-            hasher.update(prev.as_bytes());
-        }
-
-        hasher.update(event.id.as_bytes());
-        hasher.update(event.timestamp.to_rfc3339().as_bytes());
-        hasher.update(event.kind.to_string().as_bytes());
-        hasher.update(&[event.severity.as_syslog_severity()]);
-        hasher.update(event.service_name.as_bytes());
-
-        if let Some(ref method) = event.method {
-            hasher.update(method.as_bytes());
-        }
-        if let Some(ref path) = event.path {
-            hasher.update(path.as_bytes());
-        }
-        if let Some(code) = event.status_code {
-            hasher.update(code.to_le_bytes().as_ref());
-        }
-        if let Some(ref subject) = event.source.subject {
-            hasher.update(subject.as_bytes());
-        }
-
-        hasher.finalize().to_hex().to_string()
+        compute_hash_v2(event)
     }
+}
+
+/// Serialize a JSON value with recursively sorted object keys.
+///
+/// This is the canonical form the v2 hash consumes for `metadata`, and the
+/// form the syslog exporter emits, so the two always agree. Plain
+/// `serde_json::to_string` is not stable enough for either job: with the
+/// `preserve_order` feature (which any crate in a shared workspace can switch
+/// on), objects serialize in insertion order, and JSON stores like Postgres
+/// `jsonb` re-normalize key order on round-trip.
+pub(crate) fn canonical_json(value: &serde_json::Value) -> String {
+    fn write_value(value: &serde_json::Value, out: &mut String) {
+        match value {
+            serde_json::Value::Object(map) => {
+                let mut keys: Vec<&String> = map.keys().collect();
+                keys.sort_unstable();
+                out.push('{');
+                for (index, key) in keys.iter().enumerate() {
+                    if index > 0 {
+                        out.push(',');
+                    }
+                    // Key and scalar serialization cannot fail: a JSON string
+                    // or scalar has no fallible Serialize path.
+                    out.push_str(&serde_json::to_string(key).expect("JSON string serializes"));
+                    out.push(':');
+                    write_value(&map[key.as_str()], out);
+                }
+                out.push('}');
+            }
+            serde_json::Value::Array(items) => {
+                out.push('[');
+                for (index, item) in items.iter().enumerate() {
+                    if index > 0 {
+                        out.push(',');
+                    }
+                    write_value(item, out);
+                }
+                out.push(']');
+            }
+            scalar => {
+                out.push_str(&serde_json::to_string(scalar).expect("JSON scalar serializes"));
+            }
+        }
+    }
+
+    let mut out = String::new();
+    write_value(value, &mut out);
+    out
+}
+
+/// Compute the v2 (full-coverage) hash for an event, `v2:`-prefixed.
+///
+/// Every field is framed as a presence tag (`0`/`1`) followed, when present,
+/// by a little-endian `u64` byte length and the bytes themselves, in this
+/// fixed order: sequence, previous_hash, id, timestamp (RFC 3339), kind,
+/// severity, service_name, method, path, status_code, subject, ip,
+/// user_agent, request_id, duration_ms, metadata (canonical JSON). The
+/// framing makes field boundaries unambiguous, unlike the v1 concatenation.
+fn compute_hash_v2(event: &AuditEvent) -> String {
+    let mut hasher = blake3::Hasher::new();
+
+    let mut frame = |bytes: Option<&[u8]>| match bytes {
+        Some(bytes) => {
+            hasher.update(&[1]);
+            hasher.update((bytes.len() as u64).to_le_bytes().as_ref());
+            hasher.update(bytes);
+        }
+        None => {
+            hasher.update(&[0]);
+        }
+    };
+
+    frame(Some(event.sequence.to_le_bytes().as_ref()));
+    frame(event.previous_hash.as_deref().map(str::as_bytes));
+    frame(Some(event.id.as_bytes()));
+    frame(Some(event.timestamp.to_rfc3339().as_bytes()));
+    frame(Some(event.kind.to_string().as_bytes()));
+    frame(Some(&[event.severity.as_syslog_severity()]));
+    frame(Some(event.service_name.as_bytes()));
+    frame(event.method.as_deref().map(str::as_bytes));
+    frame(event.path.as_deref().map(str::as_bytes));
+    let status_bytes = event.status_code.map(u16::to_le_bytes);
+    frame(status_bytes.as_ref().map(<[u8; 2]>::as_slice));
+    frame(event.source.subject.as_deref().map(str::as_bytes));
+    frame(event.source.ip.as_deref().map(str::as_bytes));
+    frame(event.source.user_agent.as_deref().map(str::as_bytes));
+    frame(event.source.request_id.as_deref().map(str::as_bytes));
+    let duration_bytes = event.duration_ms.map(u64::to_le_bytes);
+    frame(duration_bytes.as_ref().map(<[u8; 8]>::as_slice));
+    let metadata_canonical = event.metadata.as_ref().map(canonical_json);
+    frame(metadata_canonical.as_deref().map(str::as_bytes));
+
+    format!("{HASH_V2_PREFIX}{}", hasher.finalize().to_hex())
 }
 
 /// Verify a chain of events is intact
@@ -146,8 +236,22 @@ pub fn verify_chain(events: &[AuditEvent]) -> Result<(), ChainVerificationError>
     Ok(())
 }
 
-/// Recompute the BLAKE3 hash for a single event (for verification)
+/// Recompute the hash for a single event (for verification), dispatching on
+/// the version prefix carried by the event's own hash string. An event with
+/// no hash at all recomputes under the current scheme, which cannot match —
+/// verification then fails, as it should.
 fn recompute_hash(event: &AuditEvent) -> String {
+    match event.hash.as_deref() {
+        Some(hash) if hash.starts_with(HASH_V2_PREFIX) => compute_hash_v2(event),
+        Some(_) => compute_hash_v1(event),
+        None => compute_hash_v2(event),
+    }
+}
+
+/// The legacy (v1) hash: unframed concatenation of a subset of fields.
+/// Kept only so chains sealed before the v2 scheme still verify; nothing
+/// seals with it anymore.
+fn compute_hash_v1(event: &AuditEvent) -> String {
     let mut hasher = blake3::Hasher::new();
 
     hasher.update(event.sequence.to_le_bytes().as_ref());
@@ -314,5 +418,103 @@ mod tests {
             assert!(event.sequence > prev_seq);
             prev_seq = event.sequence;
         }
+    }
+
+    /// Builds an event carrying every field the v1 hash ignored.
+    fn make_rich_event() -> AuditEvent {
+        let mut event = make_event(AuditEventKind::HttpRequest).with_source(
+            crate::audit::event::AuditSource {
+                ip: Some("198.51.100.42".to_string()),
+                user_agent: Some("curl/8.0".to_string()),
+                subject: Some("operator-1".to_string()),
+                request_id: Some("req_abc".to_string()),
+            },
+        );
+        event = event.with_http("POST".to_string(), "/admin/x".to_string(), Some(200), Some(12));
+        event.metadata = Some(serde_json::json!({"roles": ["auditor"], "action": "readX"}));
+        event
+    }
+
+    #[test]
+    fn sealed_hashes_carry_the_v2_prefix() {
+        let mut chain = AuditChain::new("test-service".to_string());
+        let sealed = chain.seal(make_rich_event());
+        assert!(sealed.hash.as_deref().unwrap().starts_with("v2:"));
+    }
+
+    /// The v1 blind spots — metadata, source IP, user agent, request ID, and
+    /// duration — must each invalidate the v2 hash when tampered with.
+    #[test]
+    fn v2_hash_covers_the_fields_v1_ignored() {
+        let mut chain = AuditChain::new("test-service".to_string());
+        let sealed = chain.seal(make_rich_event());
+
+        let tampers: [fn(&mut AuditEvent); 5] = [
+            |e| e.metadata = Some(serde_json::json!({"roles": ["provisioner"]})),
+            |e| e.source.ip = Some("203.0.113.99".to_string()),
+            |e| e.source.user_agent = Some("evil/1.0".to_string()),
+            |e| e.source.request_id = Some("req_forged".to_string()),
+            |e| e.duration_ms = Some(9999),
+        ];
+
+        for tamper in tampers {
+            let mut tampered = sealed.clone();
+            tamper(&mut tampered);
+            assert!(
+                verify_chain(std::slice::from_ref(&tampered)).is_err(),
+                "a tampered field the v1 hash ignored must break v2 verification"
+            );
+        }
+
+        assert!(verify_chain(std::slice::from_ref(&sealed)).is_ok());
+    }
+
+    /// A chain spanning the scheme change — legacy v1 events followed by v2
+    /// events — verifies end to end, with each hash judged under its own
+    /// scheme.
+    #[test]
+    fn mixed_v1_and_v2_chains_verify() {
+        // Hand-seal a legacy event exactly as the v1 chain did.
+        let mut legacy = make_event(AuditEventKind::AuthLoginSuccess);
+        legacy.sequence = 1;
+        legacy.previous_hash = None;
+        let legacy_hash = compute_hash_v1(&legacy);
+        assert!(!legacy_hash.starts_with("v2:"));
+        legacy.hash = Some(legacy_hash.clone());
+
+        // Continue the chain under the current scheme.
+        let mut chain = AuditChain::resume("test-service".to_string(), legacy_hash, 1);
+        let successor = chain.seal(make_rich_event());
+        assert!(successor.hash.as_deref().unwrap().starts_with("v2:"));
+
+        assert!(verify_chain(&[legacy, successor]).is_ok());
+    }
+
+    /// Rewriting a v2 event and stamping it with an unprefixed v1 hash must
+    /// not slip past verification when the event has a successor: the
+    /// successor's `previous_hash` pins the original v2 string.
+    #[test]
+    fn downgrade_forgery_is_caught_by_the_successor_link() {
+        let mut chain = AuditChain::new("test-service".to_string());
+        let first = chain.seal(make_rich_event());
+        let second = chain.seal(make_event(AuditEventKind::HttpRequest));
+
+        let mut forged = first.clone();
+        forged.metadata = Some(serde_json::json!({"roles": ["provisioner"]}));
+        forged.hash = Some(compute_hash_v1(&forged));
+
+        assert!(verify_chain(&[forged, second]).is_err());
+    }
+
+    #[test]
+    fn canonical_json_sorts_keys_recursively() {
+        let value = serde_json::json!({
+            "zeta": {"b": 2, "a": 1},
+            "alpha": [{"y": true, "x": false}],
+        });
+        assert_eq!(
+            canonical_json(&value),
+            r#"{"alpha":[{"x":false,"y":true}],"zeta":{"a":1,"b":2}}"#
+        );
     }
 }

--- a/acton-service/src/audit/config.rs
+++ b/acton-service/src/audit/config.rs
@@ -33,6 +33,18 @@ pub struct AuditConfig {
     #[serde(default = "default_true")]
     pub audit_config_events: bool,
 
+    /// Mount the `GET /admin/config/drift` endpoint (default: false)
+    ///
+    /// The drift endpoint reports the active config fingerprint and which
+    /// sections changed on disk. It carries no authentication of its own and
+    /// is mounted on the outer router, outside any route-level middleware —
+    /// so it discloses configuration metadata to any caller that can reach
+    /// the listener. It stays unmounted unless explicitly enabled, and
+    /// deployments that enable it should front it with their own access
+    /// control.
+    #[serde(default)]
+    pub drift_endpoint_enabled: bool,
+
     /// Syslog export configuration
     #[serde(default)]
     pub syslog: SyslogConfig,
@@ -75,6 +87,7 @@ impl Default for AuditConfig {
             audit_all_requests: false,
             audit_auth_events: true,
             audit_config_events: true,
+            drift_endpoint_enabled: false,
             syslog: SyslogConfig::default(),
             otlp_logs_enabled: false,
             audited_routes: Vec::new(),
@@ -250,6 +263,7 @@ mod tests {
             audit_all_requests: true,
             audit_auth_events: false,
             audit_config_events: true,
+            drift_endpoint_enabled: false,
             syslog: SyslogConfig {
                 transport: "tcp".to_string(),
                 address: "syslog.example.com:514".to_string(),

--- a/acton-service/src/audit/event.rs
+++ b/acton-service/src/audit/event.rs
@@ -223,6 +223,66 @@ impl std::fmt::Display for AuditEventKind {
     }
 }
 
+impl AuditEventKind {
+    /// Parse a kind back from its wire string — the exact inverse of
+    /// [`Display`](std::fmt::Display), which the chain hash and the syslog
+    /// `kind` param both consume. A verifier rebuilding events from exported
+    /// lines needs this to recompute hashes, so the two `match`es must stay
+    /// mirror images.
+    ///
+    /// Returns `None` for a string this build does not know — either a kind
+    /// introduced by a newer producer, or one behind a feature this build
+    /// compiled out. Verification cannot proceed past such an event, which is
+    /// the honest answer: an unknown kind cannot be re-hashed faithfully.
+    pub fn from_wire(s: &str) -> Option<Self> {
+        if let Some(name) = s.strip_prefix("custom.") {
+            return Some(Self::Custom(name.to_string()));
+        }
+        match s {
+            "auth.login.success" => Some(Self::AuthLoginSuccess),
+            "auth.login.failed" => Some(Self::AuthLoginFailed),
+            "auth.token.missing" => Some(Self::AuthTokenMissing),
+            "auth.token.invalid" => Some(Self::AuthTokenInvalid),
+            "auth.logout" => Some(Self::AuthLogout),
+            "auth.token.refresh" => Some(Self::AuthTokenRefresh),
+            "auth.token.revoked" => Some(Self::AuthTokenRevoked),
+            "auth.password.changed" => Some(Self::AuthPasswordChanged),
+            "auth.apikey.created" => Some(Self::AuthApiKeyCreated),
+            "auth.apikey.revoked" => Some(Self::AuthApiKeyRevoked),
+            "auth.oauth.callback" => Some(Self::AuthOAuthCallback),
+            "auth.permission.denied" => Some(Self::AuthPermissionDenied),
+            #[cfg(feature = "login-lockout")]
+            "auth.account.locked" => Some(Self::AuthAccountLocked),
+            #[cfg(feature = "login-lockout")]
+            "auth.account.unlocked" => Some(Self::AuthAccountUnlocked),
+            #[cfg(feature = "accounts")]
+            "account.created" => Some(Self::AccountCreated),
+            #[cfg(feature = "accounts")]
+            "account.disabled" => Some(Self::AccountDisabled),
+            #[cfg(feature = "accounts")]
+            "account.enabled" => Some(Self::AccountEnabled),
+            #[cfg(feature = "accounts")]
+            "account.locked" => Some(Self::AccountLocked),
+            #[cfg(feature = "accounts")]
+            "account.unlocked" => Some(Self::AccountUnlocked),
+            #[cfg(feature = "accounts")]
+            "account.expired" => Some(Self::AccountExpired),
+            #[cfg(feature = "accounts")]
+            "account.deleted" => Some(Self::AccountDeleted),
+            #[cfg(feature = "accounts")]
+            "account.updated" => Some(Self::AccountUpdated),
+            "auth.key.rotated" => Some(Self::AuthKeyRotated),
+            "auth.key.retired" => Some(Self::AuthKeyRetired),
+            "auth.key.rotation_failed" => Some(Self::AuthKeyRotationFailed),
+            "config.loaded" => Some(Self::ConfigLoaded),
+            "config.drift_detected" => Some(Self::ConfigDriftDetected),
+            "http.request" => Some(Self::HttpRequest),
+            "http.request.denied" => Some(Self::HttpRequestDenied),
+            _ => None,
+        }
+    }
+}
+
 /// Audit event severity levels
 ///
 /// Maps directly to syslog severity values (RFC 5424).
@@ -324,6 +384,59 @@ mod tests {
             AuditEventKind::Custom("user.delete".to_string()).to_string(),
             "custom.user.delete"
         );
+    }
+
+    #[test]
+    fn every_kind_round_trips_through_its_wire_string() {
+        let mut kinds = vec![
+            AuditEventKind::AuthLoginSuccess,
+            AuditEventKind::AuthLoginFailed,
+            AuditEventKind::AuthTokenMissing,
+            AuditEventKind::AuthTokenInvalid,
+            AuditEventKind::AuthLogout,
+            AuditEventKind::AuthTokenRefresh,
+            AuditEventKind::AuthTokenRevoked,
+            AuditEventKind::AuthPasswordChanged,
+            AuditEventKind::AuthApiKeyCreated,
+            AuditEventKind::AuthApiKeyRevoked,
+            AuditEventKind::AuthOAuthCallback,
+            AuditEventKind::AuthPermissionDenied,
+            AuditEventKind::AuthKeyRotated,
+            AuditEventKind::AuthKeyRetired,
+            AuditEventKind::AuthKeyRotationFailed,
+            AuditEventKind::ConfigLoaded,
+            AuditEventKind::ConfigDriftDetected,
+            AuditEventKind::HttpRequest,
+            AuditEventKind::HttpRequestDenied,
+            AuditEventKind::Custom("user.delete".to_string()),
+        ];
+        #[cfg(feature = "login-lockout")]
+        kinds.extend([
+            AuditEventKind::AuthAccountLocked,
+            AuditEventKind::AuthAccountUnlocked,
+        ]);
+        #[cfg(feature = "accounts")]
+        kinds.extend([
+            AuditEventKind::AccountCreated,
+            AuditEventKind::AccountDisabled,
+            AuditEventKind::AccountEnabled,
+            AuditEventKind::AccountLocked,
+            AuditEventKind::AccountUnlocked,
+            AuditEventKind::AccountExpired,
+            AuditEventKind::AccountDeleted,
+            AuditEventKind::AccountUpdated,
+        ]);
+
+        for kind in kinds {
+            let wire = kind.to_string();
+            assert_eq!(
+                AuditEventKind::from_wire(&wire),
+                Some(kind),
+                "from_wire must invert Display for `{wire}`"
+            );
+        }
+
+        assert_eq!(AuditEventKind::from_wire("no.such.kind"), None);
     }
 
     #[test]

--- a/acton-service/src/audit/syslog.rs
+++ b/acton-service/src/audit/syslog.rs
@@ -84,6 +84,15 @@ impl SyslogSender {
     /// Format an audit event as RFC 5424 syslog message
     ///
     /// Format: `<PRI>VERSION TIMESTAMP HOSTNAME APP-NAME PROCID MSGID [SD-ID SD-PARAM...] MSG`
+    ///
+    /// The structured data carries **every input of the chain hash** — with
+    /// syslog as the only durable store, the exported stream must be enough
+    /// to recompute and verify the chain on its own. `ts` is the exact
+    /// RFC 3339 string the hash consumes (the header timestamp uses the
+    /// RFC 5424 format and is not byte-identical), `metadata` is the same
+    /// canonical key-sorted JSON the hash consumes, and `prev_hash` makes any
+    /// contiguous slice of exported lines verifiable without the lines before
+    /// it.
     fn format_rfc5424(&self, event: &AuditEvent) -> String {
         // PRI = facility * 8 + severity
         let pri = (self.facility as u16) * 8 + event.severity.as_syslog_severity() as u16;
@@ -99,8 +108,28 @@ impl SyslogSender {
 
         // Structured data
         let mut sd_params = Vec::new();
+        sd_params.push(format!("event_id=\"{}\"", event.id));
+        sd_params.push(format!(
+            "ts=\"{}\"",
+            escape_sd_value(&event.timestamp.to_rfc3339())
+        ));
+        sd_params.push(format!(
+            "kind=\"{}\"",
+            escape_sd_value(&event.kind.to_string())
+        ));
+        sd_params.push(format!(
+            "severity=\"{}\"",
+            event.severity.as_syslog_severity()
+        ));
+        sd_params.push(format!(
+            "service=\"{}\"",
+            escape_sd_value(&event.service_name)
+        ));
         if let Some(ref ip) = event.source.ip {
             sd_params.push(format!("src_ip=\"{}\"", escape_sd_value(ip)));
+        }
+        if let Some(ref user_agent) = event.source.user_agent {
+            sd_params.push(format!("ua=\"{}\"", escape_sd_value(user_agent)));
         }
         if let Some(ref subject) = event.source.subject {
             sd_params.push(format!("subject=\"{}\"", escape_sd_value(subject)));
@@ -120,8 +149,17 @@ impl SyslogSender {
         if let Some(ms) = event.duration_ms {
             sd_params.push(format!("duration_ms=\"{}\"", ms));
         }
+        if let Some(ref metadata) = event.metadata {
+            sd_params.push(format!(
+                "metadata=\"{}\"",
+                escape_sd_value(&crate::audit::chain::canonical_json(metadata))
+            ));
+        }
+        if let Some(ref prev) = event.previous_hash {
+            sd_params.push(format!("prev_hash=\"{}\"", escape_sd_value(prev)));
+        }
         if let Some(ref hash) = event.hash {
-            sd_params.push(format!("hash=\"{}\"", hash));
+            sd_params.push(format!("hash=\"{}\"", escape_sd_value(hash)));
         }
         sd_params.push(format!("seq=\"{}\"", event.sequence));
 
@@ -183,5 +221,139 @@ mod tests {
         assert_eq!(escape_sd_value("he\"llo"), "he\\\"llo");
         assert_eq!(escape_sd_value("he\\llo"), "he\\\\llo");
         assert_eq!(escape_sd_value("he]llo"), "he\\]llo");
+    }
+
+    /// Escape-aware parse of the `[audit@49610 …]` structured-data element
+    /// into key/value pairs — the verifier side of the export format.
+    fn parse_sd_params(message: &str) -> std::collections::HashMap<String, String> {
+        let start = message
+            .find("[audit@49610 ")
+            .expect("audit structured data present")
+            + "[audit@49610 ".len();
+        let mut params = std::collections::HashMap::new();
+        let mut chars = message[start..].chars().peekable();
+
+        loop {
+            match chars.peek() {
+                Some(']') => break,
+                Some(' ') => {
+                    chars.next();
+                }
+                Some(_) => {
+                    let mut key = String::new();
+                    for c in chars.by_ref() {
+                        if c == '=' {
+                            break;
+                        }
+                        key.push(c);
+                    }
+                    assert_eq!(chars.next(), Some('"'), "param value must be quoted");
+                    let mut value = String::new();
+                    loop {
+                        match chars.next().expect("unterminated param value") {
+                            '\\' => value.push(chars.next().expect("dangling escape")),
+                            '"' => break,
+                            c => value.push(c),
+                        }
+                    }
+                    params.insert(key, value);
+                }
+                None => panic!("unterminated structured data"),
+            }
+        }
+        params
+    }
+
+    fn severity_from_byte(byte: u8) -> AuditSeverity {
+        match byte {
+            0 => AuditSeverity::Emergency,
+            1 => AuditSeverity::Alert,
+            2 => AuditSeverity::Critical,
+            3 => AuditSeverity::Error,
+            4 => AuditSeverity::Warning,
+            5 => AuditSeverity::Notice,
+            6 => AuditSeverity::Informational,
+            _ => AuditSeverity::Debug,
+        }
+    }
+
+    /// Rebuild an event purely from an exported line's structured data. The
+    /// kind maps to `Custom(raw)` — only the kind's string enters the hash,
+    /// so a verifier needs no knowledge of the kind vocabulary.
+    fn event_from_sd(params: &std::collections::HashMap<String, String>) -> AuditEvent {
+        AuditEvent {
+            id: params["event_id"].parse().expect("uuid parses"),
+            timestamp: chrono::DateTime::parse_from_rfc3339(&params["ts"])
+                .expect("rfc3339 parses")
+                .with_timezone(&chrono::Utc),
+            kind: AuditEventKind::from_wire(&params["kind"]).expect("kind is known"),
+            severity: severity_from_byte(params["severity"].parse().expect("severity parses")),
+            source: crate::audit::event::AuditSource {
+                ip: params.get("src_ip").cloned(),
+                user_agent: params.get("ua").cloned(),
+                subject: params.get("subject").cloned(),
+                request_id: params.get("request_id").cloned(),
+            },
+            method: params.get("method").cloned(),
+            path: params.get("path").cloned(),
+            status_code: params.get("status").map(|s| s.parse().expect("status parses")),
+            duration_ms: params
+                .get("duration_ms")
+                .map(|s| s.parse().expect("duration parses")),
+            service_name: params["service"].clone(),
+            metadata: params
+                .get("metadata")
+                .map(|s| serde_json::from_str(s).expect("metadata parses")),
+            hash: params.get("hash").cloned(),
+            previous_hash: params.get("prev_hash").cloned(),
+            sequence: params["seq"].parse().expect("seq parses"),
+        }
+    }
+
+    /// The load-bearing property of syslog-only durability: a chain rebuilt
+    /// from nothing but exported lines recomputes and verifies, and a
+    /// tampered export does not.
+    #[test]
+    fn exported_chain_recomputes_and_verifies_from_lines_alone() {
+        let sender = SyslogSender {
+            address: "127.0.0.1:514".parse().unwrap(),
+            facility: 13,
+            app_name: "test-app".to_string(),
+            transport: SyslogTransport::Udp,
+        };
+
+        let mut chain = crate::audit::chain::AuditChain::new("test-service".to_string());
+        let mut lines = Vec::new();
+        for index in 0..3u16 {
+            let mut event = AuditEvent::new(
+                AuditEventKind::Custom(format!("admin.action{index}")),
+                AuditSeverity::Warning,
+                "test-service".to_string(),
+            )
+            .with_source(crate::audit::event::AuditSource {
+                ip: Some("198.51.100.42".to_string()),
+                user_agent: Some("curl/8.0 \"quoted\" [bracketed]".to_string()),
+                subject: Some("operator-1".to_string()),
+                request_id: Some(format!("req_{index}")),
+            })
+            .with_http("POST".to_string(), "/admin/x".to_string(), Some(200), Some(12));
+            event.metadata =
+                Some(serde_json::json!({"roles": ["auditor"], "decision": "permit"}));
+            let sealed = chain.seal(event);
+            lines.push(sender.format_rfc5424(&sealed));
+        }
+
+        let rebuilt: Vec<AuditEvent> = lines
+            .iter()
+            .map(|line| event_from_sd(&parse_sd_params(line)))
+            .collect();
+
+        crate::audit::chain::verify_chain(&rebuilt)
+            .expect("chain rebuilt from exported lines alone must verify");
+
+        // A tampered export breaks: flip one metadata byte in the middle line.
+        let mut tampered = rebuilt;
+        tampered[1].metadata = Some(serde_json::json!({"roles": ["provisioner"]}));
+        assert!(crate::audit::chain::verify_chain(&tampered).is_err());
     }
 }

--- a/acton-service/src/config.rs
+++ b/acton-service/src/config.rs
@@ -184,6 +184,22 @@ pub struct ServiceConfig {
     /// Environment (dev, staging, production)
     #[serde(default = "default_environment")]
     pub environment: String,
+
+    /// Whether the request context trusts forwarded-for headers when resolving
+    /// the client IP.
+    ///
+    /// Governs the [`RequestContext`](crate::middleware::request_context::RequestContext)
+    /// resolution every downstream consumer shares — including audit-event
+    /// source capture. When `true`, `X-Forwarded-For` (first value) and
+    /// `X-Real-IP` are consulted before the direct TCP/TLS peer address. Only
+    /// enable behind a proxy you trust to set these headers — a direct client
+    /// can otherwise spoof the IP recorded in its audit trail.
+    ///
+    /// Defaults to `false` (do not trust) to be safe by default. Rate limiting
+    /// has its own independent flag ([`RateLimitConfig::trust_forwarded_headers`])
+    /// so the governor's trust posture can differ from the audit record's.
+    #[serde(default = "default_false")]
+    pub trust_forwarded_headers: bool,
 }
 
 /// Token authentication configuration
@@ -1760,6 +1776,7 @@ where
                 log_level: default_log_level(),
                 timeout_secs: default_timeout(),
                 environment: default_environment(),
+                trust_forwarded_headers: false,
             },
             token: None,
             rate_limit: RateLimitConfig::default(),
@@ -1917,6 +1934,7 @@ mod tests {
                 log_level: "debug".to_string(),
                 timeout_secs: 30,
                 environment: "test".to_string(),
+                trust_forwarded_headers: false,
             },
             token: Some(TokenConfig::Paseto(PasetoConfig {
                 version: "v4".to_string(),
@@ -1992,6 +2010,7 @@ mod tests {
                 log_level: "info".to_string(),
                 timeout_secs: 30,
                 environment: "dev".to_string(),
+                trust_forwarded_headers: false,
             },
             token: None,
             rate_limit: RateLimitConfig {

--- a/acton-service/src/middleware/request_context.rs
+++ b/acton-service/src/middleware/request_context.rs
@@ -20,6 +20,16 @@
 //! position automatically; services that assemble a `Router` by hand are
 //! responsible for the same ordering, and consumers fall back to header-only
 //! extraction when the extension is absent.
+//!
+//! # Forwarded-header trust
+//!
+//! The client IP resolves from the direct TCP/TLS peer address unless
+//! `[service] trust_forwarded_headers = true` opts into consulting
+//! `X-Forwarded-For` / `X-Real-IP` first. The flag defaults to `false`: these
+//! headers are client-supplied, and trusting them without a fronting proxy
+//! lets any caller falsify the IP recorded in its own audit trail. The
+//! header-only fallback used when this layer is not wired never resolves an
+//! IP at all, for the same reason.
 
 use axum::{
     extract::{ConnectInfo, Request},
@@ -43,11 +53,16 @@ pub struct RequestContext {
 impl RequestContext {
     /// Resolve the context from request parts. Pure — the middleware is a thin
     /// wrapper around this so the resolution logic stays unit-testable.
-    pub(crate) fn resolve(headers: &HeaderMap, connect_info: Option<&SocketAddr>) -> Self {
+    ///
+    /// `trust_forwarded_headers` comes from `[service] trust_forwarded_headers`
+    /// (default `false`); the governor applies its own trust policy separately.
+    pub(crate) fn resolve(
+        headers: &HeaderMap,
+        connect_info: Option<&SocketAddr>,
+        trust_forwarded_headers: bool,
+    ) -> Self {
         Self {
-            // Forwarding headers are trusted here to match the extraction this
-            // replaces; the governor applies its own trust policy separately.
-            ip: extract_client_ip(headers, connect_info, true),
+            ip: extract_client_ip(headers, connect_info, trust_forwarded_headers),
             request_id: header_string(headers, "x-request-id"),
             user_agent: header_string(headers, "user-agent"),
         }
@@ -155,16 +170,15 @@ pub(crate) fn audit_source_for_request<B>(
 
 /// Header-only [`AuditSource`](crate::audit::event::AuditSource) extraction.
 ///
-/// Unlike [`extract_client_ip`] this does not parse the IP, so a malformed
-/// `X-Forwarded-For` still round-trips verbatim into the audit record.
+/// Used only when the [`RequestContext`] extension is absent (hand-assembled
+/// routers that skip [`request_context_middleware`]). The IP is deliberately
+/// left unresolved: on this path there is no connect-info to fall back to, so
+/// the only candidates are client-supplied forwarding headers — and recording
+/// a spoofable value in an audit trail is worse than recording none.
 #[cfg(feature = "audit")]
 pub(crate) fn audit_source_from_headers(headers: &HeaderMap) -> crate::audit::event::AuditSource {
     crate::audit::event::AuditSource {
-        ip: headers
-            .get("x-forwarded-for")
-            .or_else(|| headers.get("x-real-ip"))
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.split(',').next().unwrap_or(s).trim().to_string()),
+        ip: None,
         user_agent: header_string(headers, "user-agent"),
         subject: None,
         request_id: header_string(headers, "x-request-id"),
@@ -173,11 +187,20 @@ pub(crate) fn audit_source_from_headers(headers: &HeaderMap) -> crate::audit::ev
 
 /// Middleware that inserts a [`RequestContext`] into the request extensions.
 ///
-/// Use with [`axum::middleware::from_fn`]. See the module docs for the ordering
-/// this requires.
-pub async fn request_context_middleware(mut request: Request, next: Next) -> Response {
+/// Use with [`axum::middleware::from_fn_with_state`], where the state is the
+/// `[service] trust_forwarded_headers` flag. See the module docs for the
+/// ordering this requires and the trust semantics.
+pub async fn request_context_middleware(
+    axum::extract::State(trust_forwarded_headers): axum::extract::State<bool>,
+    mut request: Request,
+    next: Next,
+) -> Response {
     let connect_info = connect_info_remote_addr(request.extensions());
-    let context = RequestContext::resolve(request.headers(), connect_info.as_ref());
+    let context = RequestContext::resolve(
+        request.headers(),
+        connect_info.as_ref(),
+        trust_forwarded_headers,
+    );
     request.extensions_mut().insert(context);
     next.run(request).await
 }
@@ -246,7 +269,7 @@ mod tests {
         headers.insert("x-request-id", "req_abc123".parse().unwrap());
         headers.insert("user-agent", "acton-test/1.0".parse().unwrap());
 
-        let ctx = RequestContext::resolve(&headers, None);
+        let ctx = RequestContext::resolve(&headers, None, false);
         assert_eq!(ctx.request_id.as_deref(), Some("req_abc123"));
         assert_eq!(ctx.user_agent.as_deref(), Some("acton-test/1.0"));
         assert!(ctx.ip.is_none());
@@ -254,14 +277,24 @@ mod tests {
 
     #[test]
     fn resolve_yields_all_none_for_bare_request() {
-        let ctx = RequestContext::resolve(&HeaderMap::new(), None);
+        let ctx = RequestContext::resolve(&HeaderMap::new(), None, false);
         assert!(ctx.ip.is_none());
         assert!(ctx.request_id.is_none());
         assert!(ctx.user_agent.is_none());
     }
 
+    #[test]
+    fn resolve_ignores_forwarded_headers_by_default_posture() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "203.0.113.5".parse().unwrap());
+        let sa = peer([192, 0, 2, 9], 12345);
+
+        let ctx = RequestContext::resolve(&headers, Some(&sa), false);
+        assert_eq!(ctx.ip.map(|ip| ip.to_string()).as_deref(), Some("192.0.2.9"));
+    }
+
     /// Captures the context observed by a downstream handler.
-    fn capture_router(sink: Arc<Mutex<Option<RequestContext>>>) -> Router {
+    fn capture_router(sink: Arc<Mutex<Option<RequestContext>>>, trust: bool) -> Router {
         Router::new()
             .route(
                 "/",
@@ -274,13 +307,16 @@ mod tests {
                     }
                 }),
             )
-            .layer(axum::middleware::from_fn(request_context_middleware))
+            .layer(axum::middleware::from_fn_with_state(
+                trust,
+                request_context_middleware,
+            ))
     }
 
     #[tokio::test]
-    async fn middleware_inserts_context_from_headers() {
+    async fn middleware_inserts_context_from_headers_when_trusted() {
         let sink = Arc::new(Mutex::new(None));
-        let router = capture_router(Arc::clone(&sink));
+        let router = capture_router(Arc::clone(&sink), true);
 
         let request = http::Request::builder()
             .uri("/")
@@ -302,12 +338,38 @@ mod tests {
         assert_eq!(ctx.user_agent.as_deref(), Some("curl/8.0"));
     }
 
+    /// A direct client cannot falsify its recorded origin: with the default
+    /// untrusted posture, a spoofed `X-Forwarded-For` loses to the peer address.
+    #[tokio::test]
+    async fn middleware_records_peer_over_spoofed_headers_by_default() {
+        let sink = Arc::new(Mutex::new(None));
+        let router = capture_router(Arc::clone(&sink), false);
+
+        let mut request = http::Request::builder()
+            .uri("/")
+            .header("x-forwarded-for", "203.0.113.5")
+            .body(Body::empty())
+            .unwrap();
+        request
+            .extensions_mut()
+            .insert(ConnectInfo(peer([198, 51, 100, 42], 51234)));
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let ctx = sink.lock().unwrap().clone().expect("context inserted");
+        assert_eq!(
+            ctx.ip.map(|ip| ip.to_string()).as_deref(),
+            Some("198.51.100.42")
+        );
+    }
+
     /// The issue #17 regression: with proxy headers stripped, the peer address
     /// must still reach downstream consumers.
     #[tokio::test]
     async fn middleware_uses_connect_info_when_headers_absent() {
         let sink = Arc::new(Mutex::new(None));
-        let router = capture_router(Arc::clone(&sink));
+        let router = capture_router(Arc::clone(&sink), false);
 
         let mut request = http::Request::builder()
             .uri("/")
@@ -387,9 +449,11 @@ mod tests {
         assert_eq!(source.request_id.as_deref(), Some("req_generated"));
     }
 
+    /// The header-only fallback (no [`RequestContext`] wired) never resolves
+    /// an IP: the only candidates are client-supplied forwarding headers.
     #[cfg(feature = "audit")]
     #[test]
-    fn audit_source_for_request_falls_back_to_headers() {
+    fn audit_source_for_request_falls_back_to_headers_without_an_ip() {
         let request = http::Request::builder()
             .uri("/")
             .header("x-forwarded-for", "203.0.113.5, 10.0.0.1")
@@ -399,7 +463,7 @@ mod tests {
             .unwrap();
 
         let source = audit_source_for_request(&request);
-        assert_eq!(source.ip.as_deref(), Some("203.0.113.5"));
+        assert!(source.ip.is_none());
         assert_eq!(source.request_id.as_deref(), Some("req_client"));
         assert_eq!(source.user_agent.as_deref(), Some("curl/8.0"));
         assert!(source.subject.is_none());

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -1241,15 +1241,28 @@ where
         // AppState uses Arc internally, so this is a cheap reference-count bump.
         let state_clone = state.clone();
 
+        // The drift endpoint carries no authentication of its own and sits on
+        // the outer router, outside any route-level middleware — it stays
+        // unmounted unless the deployment opts in.
+        #[cfg(feature = "audit")]
+        let drift_endpoint_enabled = config
+            .audit
+            .as_ref()
+            .is_some_and(|audit| audit.enabled && audit.drift_endpoint_enabled);
+
         // Handle both types of versioned routes
         let app = match routes {
             VersionedRoutes::WithState(router) => {
                 // Health routes already added, just attach state
                 #[cfg(feature = "audit")]
-                let router = router.route(
-                    "/admin/config/drift",
-                    axum::routing::get(crate::audit::config_audit::drift_check_handler::<T>),
-                );
+                let router = if drift_endpoint_enabled {
+                    router.route(
+                        "/admin/config/drift",
+                        axum::routing::get(crate::audit::config_audit::drift_check_handler::<T>),
+                    )
+                } else {
+                    router
+                };
                 #[cfg(feature = "prometheus-metrics")]
                 let router = router.route(
                     "/metrics",
@@ -1265,10 +1278,14 @@ where
                     .route("/ready", get(crate::health::readiness));
 
                 #[cfg(feature = "audit")]
-                let health_router = health_router.route(
-                    "/admin/config/drift",
-                    get(crate::audit::config_audit::drift_check_handler::<T>),
-                );
+                let health_router = if drift_endpoint_enabled {
+                    health_router.route(
+                        "/admin/config/drift",
+                        get(crate::audit::config_audit::drift_check_handler::<T>),
+                    )
+                } else {
+                    health_router
+                };
 
                 #[cfg(feature = "prometheus-metrics")]
                 let health_router =
@@ -2183,7 +2200,8 @@ where
         // request-tracking layers below (later-added layer = outer = runs first) and
         // before auth/audit, which would otherwise see a request ID that has not been
         // generated yet and no ConnectInfo-derived IP (issue #17).
-        app = app.layer(axum::middleware::from_fn(
+        app = app.layer(axum::middleware::from_fn_with_state(
+            config.service.trust_forwarded_headers,
             crate::middleware::request_context::request_context_middleware,
         ));
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -9,6 +9,12 @@ port = 8080
 log_level = "info"  # trace, debug, info, warn, error
 timeout_secs = 30
 environment = "dev"  # dev, staging, production
+# trust_forwarded_headers = false  # Trust X-Forwarded-For / X-Real-IP for the client IP
+                                   # the request context (and audit events) record.
+                                   # Default false: only enable behind a proxy you trust
+                                   # to set these headers — a direct client can otherwise
+                                   # spoof the IP in its own audit trail. Rate limiting
+                                   # has its own flag under [rate_limit].
 
 # ============================================================================
 # gRPC ([grpc] section, requires the `grpc` feature)
@@ -298,6 +304,10 @@ lazy_init = true      # Initialize connection in background
 # otlp_logs_enabled = false         # Export audit logs via OTLP (requires observability)
 # audited_routes = ["/api/v1/admin/*"]   # Glob patterns for per-route auditing
 # excluded_routes = ["/health", "/ready", "/metrics"]
+# drift_endpoint_enabled = false    # Mount GET /admin/config/drift. Default false: the
+                                    # endpoint has no auth of its own and sits outside
+                                    # route-level middleware — front it with your own
+                                    # access control if you enable it.
 #
 # retention_days = 90               # Days to keep events (omit for infinite)
 # archive_path = "/var/audit/archive"  # JSONL archive dir before purge (omit to skip)


### PR DESCRIPTION
## Summary

Three security-hardening fixes for the `audit` feature, released together as **0.31.2**.

### 1. Chain hash v2: full field coverage
The v1 chain hash covered only sequence/prev/id/timestamp/kind/severity/service/method/path/status/subject — `metadata`, `ip`, `user_agent`, `request_id`, and `duration_ms` could be tampered without breaking verification. v2 hashes every field with length-framed, presence-tagged input and a self-describing `v2:` prefix:

- The version travels **inside the hash string**, so no schema change is needed in any storage backend (pg/turso/surrealdb/clickhouse all `SELECT *` then `verify_chain`).
- Mixed v1/v2 chains verify per event; a mid-chain downgrade forgery is caught by the successor's `previous_hash`.
- Metadata is serialized via recursive key-sorted canonical JSON, so `serde_json` `preserve_order` feature unification and jsonb key re-normalization cannot change the hash input.

### 2. Recomputable syslog export
The RFC 5424 export dropped several hash inputs (metadata, user agent, event id, canonical timestamp), so an exported chain could not be independently verified. The export now emits every input, and `AuditEventKind::from_wire` (exact `Display` inverse) lets export-based verifiers rebuild events. A pinning test parses exported lines back into events, recomputes the chain, and verifies it — and fails on metadata tamper.

### 3. Exposure defaults
- `/admin/config/drift` was mounted unconditionally on the **outer** router (no auth, no config gate) whenever the audit feature was compiled in. It is now gated behind `[audit] drift_endpoint_enabled` (default `false`).
- `RequestContext::resolve` hardcoded trust in forwarded-for headers when resolving the client IP. New `[service] trust_forwarded_headers` (default `false`) threads through the middleware; the header-only audit fallback now records no IP rather than a spoofable one.

## Testing

- clippy clean: `--features audit`, `--features full`, `--no-default-features --features "full,crypto-ring"`
- nextest: 776/776 (`full`), 776/776 (`full,crypto-ring`), 236/236 (`audit,turso`), 236/236 (`audit,surrealdb`), 221/221 (`audit,clickhouse`), doctests pass
- New tests: v2 tamper coverage across all previously-uncovered fields, mixed v1/v2 chain verification, downgrade-forgery detection, canonical JSON key sorting, export round-trip recompute+verify, `from_wire` exhaustive round-trip, spoofed-header/peer-IP posture, drift-endpoint gating

## Release prep

Workspace version 0.31.2, CHANGELOG entry, `config.example.toml` documentation for both new flags, acton-docs version files.
