### PR TITLE
feat(health): app-defined liveness and readiness checks on the service builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [acton-service-v0.32.0] - 2026-07-24
+
+Lets a service tell the truth on its probe endpoints. Until now `/health`
+could never fail and `/ready` probed only framework-managed backends
+(database, cache, events); a service whose real readiness lives in
+application state — a writer task, a consensus quorum, a sidecar — had no
+way to surface it. Additive only; services registering no checks behave
+exactly as before.
+
+### Added
+
+- **checks**: App-defined probe checks, registered on the builder:
+  `ServiceBuilder::with_readiness_check(name, || async { … })` folds into
+  `/ready`, `with_liveness_check` into `/health`; both repeatable. A check
+  returns `CheckOutcome::Ready`, `Degraded(message)` (rendered as an
+  unhealthy dependency in the readiness body **without** flipping overall
+  readiness — visible to operators, invisible to the load balancer), or
+  `Unready(message)` (flips the endpoint to 503). Liveness treats `Degraded`
+  as alive — liveness is binary, and a degraded-but-working process must not
+  be killed.
+- **checks**: All of an endpoint's registered checks run concurrently under
+  **one shared deadline** (`with_check_deadline`, default 2s) — N stalled
+  checks cost one deadline, not N; a check unresolved at the deadline
+  reports `Unready("check timed out")`.
+- **state**: `AppState::health_checks()` exposes the installed check set;
+  checks are installed by `build()` whether the state was framework-built or
+  caller-provided.
+
+### Changed
+
+- **health**: `/health` answers 503 with `status: "unhealthy"` when a
+  registered liveness check fails. With no registered checks it cannot fail,
+  exactly as before. `/ready`'s response shape is unchanged; app-defined
+  checks appear as additional entries in `dependencies`.
+
 ## [acton-service-v0.31.2] - 2026-07-24
 
 Hardens the audit trail for deployments that treat the exported stream as the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "acton-cli"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "acton-service",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["acton-service", "acton-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.31.2"
+version = "0.32.0"
 edition = "2021"
 authors = ["roland@govcraft.ai"]
 license = "MIT"

--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-acton-service = { path = "../acton-service", version = "0.31.2" }
+acton-service = { path = "../acton-service", version = "0.32.0" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/acton-service/src/checks.rs
+++ b/acton-service/src/checks.rs
@@ -1,0 +1,254 @@
+//! App-defined liveness and readiness checks.
+//!
+//! The framework's built-in `/ready` handler probes only the backends it
+//! manages (database, cache, events, …). Services whose real readiness lives
+//! in application state — a writer task, a consensus quorum, a sidecar —
+//! register checks here via
+//! [`ServiceBuilder::with_readiness_check`](crate::service::ServiceBuilder::with_readiness_check)
+//! and
+//! [`ServiceBuilder::with_liveness_check`](crate::service::ServiceBuilder::with_liveness_check).
+//!
+//! Semantics:
+//!
+//! - **Liveness** (`/health`) answers "should the process be restarted?". Any
+//!   liveness check returning [`CheckOutcome::Unready`] turns `/health` into
+//!   `503`. A `Degraded` outcome from a liveness check counts as healthy —
+//!   liveness is binary; a degraded-but-working process must not be killed.
+//! - **Readiness** (`/ready`) answers "should the process receive traffic?".
+//!   `Unready` flips the endpoint to `503`; `Degraded` renders the check as an
+//!   unhealthy dependency in the response body **without** flipping overall
+//!   readiness — visible to operators, invisible to the load balancer.
+//!
+//! All registered checks for an endpoint run **concurrently under one shared
+//! deadline** (default [`DEFAULT_CHECK_DEADLINE`]): N stalled checks cost one
+//! deadline, not N. A check unresolved at the deadline reports
+//! `Unready("check timed out")`.
+
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// The shared deadline applied to one endpoint's registered checks when the
+/// builder is not given an explicit one.
+pub const DEFAULT_CHECK_DEADLINE: Duration = Duration::from_secs(2);
+
+/// The message reported for a check still unresolved at the shared deadline.
+const TIMED_OUT: &str = "check timed out";
+
+/// The outcome of one app-defined check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckOutcome {
+    /// The checked concern is healthy.
+    Ready,
+    /// The checked concern is impaired but the endpoint's overall answer is
+    /// unaffected: rendered as an unhealthy dependency on `/ready`, ignored
+    /// for `/health`. The message should say what is impaired and why traffic
+    /// can still flow.
+    Degraded(String),
+    /// The checked concern has failed: `/ready` answers `503` (drain traffic);
+    /// on a liveness check, `/health` answers `503` (restart the process).
+    Unready(String),
+}
+
+/// A boxed future produced by one invocation of a registered check.
+type CheckFuture = Pin<Box<dyn Future<Output = CheckOutcome> + Send>>;
+
+/// One registered check: a display name plus the closure that produces a fresh
+/// outcome future per probe hit.
+#[derive(Clone)]
+pub struct RegisteredCheck {
+    name: String,
+    run: Arc<dyn Fn() -> CheckFuture + Send + Sync>,
+}
+
+impl fmt::Debug for RegisteredCheck {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RegisteredCheck")
+            .field("name", &self.name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RegisteredCheck {
+    /// Wrap a check closure under its display name.
+    pub fn new<F, Fut>(name: impl Into<String>, check: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = CheckOutcome> + Send + 'static,
+    {
+        Self {
+            name: name.into(),
+            run: Arc::new(move || Box::pin(check())),
+        }
+    }
+
+    /// The name the check reports under in the readiness body.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// The immutable set of app-defined checks carried on the application state.
+///
+/// Cheap to clone (the check lists are shared); empty by default, in which
+/// case both endpoints behave exactly as they did before checks existed.
+#[derive(Debug, Clone)]
+pub struct HealthChecks {
+    liveness: Arc<[RegisteredCheck]>,
+    readiness: Arc<[RegisteredCheck]>,
+    deadline: Duration,
+}
+
+impl Default for HealthChecks {
+    fn default() -> Self {
+        Self {
+            liveness: Arc::from([]),
+            readiness: Arc::from([]),
+            deadline: DEFAULT_CHECK_DEADLINE,
+        }
+    }
+}
+
+impl HealthChecks {
+    /// Assemble the frozen check set (called once by the service builder).
+    pub(crate) fn new(
+        liveness: Vec<RegisteredCheck>,
+        readiness: Vec<RegisteredCheck>,
+        deadline: Duration,
+    ) -> Self {
+        Self {
+            liveness: liveness.into(),
+            readiness: readiness.into(),
+            deadline,
+        }
+    }
+
+    /// Run every registered liveness check; `true` when none answered
+    /// `Unready` (a `Degraded` liveness outcome counts as alive).
+    pub async fn liveness_ok(&self) -> bool {
+        run_concurrent(&self.liveness, self.deadline)
+            .await
+            .iter()
+            .all(|(_, outcome)| !matches!(outcome, CheckOutcome::Unready(_)))
+    }
+
+    /// Run every registered readiness check concurrently under the shared
+    /// deadline, returning `(name, outcome)` pairs in registration order.
+    pub async fn readiness_outcomes(&self) -> Vec<(String, CheckOutcome)> {
+        run_concurrent(&self.readiness, self.deadline).await
+    }
+
+    /// Whether any readiness checks are registered.
+    pub fn has_readiness_checks(&self) -> bool {
+        !self.readiness.is_empty()
+    }
+}
+
+/// Run `checks` concurrently under one shared deadline. A check unresolved at
+/// the deadline reports [`CheckOutcome::Unready`] with [`TIMED_OUT`].
+async fn run_concurrent(
+    checks: &[RegisteredCheck],
+    deadline: Duration,
+) -> Vec<(String, CheckOutcome)> {
+    if checks.is_empty() {
+        return Vec::new();
+    }
+    let expiry = tokio::time::Instant::now() + deadline;
+    let futures = checks.iter().map(|check| {
+        let name = check.name.clone();
+        let fut = (check.run)();
+        async move {
+            let outcome = tokio::time::timeout_at(expiry, fut)
+                .await
+                .unwrap_or_else(|_| CheckOutcome::Unready(TIMED_OUT.to_string()));
+            (name, outcome)
+        }
+    });
+    futures::future::join_all(futures).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn checks_of(list: Vec<RegisteredCheck>) -> HealthChecks {
+        HealthChecks::new(list.clone(), list, Duration::from_millis(200))
+    }
+
+    #[tokio::test]
+    async fn empty_check_set_is_ready_and_alive() {
+        let checks = HealthChecks::default();
+        assert!(checks.liveness_ok().await);
+        assert!(checks.readiness_outcomes().await.is_empty());
+        assert!(!checks.has_readiness_checks());
+    }
+
+    #[tokio::test]
+    async fn outcomes_preserve_registration_order_and_values() {
+        let checks = checks_of(vec![
+            RegisteredCheck::new("a", || async { CheckOutcome::Ready }),
+            RegisteredCheck::new("b", || async {
+                CheckOutcome::Degraded("impaired".to_string())
+            }),
+            RegisteredCheck::new("c", || async {
+                CheckOutcome::Unready("failed".to_string())
+            }),
+        ]);
+        let outcomes = checks.readiness_outcomes().await;
+        assert_eq!(outcomes.len(), 3);
+        assert_eq!(outcomes[0], ("a".to_string(), CheckOutcome::Ready));
+        assert_eq!(
+            outcomes[1],
+            ("b".to_string(), CheckOutcome::Degraded("impaired".to_string()))
+        );
+        assert_eq!(
+            outcomes[2],
+            ("c".to_string(), CheckOutcome::Unready("failed".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn degraded_liveness_counts_as_alive_but_unready_does_not() {
+        let degraded = checks_of(vec![RegisteredCheck::new("d", || async {
+            CheckOutcome::Degraded("limping".to_string())
+        })]);
+        assert!(degraded.liveness_ok().await);
+
+        let unready = checks_of(vec![RegisteredCheck::new("u", || async {
+            CheckOutcome::Unready("dead".to_string())
+        })]);
+        assert!(!unready.liveness_ok().await);
+    }
+
+    #[tokio::test]
+    async fn stalled_checks_share_one_deadline_and_report_timeout() {
+        let stall = || async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            CheckOutcome::Ready
+        };
+        let checks = HealthChecks::new(
+            Vec::new(),
+            vec![
+                RegisteredCheck::new("slow-1", stall),
+                RegisteredCheck::new("slow-2", stall),
+                RegisteredCheck::new("fast", || async { CheckOutcome::Ready }),
+            ],
+            Duration::from_millis(100),
+        );
+        let started = tokio::time::Instant::now();
+        let outcomes = checks.readiness_outcomes().await;
+        // Two stalled checks cost one shared deadline, not two.
+        assert!(started.elapsed() < Duration::from_millis(1_500));
+        assert_eq!(
+            outcomes[0].1,
+            CheckOutcome::Unready(TIMED_OUT.to_string())
+        );
+        assert_eq!(
+            outcomes[1].1,
+            CheckOutcome::Unready(TIMED_OUT.to_string())
+        );
+        assert_eq!(outcomes[2].1, CheckOutcome::Ready);
+    }
+}

--- a/acton-service/src/health.rs
+++ b/acton-service/src/health.rs
@@ -46,19 +46,29 @@ pub struct DependencyStatus {
 
 /// Simple health check (liveness probe)
 ///
-/// Always returns 200 OK if the service is running.
-/// This is used by Kubernetes to determine if the pod should be restarted.
+/// Returns 200 OK while the process should keep running. When the service has
+/// registered app-defined liveness checks (see
+/// [`ServiceBuilder::with_liveness_check`](crate::service_builder::ServiceBuilder::with_liveness_check)),
+/// any check answering `Unready` turns this into 503 — the signal an
+/// orchestrator restarts on. With no registered checks the endpoint cannot
+/// fail, exactly as before.
 pub async fn health<T>(State(state): State<AppState<T>>) -> impl IntoResponse
 where
     T: Serialize + DeserializeOwned + Clone + Default + Send + Sync + 'static,
 {
+    let alive = state.health_checks().liveness_ok().await;
     let response = HealthResponse {
-        status: "healthy".to_string(),
+        status: if alive { "healthy" } else { "unhealthy" }.to_string(),
         service: state.config().service.name.clone(),
         version: Some(env!("CARGO_PKG_VERSION").to_string()),
     };
 
-    (StatusCode::OK, Json(response))
+    let status = if alive {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (status, Json(response))
 }
 
 /// Readiness check with dependency validation (readiness probe)
@@ -70,29 +80,9 @@ pub async fn readiness<T>(State(state): State<AppState<T>>) -> Result<impl IntoR
 where
     T: Serialize + DeserializeOwned + Clone + Default + Send + Sync + 'static,
 {
-    #[cfg_attr(
-        not(any(
-            feature = "database",
-            feature = "cache",
-            feature = "events",
-            feature = "turso",
-            feature = "surrealdb",
-            feature = "clickhouse"
-        )),
-        allow(unused_mut)
-    )]
+    // Unconditionally `mut`: app-defined checks below can update both even
+    // when no backend feature is compiled in.
     let mut dependencies = HashMap::new();
-    #[cfg_attr(
-        not(any(
-            feature = "database",
-            feature = "cache",
-            feature = "events",
-            feature = "turso",
-            feature = "surrealdb",
-            feature = "clickhouse"
-        )),
-        allow(unused_mut)
-    )]
     let mut all_ready = true;
 
     // Check database connection
@@ -614,6 +604,31 @@ where
         );
     }
 
+    // App-defined checks run after the built-in backend probes, concurrently
+    // under one shared deadline. `Unready` flips overall readiness; `Degraded`
+    // renders the dependency unhealthy without flipping it — visible to the
+    // operator, invisible to the load balancer.
+    for (name, outcome) in state.health_checks().readiness_outcomes().await {
+        let status = match outcome {
+            crate::checks::CheckOutcome::Ready => DependencyStatus {
+                healthy: true,
+                message: None,
+            },
+            crate::checks::CheckOutcome::Degraded(message) => DependencyStatus {
+                healthy: false,
+                message: Some(message),
+            },
+            crate::checks::CheckOutcome::Unready(message) => {
+                all_ready = false;
+                DependencyStatus {
+                    healthy: false,
+                    message: Some(message),
+                }
+            }
+        };
+        dependencies.insert(name, status);
+    }
+
     let response = ReadinessResponse {
         ready: all_ready,
         service: state.config().service.name.clone(),
@@ -676,5 +691,100 @@ mod tests {
 
         assert!(status.healthy);
         assert_eq!(status.message, Some("OK".to_string()));
+    }
+
+    mod app_defined_checks {
+        use super::super::*;
+        use crate::checks::{CheckOutcome, HealthChecks, RegisteredCheck};
+        use std::time::Duration;
+
+        fn state_with(liveness: Vec<RegisteredCheck>, readiness: Vec<RegisteredCheck>) -> AppState {
+            let mut state = AppState::<()>::default();
+            state.set_health_checks(HealthChecks::new(
+                liveness,
+                readiness,
+                Duration::from_millis(200),
+            ));
+            state
+        }
+
+        async fn body_json(response: axum::response::Response) -> serde_json::Value {
+            let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("body");
+            serde_json::from_slice(&bytes).expect("json")
+        }
+
+        #[tokio::test]
+        async fn health_without_checks_stays_200() {
+            let response = health(State(state_with(Vec::new(), Vec::new())))
+                .await
+                .into_response();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn unready_liveness_check_fails_health() {
+            let state = state_with(
+                vec![RegisteredCheck::new("writer", || async {
+                    CheckOutcome::Unready("writer task exited".to_string())
+                })],
+                Vec::new(),
+            );
+            let response = health(State(state)).await.into_response();
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+            let body = body_json(response).await;
+            assert_eq!(body["status"], "unhealthy");
+        }
+
+        #[tokio::test]
+        async fn unready_readiness_check_fails_ready_with_message() {
+            let state = state_with(
+                Vec::new(),
+                vec![RegisteredCheck::new("quorum", || async {
+                    CheckOutcome::Unready("no quorum".to_string())
+                })],
+            );
+            let response = readiness(State(state)).await.expect("ok").into_response();
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+            let body = body_json(response).await;
+            assert_eq!(body["ready"], false);
+            assert_eq!(body["dependencies"]["quorum"]["healthy"], false);
+            assert_eq!(body["dependencies"]["quorum"]["message"], "no quorum");
+        }
+
+        #[tokio::test]
+        async fn degraded_readiness_check_is_visible_but_ready() {
+            let state = state_with(
+                Vec::new(),
+                vec![
+                    RegisteredCheck::new("signing", || async {
+                        CheckOutcome::Degraded("sidecar unreachable; 3 mints pending".to_string())
+                    }),
+                    RegisteredCheck::new("journal", || async { CheckOutcome::Ready }),
+                ],
+            );
+            let response = readiness(State(state)).await.expect("ok").into_response();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = body_json(response).await;
+            assert_eq!(body["ready"], true);
+            assert_eq!(body["dependencies"]["signing"]["healthy"], false);
+            assert_eq!(body["dependencies"]["journal"]["healthy"], true);
+        }
+
+        #[tokio::test]
+        async fn timed_out_readiness_check_reports_unready() {
+            let state = state_with(
+                Vec::new(),
+                vec![RegisteredCheck::new("stuck", || async {
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                    CheckOutcome::Ready
+                })],
+            );
+            let response = readiness(State(state)).await.expect("ok").into_response();
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+            let body = body_json(response).await;
+            assert_eq!(body["dependencies"]["stuck"]["message"], "check timed out");
+        }
     }
 }

--- a/acton-service/src/lib.rs
+++ b/acton-service/src/lib.rs
@@ -82,6 +82,7 @@ compile_error!(
      Enable `crypto-aws-lc-rs` (default) or `crypto-ring`."
 );
 
+pub mod checks;
 pub mod config;
 pub mod crypto;
 pub mod error;
@@ -201,6 +202,7 @@ pub mod prelude {
     #[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
     pub use crate::error::{DatabaseError, DatabaseErrorKind, DatabaseOperation};
 
+    pub use crate::checks::CheckOutcome;
     pub use crate::health::{health, pool_metrics, readiness};
     pub use crate::ids::{MakeTypedRequestId, RequestId, RequestIdError};
     pub use crate::pool_health::PoolHealthSummary;

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -147,6 +147,12 @@ where
     /// serve time. See [`ServiceBuilder::with_tls_reload`].
     #[cfg(feature = "tls")]
     tls_reload_hook: Option<Box<dyn FnOnce(crate::tls::TlsReloadHandle) + Send>>,
+    /// App-defined liveness checks folded into `/health`.
+    liveness_checks: Vec<crate::checks::RegisteredCheck>,
+    /// App-defined readiness checks folded into `/ready`.
+    readiness_checks: Vec<crate::checks::RegisteredCheck>,
+    /// Shared deadline for one endpoint's registered checks.
+    check_deadline: std::time::Duration,
 }
 
 impl<T> ServiceBuilder<T>
@@ -175,7 +181,61 @@ where
             grpc_tls_config_override: None,
             #[cfg(feature = "tls")]
             tls_reload_hook: None,
+            liveness_checks: Vec::new(),
+            readiness_checks: Vec::new(),
+            check_deadline: crate::checks::DEFAULT_CHECK_DEADLINE,
         }
+    }
+
+    /// Register an app-defined **readiness** check folded into `/ready`.
+    ///
+    /// The closure runs on every probe hit, concurrently with the other
+    /// registered checks under one shared deadline (see
+    /// [`with_check_deadline`](Self::with_check_deadline)). Its outcome is
+    /// rendered as a dependency named `name` in the readiness body:
+    /// [`CheckOutcome::Unready`](crate::checks::CheckOutcome::Unready) turns
+    /// `/ready` into `503` (drain traffic);
+    /// [`CheckOutcome::Degraded`](crate::checks::CheckOutcome::Degraded) shows
+    /// the dependency unhealthy **without** flipping overall readiness.
+    ///
+    /// Repeatable; checks report in registration order.
+    pub fn with_readiness_check<F, Fut>(mut self, name: impl Into<String>, check: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = crate::checks::CheckOutcome> + Send + 'static,
+    {
+        self.readiness_checks
+            .push(crate::checks::RegisteredCheck::new(name, check));
+        self
+    }
+
+    /// Register an app-defined **liveness** check folded into `/health`.
+    ///
+    /// Liveness answers "should the process be restarted?" — any registered
+    /// check returning
+    /// [`CheckOutcome::Unready`](crate::checks::CheckOutcome::Unready) turns
+    /// `/health` into `503`. A `Degraded` outcome counts as healthy here:
+    /// liveness is binary, and a degraded-but-working process must not be
+    /// killed. Repeatable.
+    pub fn with_liveness_check<F, Fut>(mut self, name: impl Into<String>, check: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = crate::checks::CheckOutcome> + Send + 'static,
+    {
+        self.liveness_checks
+            .push(crate::checks::RegisteredCheck::new(name, check));
+        self
+    }
+
+    /// Override the shared deadline for one endpoint's registered checks
+    /// (default [`DEFAULT_CHECK_DEADLINE`](crate::checks::DEFAULT_CHECK_DEADLINE)).
+    ///
+    /// All of an endpoint's checks run concurrently under this single
+    /// deadline, so N stalled checks cost one deadline, not N; a check
+    /// unresolved at the deadline reports `Unready("check timed out")`.
+    pub fn with_check_deadline(mut self, deadline: std::time::Duration) -> Self {
+        self.check_deadline = deadline;
+        self
     }
 
     /// Supply a pre-built HTTP TLS configuration.
@@ -1170,7 +1230,7 @@ where
         let routes = self.routes.unwrap_or_default();
 
         // Build AppState with agent-managed pools
-        let state = if let Some(provided_state) = self.state {
+        let mut state = if let Some(provided_state) = self.state {
             provided_state
         } else {
             let mut state = AppState::new(config.clone());
@@ -1236,6 +1296,15 @@ where
 
             state
         };
+
+        // Install app-defined checks on whichever state is in play — built
+        // here or caller-provided — so `/health` and `/ready` see them either
+        // way.
+        state.set_health_checks(crate::checks::HealthChecks::new(
+            std::mem::take(&mut self.liveness_checks),
+            std::mem::take(&mut self.readiness_checks),
+            self.check_deadline,
+        ));
 
         // Clone state before it's consumed by Router::with_state().
         // AppState uses Arc internally, so this is a cheap reference-count bump.

--- a/acton-service/src/state.rs
+++ b/acton-service/src/state.rs
@@ -113,6 +113,9 @@ where
 
     /// User-registered actor extensions
     actor_extensions: crate::extensions::ActorExtensions,
+
+    /// App-defined liveness/readiness checks folded into `/health` and `/ready`
+    health_checks: crate::checks::HealthChecks,
 }
 
 impl<T> Default for AppState<T>
@@ -145,6 +148,7 @@ where
             background_worker: None,
             broker: None,
             actor_extensions: crate::extensions::ActorExtensions::default(),
+            health_checks: crate::checks::HealthChecks::default(),
         }
     }
 }
@@ -183,6 +187,7 @@ where
             background_worker: None,
             broker: None,
             actor_extensions: crate::extensions::ActorExtensions::default(),
+            health_checks: crate::checks::HealthChecks::default(),
         }
     }
 
@@ -194,6 +199,17 @@ where
     /// Get the configuration
     pub fn config(&self) -> &Config<T> {
         &self.config
+    }
+
+    /// The app-defined liveness/readiness checks (empty unless registered
+    /// through the service builder).
+    pub fn health_checks(&self) -> &crate::checks::HealthChecks {
+        &self.health_checks
+    }
+
+    /// Install the app-defined check set (called once by the service builder).
+    pub(crate) fn set_health_checks(&mut self, checks: crate::checks::HealthChecks) {
+        self.health_checks = checks;
     }
 
     /// Get the database pool
@@ -850,6 +866,7 @@ where
             background_worker: None,
             broker: None,
             actor_extensions: crate::extensions::ActorExtensions::default(),
+            health_checks: crate::checks::HealthChecks::default(),
         })
     }
 }


### PR DESCRIPTION
## Summary

`/health` can never fail and `/ready` probes only framework-managed backends (database/cache/events/…). A service whose real readiness lives in application state — a writer task, a consensus quorum, a sidecar — has no way to surface it, and an orchestrator wired to these probes routes traffic through exactly the incidents a probe exists to catch. (Downstream driver: AxorumHQ/internal#67.)

## What's added

- `ServiceBuilder::with_readiness_check(name, || async { … })` / `with_liveness_check` (repeatable) + `with_check_deadline` (default 2s).
- `CheckOutcome::{Ready, Degraded(msg), Unready(msg)}`:
  - readiness: `Unready` → 503; `Degraded` → unhealthy dependency in the body **without** flipping overall readiness (visible to operators, invisible to the load balancer).
  - liveness: `Unready` → `/health` 503 (restart semantics); `Degraded` counts as alive — liveness is binary.
- All of an endpoint's checks run **concurrently under one shared deadline** — N stalled checks cost one deadline, not N; an unresolved check reports `Unready("check timed out")`.
- `AppState::health_checks()`; checks install in `build()` for both framework-built and caller-provided state.

## Compatibility

Additive only. No registered checks → both endpoints behave byte-for-byte as before. `/ready`'s wire shape unchanged (new entries appear in `dependencies`); `/health` gains `status: "unhealthy"` + 503 only when a registered liveness check fails.

## Testing

- 9 new tests (check semantics, shared-deadline timeout, handler-level 200/503 + body assertions for both endpoints).
- Full suite: 785/785 with `--features full`; clippy clean on default and full feature sets.

Release 0.32.0.