### PR TITLE
feat(checks): ReadyWithMessage — healthy dependency affirmation on /ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [acton-service-v0.33.0] - 2026-07-24
+
+A healthy dependency can now speak. `CheckOutcome::Ready` carries no
+message, which left no way for a readiness check to affirm *what* is
+healthy — e.g. the verified identity of a mounted artifact — without
+abusing `Degraded` (and reporting `healthy: false` for a healthy concern).
+
+### Added
+
+- `CheckOutcome::ReadyWithMessage(String)`: healthy, with an
+  operator-facing affirmation rendered as the dependency's `message` on
+  `/ready`. `healthy` stays `true`; the endpoint's answer is unaffected;
+  liveness treats it as alive.
+
+### Changed
+
+- **Breaking**: adding a variant to the exhaustive `CheckOutcome` enum
+  requires downstream exhaustive matches to add an arm — hence 0.33.0.
+
 ## [acton-service-v0.32.0] - 2026-07-24
 
 Lets a service tell the truth on its probe endpoints. Until now `/health`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "acton-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "acton-service",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["acton-service", "acton-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 authors = ["roland@govcraft.ai"]
 license = "MIT"

--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-acton-service = { path = "../acton-service", version = "0.32.0" }
+acton-service = { path = "../acton-service", version = "0.33.0" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/acton-service/src/checks.rs
+++ b/acton-service/src/checks.rs
@@ -42,6 +42,11 @@ const TIMED_OUT: &str = "check timed out";
 pub enum CheckOutcome {
     /// The checked concern is healthy.
     Ready,
+    /// The checked concern is healthy and carries an operator-facing
+    /// affirmation — e.g. the verified identity of a mounted artifact —
+    /// rendered as the dependency's message on `/ready` without affecting
+    /// the endpoint's answer.
+    ReadyWithMessage(String),
     /// The checked concern is impaired but the endpoint's overall answer is
     /// unaffected: rendered as an unhealthy dependency on `/ready`, ignored
     /// for `/health`. The message should say what is impaired and why traffic

--- a/acton-service/src/health.rs
+++ b/acton-service/src/health.rs
@@ -614,6 +614,10 @@ where
                 healthy: true,
                 message: None,
             },
+            crate::checks::CheckOutcome::ReadyWithMessage(message) => DependencyStatus {
+                healthy: true,
+                message: Some(message),
+            },
             crate::checks::CheckOutcome::Degraded(message) => DependencyStatus {
                 healthy: false,
                 message: Some(message),
@@ -770,6 +774,27 @@ mod tests {
             assert_eq!(body["ready"], true);
             assert_eq!(body["dependencies"]["signing"]["healthy"], false);
             assert_eq!(body["dependencies"]["journal"]["healthy"], true);
+        }
+
+        #[tokio::test]
+        async fn ready_with_message_affirms_while_staying_healthy() {
+            let state = state_with(
+                Vec::new(),
+                vec![RegisteredCheck::new("lake", || async {
+                    CheckOutcome::ReadyWithMessage(
+                        "The verified lake is mounted at freeze sequence 7.".to_string(),
+                    )
+                })],
+            );
+            let response = readiness(State(state)).await.expect("ok").into_response();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = body_json(response).await;
+            assert_eq!(body["ready"], true);
+            assert_eq!(body["dependencies"]["lake"]["healthy"], true);
+            assert_eq!(
+                body["dependencies"]["lake"]["message"],
+                "The verified lake is mounted at freeze sequence 7."
+            );
         }
 
         #[tokio::test]


### PR DESCRIPTION
Adds `CheckOutcome::ReadyWithMessage(String)`: a healthy outcome that renders `healthy: true` with an operator-facing message in the `/ready` dependencies body.

Motivation: a readiness check affirming the verified identity of a mounted artifact (axorum queryd's lake posture) currently has no honest encoding — `Ready` is mute and `Degraded` reports `healthy: false` for a healthy concern.

- `/ready`: `healthy: true` + `message`; does not affect `all_ready` or status code
- liveness: treated as alive (unchanged `liveness_ok` logic)
- Breaking (exhaustive enum gains a variant) → 0.33.0

Follow-up to #106.