### PR TITLE
ci: lint every feature combination, not just the full ones

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,12 +216,71 @@ jobs:
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
           key: audit-${{ matrix.backend }}
       - uses: taiki-e/install-action@nextest
+      - name: Clippy
+        run: cargo clippy -p acton-service --all-targets ${{ matrix.features }} -- -D warnings
       - name: Nextest
         run: cargo nextest run -p acton-service ${{ matrix.features }}
+
+  # Lint-only legs for feature combinations no test job compiles. `--all-features`
+  # cannot stand in for these: the crate's mutual-exclusion `compile_error!`
+  # guards (database/turso/surrealdb, crypto-aws-lc-rs/crypto-ring) reject it by
+  # design, so narrow combinations are the only way to reach cfg-gated code.
+  #
+  # These run clippy without nextest. The `full` legs above already own test
+  # coverage; what is missing is a compiler that ever *looks* at code behind a
+  # narrower gate. Adding legs here is cheap -- extend the list whenever a new
+  # feature introduces its own cfg-gated paths.
+  feature-combos:
+    name: lint ${{ matrix.combo }}
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The floor: no optional subsystem at all.
+          - combo: minimal
+            features: "http,crypto-aws-lc-rs"
+          # TLS without gRPC. This combination is what let two dead-code
+          # warnings survive in client_tls.rs until #76.
+          - combo: tls-no-grpc
+            features: "http,tls,crypto-aws-lc-rs"
+          # The mirror image: gRPC transport with no TLS material.
+          - combo: grpc-no-tls
+            features: "http,grpc,crypto-aws-lc-rs"
+          # Token validation and issuance without cache-backed revocation.
+          - combo: tokens
+            features: "http,jwt,auth,crypto-aws-lc-rs"
+          # Server-rendered stack.
+          - combo: frontend
+            features: "http,htmx,askama,sse,session-memory,crypto-aws-lc-rs"
+          # GraphQL transport plus its Cedar resolver hooks.
+          - combo: graphql
+            features: "http,graphql,graphql-cedar,cedar-authz,crypto-aws-lc-rs"
+          # Audit with no storage backend compiled in.
+          - combo: audit-nodb
+            features: "http,audit,crypto-aws-lc-rs"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: combo-${{ matrix.combo }}
+      - name: Clippy
+        run: |
+          cargo clippy -p acton-service --all-targets \
+            --no-default-features --features "${{ matrix.features }}" -- -D warnings
 
   # Builds the documentation site so that broken Markdoc fails the pull request
   # rather than reaching the deploy job after the merge has already landed on
@@ -259,7 +318,7 @@ jobs:
   # those PRs, because a skipped job reports nothing at all.
   ci-gate:
     name: ci-gate
-    needs: [changes, aws-lc-rs, ring, audit-storage, docs-build]
+    needs: [changes, aws-lc-rs, ring, audit-storage, feature-combos, docs-build]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/acton-service/src/audit/event.rs
+++ b/acton-service/src/audit/event.rs
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     fn every_kind_round_trips_through_its_wire_string() {
-        let mut kinds = vec![
+        let kinds = vec![
             AuditEventKind::AuthLoginSuccess,
             AuditEventKind::AuthLoginFailed,
             AuditEventKind::AuthTokenMissing,
@@ -410,22 +410,33 @@ mod tests {
             AuditEventKind::HttpRequestDenied,
             AuditEventKind::Custom("user.delete".to_string()),
         ];
+        // Shadow rather than declare `kinds` mutable up front: with neither
+        // feature enabled nothing ever extends it, and an unconditional `mut`
+        // would be an unused-mut warning reachable only in that combination.
         #[cfg(feature = "login-lockout")]
-        kinds.extend([
-            AuditEventKind::AuthAccountLocked,
-            AuditEventKind::AuthAccountUnlocked,
-        ]);
+        let kinds = {
+            let mut kinds = kinds;
+            kinds.extend([
+                AuditEventKind::AuthAccountLocked,
+                AuditEventKind::AuthAccountUnlocked,
+            ]);
+            kinds
+        };
         #[cfg(feature = "accounts")]
-        kinds.extend([
-            AuditEventKind::AccountCreated,
-            AuditEventKind::AccountDisabled,
-            AuditEventKind::AccountEnabled,
-            AuditEventKind::AccountLocked,
-            AuditEventKind::AccountUnlocked,
-            AuditEventKind::AccountExpired,
-            AuditEventKind::AccountDeleted,
-            AuditEventKind::AccountUpdated,
-        ]);
+        let kinds = {
+            let mut kinds = kinds;
+            kinds.extend([
+                AuditEventKind::AccountCreated,
+                AuditEventKind::AccountDisabled,
+                AuditEventKind::AccountEnabled,
+                AuditEventKind::AccountLocked,
+                AuditEventKind::AccountUnlocked,
+                AuditEventKind::AccountExpired,
+                AuditEventKind::AccountDeleted,
+                AuditEventKind::AccountUpdated,
+            ]);
+            kinds
+        };
 
         for kind in kinds {
             let wire = kind.to_string();

--- a/acton-service/src/client_tls.rs
+++ b/acton-service/src/client_tls.rs
@@ -730,6 +730,11 @@ struct ClientIdentitySourceInner {
     /// with no ALPN protocols set. Each transport clones it and sets the ALPN
     /// list appropriate to its protocol; the rotating resolver and verifier are
     /// behind `Arc`s, so every clone rotates together.
+    ///
+    /// Only gRPC transports clone it — the HTTP client is built once in
+    /// `from_config` and keeps its own copy — so without `grpc` this is carried
+    /// solely for the tests that assert the ALPN lists.
+    #[cfg(any(feature = "grpc", test))]
     tls: ClientConfig,
     /// The files a reload rereads. Never absent: every source is reloadable.
     origin: ClientIdentityConfig,
@@ -774,6 +779,7 @@ impl ClientIdentitySource {
                 client: Arc::new(client),
                 resolver,
                 verifier,
+                #[cfg(any(feature = "grpc", test))]
                 tls,
                 origin: config.clone(),
             }),
@@ -872,6 +878,11 @@ impl ClientIdentitySource {
     ///
     /// The returned value shares this source's rotating resolver and verifier,
     /// so a transport built from it rotates with the source.
+    ///
+    /// Only the gRPC path builds transports this way; the HTTP client is
+    /// constructed once in `from_config`. The `test` arm keeps it available to
+    /// the ALPN assertions, which cover both protocols regardless of features.
+    #[cfg(any(feature = "grpc", test))]
     fn tls_config_with_alpn(&self, alpn: &[&[u8]]) -> ClientConfig {
         let mut tls = self.inner.tls.clone();
         tls.alpn_protocols = alpn.iter().map(|p| p.to_vec()).collect();


### PR DESCRIPTION
Closes #76.

## The gap

CI ran clippy on exactly two configurations — `full` (`build.yml:161`) and `full,crypto-ring` (`build.yml:191`). The `audit-storage` matrix compiled its combos for `nextest` but never linted them, and nothing compiled a *narrow* combination at all. Lints in cfg-gated code were structurally unreachable by CI.

As #76 notes, `--all-features` is not a substitute: the crate's mutual-exclusion `compile_error!` guards reject it by design.

## Amendment to the issue's proposed fix

#76 proposes adding clippy to "the matrix jobs" — but the only matrix is the three audit-storage backends (`turso`, `surrealdb`, `clickhouse`). None of those is `tls`-without-`grpc`, so that fix alone would **not** have caught either warning below. The premise needed a wider combo list to deliver on itself.

So this does both: adds the clippy step to `audit-storage` as asked, **and** adds a lint-only `feature-combos` job for seven combinations no test job compiles.

| leg | why |
| --- | --- |
| `minimal` | the floor — no optional subsystem |
| `tls-no-grpc` | the gap that hid both warnings below |
| `grpc-no-tls` | mirror image |
| `tokens` | jwt/auth without cache-backed revocation |
| `frontend` | htmx/askama/sse/session stack |
| `graphql` | transport plus Cedar resolver hooks |
| `audit-nodb` | audit with no storage backend |

Clippy-only, no nextest — the `full` legs already own test coverage. What was missing is a compiler that ever *looks* at the narrower gates. `ci-gate` now requires the job.

## Lints this surfaced

Both were live on `main` and invisible to CI:

**`client_tls.rs`** — the `tls` field (`:733`) and `tls_config_with_alpn` (`:875`) were ungated, though `RotatingTlsConnector`, their only non-test consumer, is already `#[cfg(feature = "grpc")]`. Gated them on `any(feature = "grpc", test)`, which makes the gating consistent with the code that consumes them rather than papering over the warning. The `test` arm keeps the ALPN assertions, which cover both protocols regardless of features.

**`audit/event.rs:391`** — `let mut kinds` where nothing extends it unless `login-lockout` or `accounts` is enabled. Rewrote with cfg shadowing so `mut` appears only where it is used. No `allow` directive.

## Verification

Ran clippy with `-D warnings` locally across all ten combinations the new jobs will run:

```
minimal ok          tls-no-grpc ok      grpc-no-tls ok      tokens ok
frontend ok         graphql ok          audit-nodb ok       audit-turso ok
audit-surrealdb ok  audit-clickhouse ok
```

Plus `--features full`: clippy clean, 854/854 tests pass.

Also probed `websocket`, `cache-events` and `oauth-accounts` — already clean, left out to bound CI cost. The job comment records that the list is meant to grow as new features introduce cfg-gated paths.

## Note on CI cost

Seven added jobs, clippy-only, each with its own cache key. They run in parallel with the existing legs, so wall-clock impact on a PR is roughly one cold clippy build rather than seven sequential ones.