### PR TITLE
feat(routing): add feature-independent root-level fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,6 +858,11 @@ Main changes:
 2. Use `ServiceBuilder` instead of `axum::serve()`
 3. Configuration loaded automatically (optional)
 
+An `axum` app with a root-level `.fallback(...)` — a reverse proxy, a gateway,
+a custom 404 — keeps it via `VersionedApiBuilder::with_fallback` (handler) or
+`with_fallback_service` (`tower::Service`). The catch-all is installed after
+every declared route, so it shadows none of them.
+
 ### From Actix-Web
 
 Similar handler patterns, different framework:

--- a/acton-docs/src/app/docs/api-versioning/page.md
+++ b/acton-docs/src/app/docs/api-versioning/page.md
@@ -38,6 +38,7 @@ The framework offers:
 - **Automatic Health Endpoints**: `ServiceBuilder` automatically provides `/health` and `/ready` endpoints
 - **Automatic Deprecation Headers**: RFC 8594 compliant deprecation headers sent automatically
 - **Sunset Date Management**: Clear migration timelines with sunset date enforcement
+- **Root-Level Catch-All**: `with_fallback` / `with_fallback_service` for proxies, gateways, and custom 404s — no feature flags required
 
 ---
 
@@ -105,6 +106,90 @@ Routes:
 - `/ready` → Readiness check (automatic)
 - `/api/v1/users` → V1 handler
 - `/api/v2/users` → V2 handler
+
+---
+
+## Root-Level Catch-All
+
+Some services need to handle requests that match no route they declared. A
+transparent reverse proxy forwards everything it does not itself serve. A
+gateway routes unknown paths upstream. A public API may want a JSON 404 body
+instead of the default empty one.
+
+`with_fallback` and `with_fallback_service` provide that catch-all. Neither
+requires a feature flag.
+
+### A custom 404
+
+```rust
+async fn not_found() -> impl IntoResponse {
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({ "error": "no such route" })),
+    )
+}
+
+let routes = VersionedApiBuilder::new()
+    .with_base_path("/api")
+    .add_version(ApiVersion::V1, |router| {
+        router.route("/users", get(list_users))
+    })
+    .with_fallback(not_found)
+    .build_routes();
+```
+
+### A transparent reverse proxy
+
+When the catch-all is an HTTP client forwarding upstream, it is a
+`tower::Service` rather than a handler. Use `with_fallback_service`:
+
+```rust
+use tower::service_fn;
+
+let upstream = service_fn(move |req: Request| async move {
+    forward_to_upstream(req).await  // -> Result<Response, Infallible>
+});
+
+let routes = VersionedApiBuilder::new()
+    .add_version(ApiVersion::V1, |router| {
+        router.route("/paywall", post(charge))
+    })
+    .with_fallback_service(upstream)
+    .build_routes();
+
+ServiceBuilder::new()
+    .with_routes(routes)
+    .build()
+    .serve()
+    .await
+```
+
+A proxy built this way keeps the full middleware stack: request-ID
+propagation, sensitive-header masking, security headers, rate limiting, panic
+recovery, and audit wiring all apply to forwarded requests. A proxy built on
+bare `axum::serve` gets none of them.
+
+### Ordering
+
+The fallback is installed after every other route, so it never shadows one.
+It sees only what matched nothing else:
+
+| Path | Handled by |
+| --- | --- |
+| `/health`, `/ready` | Framework health endpoints |
+| `/api/v1/users` | Your V1 handler |
+| `/`, `/login` | `with_frontend_routes`, if used |
+| everything else | Your fallback |
+
+Calling either method more than once keeps the last one. If you also set a
+fallback inside `with_frontend_routes`, the one passed to `with_fallback`
+wins — the two do not conflict.
+
+{% callout type="note" title="Versioning still applies" %}
+A fallback does not weaken the versioning guarantee. Your own API surface
+still has to go through `add_version`; the catch-all handles what your API
+deliberately does not claim.
+{% /callout %}
 
 ---
 
@@ -692,6 +777,22 @@ let app = Router::new().route("/users", get(handler));
 ServiceBuilder::new().with_routes(app).build();
 //                                  ^^^ ERROR: expected VersionedRoutes, found Router
 ```
+
+### Q: How do I write a reverse proxy or gateway on ServiceBuilder?
+
+Use `with_fallback_service`. Declare whatever routes the service handles
+itself through `add_version`, then forward everything else:
+
+```rust
+let routes = VersionedApiBuilder::new()
+    .add_version(ApiVersion::V1, |router| router.route("/paywall", post(charge)))
+    .with_fallback_service(upstream)  // catches every unmatched path
+    .build_routes();
+```
+
+This keeps the service on `ServiceBuilder`, so forwarded requests still get
+request-ID propagation, security headers, rate limiting, panic recovery, and
+audit wiring. See [Root-Level Catch-All](#root-level-catch-all).
 
 ### Q: How many versions should I maintain?
 

--- a/acton-service/src/checks.rs
+++ b/acton-service/src/checks.rs
@@ -4,9 +4,9 @@
 //! manages (database, cache, events, …). Services whose real readiness lives
 //! in application state — a writer task, a consensus quorum, a sidecar —
 //! register checks here via
-//! [`ServiceBuilder::with_readiness_check`](crate::service::ServiceBuilder::with_readiness_check)
+//! [`ServiceBuilder::with_readiness_check`](crate::service_builder::ServiceBuilder::with_readiness_check)
 //! and
-//! [`ServiceBuilder::with_liveness_check`](crate::service::ServiceBuilder::with_liveness_check).
+//! [`ServiceBuilder::with_liveness_check`](crate::service_builder::ServiceBuilder::with_liveness_check).
 //!
 //! Semantics:
 //!

--- a/acton-service/src/versioning.rs
+++ b/acton-service/src/versioning.rs
@@ -347,6 +347,18 @@ pub fn extract_version_from_path(path: &str) -> Option<ApiVersion> {
         .and_then(ApiVersion::parse)
 }
 
+/// A deferred `Router::fallback` / `Router::fallback_service` call.
+///
+/// The handler or service is captured at the call site and applied once, in
+/// `build_routes`, after every other route is in place. Boxing it this way is
+/// what lets `with_fallback` and `with_fallback_service` share a single slot
+/// despite having incompatible generic bounds.
+type FallbackSlot<T> = Box<
+    dyn FnOnce(Router<crate::state::AppState<T>>) -> Router<crate::state::AppState<T>>
+        + Send
+        + Sync,
+>;
+
 /// Builder for creating versioned API routers with enforcement
 ///
 /// This builder ensures that all routes are versioned and provides a structured
@@ -391,6 +403,7 @@ where
     base_path: Option<String>,
     #[cfg(feature = "htmx")]
     frontend_routes: Option<Router<crate::state::AppState<T>>>,
+    fallback: Option<FallbackSlot<T>>,
 }
 
 impl Default for VersionedApiBuilder<()> {
@@ -421,6 +434,7 @@ impl VersionedApiBuilder<()> {
             base_path: None,
             #[cfg(feature = "htmx")]
             frontend_routes: None,
+            fallback: None,
         }
     }
 }
@@ -460,6 +474,7 @@ where
             base_path: None,
             #[cfg(feature = "htmx")]
             frontend_routes: None,
+            fallback: None,
         }
     }
 
@@ -610,6 +625,96 @@ where
         self
     }
 
+    /// Handle every request that matches no other route
+    ///
+    /// This is the root-level catch-all. Use it for a transparent reverse
+    /// proxy, a gateway that forwards what it does not itself serve, or simply
+    /// a custom 404 body. Unlike `with_frontend_routes`, it needs no feature
+    /// flags — a proxy has no frontend, and should not have to compile an HTML
+    /// templating stack to reach this slot.
+    ///
+    /// The fallback is installed after health routes, frontend routes, and all
+    /// versioned routes, so it never shadows them. It sees only paths that
+    /// matched nothing else.
+    ///
+    /// Calling this more than once keeps the last handler. If you also set a
+    /// fallback inside `with_frontend_routes` (`htmx` feature), this one wins.
+    ///
+    /// For a [`tower::Service`] rather than a handler — which is what an HTTP
+    /// client forwarding upstream usually is — see
+    /// [`with_fallback_service`](Self::with_fallback_service).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use acton_service::prelude::*;
+    ///
+    /// async fn not_found() -> impl IntoResponse {
+    ///     (StatusCode::NOT_FOUND, Json(json!({ "error": "no such route" })))
+    /// }
+    ///
+    /// let routes = VersionedApiBuilder::new()
+    ///     .with_base_path("/api")
+    ///     .add_version(ApiVersion::V1, |routes| {
+    ///         routes.route("/data", get(api_handler))
+    ///     })
+    ///     .with_fallback(not_found)
+    ///     .build_routes();
+    /// ```
+    pub fn with_fallback<H, Tp>(mut self, handler: H) -> Self
+    where
+        H: axum::handler::Handler<Tp, crate::state::AppState<T>>,
+        Tp: 'static,
+    {
+        self.fallback = Some(Box::new(move |router| router.fallback(handler)));
+        self
+    }
+
+    /// Handle every unmatched request with a [`tower::Service`]
+    ///
+    /// The service form of [`with_fallback`](Self::with_fallback), for when the
+    /// catch-all is something that already speaks `Service<Request>` — an HTTP
+    /// client forwarding to an upstream, a `ServeDir`, another `Router`.
+    ///
+    /// The same ordering rules apply: installed last, shadows nothing, and
+    /// takes precedence over any fallback set inside `with_frontend_routes`.
+    ///
+    /// # Example
+    ///
+    /// A transparent reverse proxy that forwards every unhandled path upstream
+    /// while keeping the framework's request-ID propagation, security headers,
+    /// rate limiting, and panic recovery:
+    ///
+    /// ```rust,ignore
+    /// use acton_service::prelude::*;
+    /// use tower::service_fn;
+    ///
+    /// let upstream = service_fn(move |req: Request| async move {
+    ///     // rewrite the authority, forward, return the upstream response
+    ///     forward_to_upstream(req).await
+    /// });
+    ///
+    /// let routes = VersionedApiBuilder::new()
+    ///     .add_version(ApiVersion::V1, |routes| {
+    ///         routes.route("/paywall", post(charge))
+    ///     })
+    ///     .with_fallback_service(upstream)
+    ///     .build_routes();
+    /// ```
+    pub fn with_fallback_service<S>(mut self, service: S) -> Self
+    where
+        S: tower::Service<Request, Error = std::convert::Infallible>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+        S::Response: IntoResponse,
+        S::Future: Send + 'static,
+    {
+        self.fallback = Some(Box::new(move |router| router.fallback_service(service)));
+        self
+    }
+
     /// Build versioned routes (opaque VersionedRoutes type)
     ///
     /// This creates a `VersionedRoutes<T>` with all your versioned business routes
@@ -701,6 +806,15 @@ where
             };
 
             router = router.nest(&full_path, versioned);
+        }
+
+        // The root-level catch-all goes on last, once every real route is
+        // registered. Applying it here rather than merging a fallback-carrying
+        // router also sidesteps axum's "cannot merge two routers that both have
+        // a fallback" panic when `with_frontend_routes` set one too — this call
+        // simply replaces it.
+        if let Some(fallback) = self.fallback {
+            router = fallback(router);
         }
 
         crate::service_builder::VersionedRoutes::from_router_with_state(router)
@@ -923,5 +1037,183 @@ mod tests {
             .build_routes();
 
         // If we get here without panicking, the routes were built successfully
+    }
+
+    mod fallback {
+        use super::*;
+        use axum::body::Body;
+        use tower::ServiceExt as _;
+
+        /// Drive one request through a built router and report what came back.
+        ///
+        /// Construction-only assertions cannot tell a fallback that catches
+        /// everything from one that catches nothing, so every test here routes
+        /// a real request.
+        async fn get(
+            routes: crate::service_builder::VersionedRoutes<()>,
+            path: &str,
+        ) -> (StatusCode, String) {
+            let crate::service_builder::VersionedRoutes::WithState(router) = routes else {
+                panic!("build_routes always yields a stateful router");
+            };
+            let app = router.with_state(crate::state::AppState::<()>::default());
+
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .uri(path)
+                        .body(Body::empty())
+                        .expect("request builds"),
+                )
+                .await
+                .expect("router is infallible");
+
+            let status = response.status();
+            let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("body collects");
+            (status, String::from_utf8_lossy(&bytes).into_owned())
+        }
+
+        fn builder_with_api() -> VersionedApiBuilder<()> {
+            VersionedApiBuilder::new()
+                .with_base_path("/api")
+                .add_version(ApiVersion::V1, |routes| {
+                    routes.route("/data", axum::routing::get(|| async { "API V1" }))
+                })
+        }
+
+        #[tokio::test]
+        async fn unmatched_paths_reach_the_fallback() {
+            let routes = builder_with_api()
+                .with_fallback(|| async { "caught" })
+                .build_routes();
+
+            let (status, body) = get(routes, "/anything/at/all").await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(body, "caught");
+        }
+
+        #[tokio::test]
+        async fn without_a_fallback_unmatched_paths_still_404() {
+            let routes = builder_with_api().build_routes();
+
+            let (status, _) = get(routes, "/anything/at/all").await;
+            assert_eq!(status, StatusCode::NOT_FOUND);
+        }
+
+        #[tokio::test]
+        async fn the_fallback_does_not_shadow_versioned_routes() {
+            let routes = builder_with_api()
+                .with_fallback(|| async { "caught" })
+                .build_routes();
+
+            let (status, body) = get(routes, "/api/v1/data").await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(body, "API V1");
+        }
+
+        #[tokio::test]
+        async fn the_fallback_does_not_shadow_health_probes() {
+            let routes = builder_with_api()
+                .with_fallback(|| async { "caught" })
+                .build_routes();
+
+            let (status, body) = get(routes, "/health").await;
+            assert_eq!(status, StatusCode::OK);
+            assert_ne!(body, "caught");
+        }
+
+        #[tokio::test]
+        async fn a_fallback_service_catches_unmatched_paths() {
+            // The proxy shape: a tower::Service, not a handler.
+            let upstream = tower::service_fn(|_req: Request| async move {
+                Ok::<_, std::convert::Infallible>(Response::new(Body::from("upstream")))
+            });
+
+            let routes = builder_with_api()
+                .with_fallback_service(upstream)
+                .build_routes();
+
+            let (status, body) = get(routes, "/merchant/checkout").await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(body, "upstream");
+        }
+
+        #[tokio::test]
+        async fn a_fallback_service_does_not_shadow_versioned_routes() {
+            let upstream = tower::service_fn(|_req: Request| async move {
+                Ok::<_, std::convert::Infallible>(Response::new(Body::from("upstream")))
+            });
+
+            let routes = builder_with_api()
+                .with_fallback_service(upstream)
+                .build_routes();
+
+            let (status, body) = get(routes, "/api/v1/data").await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(body, "API V1");
+        }
+
+        #[tokio::test]
+        async fn the_last_fallback_wins() {
+            let routes = builder_with_api()
+                .with_fallback(|| async { "first" })
+                .with_fallback(|| async { "second" })
+                .build_routes();
+
+            let (_, body) = get(routes, "/unmatched").await;
+            assert_eq!(body, "second");
+        }
+
+        #[tokio::test]
+        async fn a_fallback_works_with_no_versions_registered() {
+            // A pure proxy registers no versioned routes at all.
+            let routes = VersionedApiBuilder::new()
+                .with_fallback(|| async { "proxied" })
+                .build_routes();
+
+            let (status, body) = get(routes, "/upstream/path").await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(body, "proxied");
+        }
+
+        #[tokio::test]
+        #[cfg(feature = "htmx")]
+        async fn a_fallback_coexists_with_frontend_routes() {
+            let routes = builder_with_api()
+                .with_frontend_routes(|router| {
+                    router.route("/", axum::routing::get(|| async { "Home" }))
+                })
+                .with_fallback(|| async { "caught" })
+                .build_routes();
+
+            let (_, home) = get(routes, "/").await;
+            assert_eq!(home, "Home");
+
+            let routes = builder_with_api()
+                .with_frontend_routes(|router| {
+                    router.route("/", axum::routing::get(|| async { "Home" }))
+                })
+                .with_fallback(|| async { "caught" })
+                .build_routes();
+
+            let (_, other) = get(routes, "/somewhere-else").await;
+            assert_eq!(other, "caught");
+        }
+
+        #[tokio::test]
+        #[cfg(feature = "htmx")]
+        async fn with_fallback_overrides_a_frontend_fallback_without_panicking() {
+            // Merging two routers that both carry a fallback panics inside
+            // axum. Applying ours after the merge replaces theirs instead.
+            let routes = builder_with_api()
+                .with_frontend_routes(|router| router.fallback(|| async { "frontend" }))
+                .with_fallback(|| async { "explicit" })
+                .build_routes();
+
+            let (_, body) = get(routes, "/unmatched").await;
+            assert_eq!(body, "explicit");
+        }
     }
 }


### PR DESCRIPTION
Closes #110.

## The gap

`VersionedApiBuilder` exposed no root-level catch-all except `with_frontend_routes`, which is `#[cfg(feature = "htmx")]`. Verified against `main`:

- the setter *and* the backing field are htmx-gated (`versioning.rs:392,619`)
- `VersionedRoutes`'s constructors are both `pub(crate)` (`service_builder.rs:81,86`), and `build_routes()` is their only caller
- `ServiceBuilder::with_routes` accepts nothing else, so there is no escape hatch

A proxy has no frontend and no templates, but had to compile `axum-htmx` to attach a catch-all — or drop off `ServiceBuilder` and lose the whole middleware stack. Per the issue, a downstream payment-gate sidecar took the second option, and that was the root cause of a security finding.

One correction to the issue's analysis: it locates the mount at `service_builder.rs:1363`, the `WithoutState` arm. That arm is unreachable from the public API — `build_routes()` always yields `WithState` (`versioning.rs:707`), which passes the router straight through (`service_builder.rs:1340`). The conclusion is unchanged, and it makes the fix simpler: the fallback becomes the application's actual fallback with no nesting in between.

## The fix

Took option (1) from the issue. `with_fallback` / `with_fallback_service` name the job rather than the mechanism — un-gating `with_frontend_routes` would have fixed the coupling but left the discoverability problem, since nobody looking for a catch-all reads the htmx docs.

Two methods because a transparent proxy forwards to a `tower::Service` (an HTTP client), not an axum handler; `fallback` alone would not cover the motivating case. They share one slot, stored as a boxed `FnOnce(Router) -> Router` — the deferral is what lets two incompatible generic bounds write to the same field.

**Ordering.** Applied in `build_routes` after health, frontend, and versioned routes, so the catch-all shadows nothing. It also sidesteps a real hazard: axum panics when merging two routers that both carry a fallback. Applying ours *after* the merge replaces theirs instead, so `with_frontend_routes(|r| r.fallback(a))` + `with_fallback(b)` resolves deterministically to `b` rather than panicking at startup. Covered by a test.

## Tests

Nine new tests in `versioning::tests::fallback`, all behavioral — they route real requests through a built router, since construction-only assertions cannot distinguish a fallback that catches everything from one that catches nothing.

Unmatched paths reach the fallback; absent one they still 404; the fallback shadows neither versioned routes nor `/health`; the service form behaves identically on both counts; last call wins; it works with zero versions registered (the pure-proxy shape); and the two htmx-gated cases — coexisting with frontend routes, and overriding a frontend fallback without panicking.

## Out of scope, flagged

A default-feature `cargo doc` had two unresolved links in `checks.rs` pointing at `crate::service` instead of `crate::service_builder`. Fixed here — one-word corrections, and they were the only ones broken in the default build.

Three more unresolved links remain under reduced feature sets (`crypto.rs:21` → `crate::tls::…`; `middleware/paseto.rs:41` → `KeyManager` / `Self::with_key_manager`), with the same pattern in `jwt.rs`, `jwt_generator.rs`, and `paseto_generator.rs` under other combos. Each needs `cfg_attr`'d doc text rather than a path correction, and a complete fix means walking the feature matrix. Deliberately left out — a partial pass would look finished without being finished. Happy to take it as its own PR.

## Gates

- `cargo nextest run --workspace --features full` — 854/854 pass
- `cargo clippy --features full --all-targets` — clean, no directives
- `cargo clippy --no-default-features --features http,crypto-aws-lc-rs --all-targets` — clean; confirms the new API compiles with `htmx` off, which is the point
- `cargo doc --features full` — zero unresolved links (was 2)

Docs: new "Root-Level Catch-All" section in `api-versioning`, covering the custom-404 and reverse-proxy shapes, an ordering table, and a FAQ entry; plus a note in the README's axum-migration section.