### PR TITLE
fix(tls): stop labelling operator config mistakes as internal errors

### DIFF
--- a/acton-service/src/client_tls.rs
+++ b/acton-service/src/client_tls.rs
@@ -151,7 +151,7 @@ pub(crate) fn load_identity_material(config: &ClientIdentityConfig) -> Result<Id
     use rustls_pki_types::pem::PemObject;
 
     let cert_pem = std::fs::read(&config.cert_path).map_err(|e| {
-        Error::Internal(format!(
+        Error::Tls(format!(
             "Failed to open client identity cert file '{}': {}",
             config.cert_path.display(),
             e
@@ -159,7 +159,7 @@ pub(crate) fn load_identity_material(config: &ClientIdentityConfig) -> Result<Id
     })?;
 
     let key_pem = Zeroizing::new(std::fs::read(&config.key_path).map_err(|e| {
-        Error::Internal(format!(
+        Error::Tls(format!(
             "Failed to open client identity key file '{}': {}",
             config.key_path.display(),
             e
@@ -169,7 +169,7 @@ pub(crate) fn load_identity_material(config: &ClientIdentityConfig) -> Result<Id
     let chain: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&cert_pem)
         .collect::<std::result::Result<Vec<_>, _>>()
         .map_err(|e| {
-            Error::Internal(format!(
+            Error::Tls(format!(
                 "Failed to parse client identity certificates from '{}': {}",
                 config.cert_path.display(),
                 e
@@ -177,14 +177,14 @@ pub(crate) fn load_identity_material(config: &ClientIdentityConfig) -> Result<Id
         })?;
 
     if chain.is_empty() {
-        return Err(Error::Internal(format!(
+        return Err(Error::Tls(format!(
             "Client identity cert file '{}' contains no certificates",
             config.cert_path.display()
         )));
     }
 
     let key = PrivateKeyDer::from_pem_slice(&key_pem).map_err(|e| {
-        Error::Internal(format!(
+        Error::Tls(format!(
             "Failed to parse client identity private key from '{}': {}",
             config.key_path.display(),
             e
@@ -223,7 +223,7 @@ fn certified_key_from_material(
     crate::crypto::ensure_default_crypto_provider();
 
     let provider = CryptoProvider::get_default().ok_or_else(|| {
-        Error::Internal(
+        Error::Tls(
             "No rustls crypto provider is installed; enable exactly one of the \
              `crypto-aws-lc-rs` or `crypto-ring` features"
                 .to_string(),
@@ -234,7 +234,7 @@ fn certified_key_from_material(
         .key_provider
         .load_private_key(material.key.clone_key())
         .map_err(|e| {
-            Error::Internal(format!(
+            Error::Tls(format!(
                 "Client identity private key from '{}' is not usable by the \
                  configured crypto provider: {}",
                 config.key_path.display(),
@@ -244,7 +244,7 @@ fn certified_key_from_material(
 
     let certified = CertifiedKey::new(material.chain.clone(), signing_key);
     certified.keys_match().map_err(|e| {
-        Error::Internal(format!(
+        Error::Tls(format!(
             "Client identity private key '{}' does not match the certificate \
              in '{}': {}",
             config.key_path.display(),
@@ -288,7 +288,7 @@ fn build_root_store(config: &ClientIdentityConfig) -> Result<RootCertStore> {
 fn read_validated_ca_bundle(path: &Path) -> Result<Vec<u8>> {
     crate::tls::load_root_store(path, PEER_CA_ROLE)?;
     std::fs::read(path).map_err(|e| {
-        Error::Internal(format!(
+        Error::Tls(format!(
             "Failed to read {} file '{}': {}",
             PEER_CA_ROLE,
             path.display(),
@@ -461,7 +461,7 @@ fn build_peer_verifier(config: &ClientIdentityConfig) -> Result<Arc<WebPkiServer
     WebPkiServerVerifier::builder(Arc::new(roots))
         .build()
         .map_err(|e| {
-            Error::Internal(format!(
+            Error::Tls(format!(
                 "Failed to build a peer certificate verifier from the configured \
                  {} roots: {}",
                 PEER_CA_ROLE, e
@@ -514,7 +514,7 @@ pub fn load_rustls_client_config(config: &ClientIdentityConfig) -> Result<Arc<Cl
     let client_config = ClientConfig::builder()
         .with_root_certificates(roots)
         .with_client_auth_cert(material.chain.clone(), material.key.clone_key())
-        .map_err(|e| Error::Internal(format!("Failed to build rustls client config: {}", e)))?;
+        .map_err(|e| Error::Tls(format!("Failed to build rustls client config: {}", e)))?;
 
     Ok(Arc::new(client_config))
 }
@@ -536,7 +536,7 @@ pub fn load_reqwest_identity(config: &ClientIdentityConfig) -> Result<reqwest::I
     let joined = concat_identity_pem(&material.cert_pem, &material.key_pem);
 
     reqwest::Identity::from_pem(&joined).map_err(|e| {
-        Error::Internal(format!(
+        Error::Tls(format!(
             "Failed to build a reqwest identity from '{}' and '{}': {}",
             config.cert_path.display(),
             config.key_path.display(),
@@ -578,7 +578,7 @@ pub fn reqwest_client_builder(config: &ClientIdentityConfig) -> Result<reqwest::
     if let Some(ref path) = config.root_ca_path {
         let pem = read_validated_ca_bundle(path)?;
         let certs = reqwest::Certificate::from_pem_bundle(&pem).map_err(|e| {
-            Error::Internal(format!(
+            Error::Tls(format!(
                 "Failed to build reqwest certificates from {} file '{}': {}",
                 PEER_CA_ROLE,
                 path.display(),
@@ -1161,7 +1161,7 @@ fn build_client(tls: &ClientConfig, config: &ClientIdentityConfig) -> Result<req
         .use_preconfigured_tls(tls)
         .build()
         .map_err(|e| {
-            Error::Internal(format!(
+            Error::Tls(format!(
                 "Failed to build a reqwest client for the identity in '{}': {}",
                 config.cert_path.display(),
                 e

--- a/acton-service/src/error.rs
+++ b/acton-service/src/error.rs
@@ -270,7 +270,12 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Main error type for the framework
 ///
 /// Large error variants are boxed to reduce stack size
+///
+/// Marked `#[non_exhaustive]`: new variants are added as the framework grows
+/// (`Tls` was added in 0.34), and downstream code must not be broken by that.
+/// Match with a `_` arm.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     /// Configuration error
     #[error("Configuration error: {0}")]
@@ -357,6 +362,19 @@ pub enum Error {
     /// Internal server error
     #[error("Internal server error: {0}")]
     Internal(String),
+
+    /// TLS material could not be loaded, parsed or validated
+    ///
+    /// These are operator configuration mistakes — an unreadable path, an
+    /// unparseable PEM, a certificate file with no certificates in it — and
+    /// they surface at boot, not while serving. `Internal` would tell an
+    /// operator to suspect the service instead of their own `cert_path`.
+    ///
+    /// [`Config`](Self::Config) cannot carry them: it wraps a
+    /// [`figment::Error`], and none of these originate from figment.
+    #[cfg(feature = "tls")]
+    #[error("TLS configuration error: {0}")]
+    Tls(String),
 
     /// Generic error
     #[error("{0}")]
@@ -601,6 +619,24 @@ impl IntoResponse for Error {
 
             Error::Internal(msg) => {
                 tracing::error!("Internal error: {}", msg);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    ErrorResponse::with_code(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "INTERNAL_ERROR",
+                        "Internal server error",
+                    ),
+                )
+            }
+
+            // A TLS material failure is a boot-time configuration fault, so it
+            // normally refuses startup and never reaches a response at all. If
+            // one somehow surfaces mid-request it is a 500 like any other
+            // server-side fault, and the operator-facing detail stays in the
+            // log rather than going out on the wire.
+            #[cfg(feature = "tls")]
+            Error::Tls(msg) => {
+                tracing::error!("TLS configuration error: {}", msg);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     ErrorResponse::with_code(

--- a/acton-service/src/tls.rs
+++ b/acton-service/src/tls.rs
@@ -212,7 +212,7 @@ impl TlsConfigSource {
     /// and then fail all at once.
     pub fn reload(&self) -> Result<()> {
         let Some(ref origin) = self.inner.origin else {
-            let err = crate::error::Error::Internal(
+            let err = crate::error::Error::Tls(
                 "TLS credentials cannot be reloaded: this source was built from an \
                  already-loaded ServerConfig and has no files to reread"
                     .to_string(),
@@ -708,7 +708,7 @@ pub const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 pub(crate) fn validate_handshake_timeout(tls_cfg: &TlsConfig, section: &str) -> Result<Duration> {
     match tls_cfg.handshake_timeout_secs {
         None => Ok(DEFAULT_HANDSHAKE_TIMEOUT),
-        Some(0) => Err(crate::error::Error::Internal(format!(
+        Some(0) => Err(crate::error::Error::Tls(format!(
             "{section} sets handshake_timeout_secs = 0, which would elapse before any \
              handshake could complete and so fail every connection. Omit the field to use \
              the default of {} seconds, or set a positive number of seconds.",
@@ -739,7 +739,7 @@ pub(crate) fn validate_reload_interval(
 ) -> Result<Option<Duration>> {
     match tls_cfg.reload_interval_secs {
         None => Ok(None),
-        Some(0) => Err(crate::error::Error::Internal(format!(
+        Some(0) => Err(crate::error::Error::Tls(format!(
             "{section} sets reload_interval_secs = 0, which would poll the certificate \
              files without pause. Omit the field to disable polling, or set a positive \
              number of seconds."
@@ -1062,7 +1062,7 @@ pub(crate) fn load_root_store(path: &Path, role: &str) -> Result<RootCertStore> 
 
     let ca_certs: Vec<CertificateDer<'static>> = CertificateDer::pem_file_iter(path)
         .map_err(|e| {
-            crate::error::Error::Internal(format!(
+            crate::error::Error::Tls(format!(
                 "Failed to open {} file '{}': {}",
                 role,
                 path.display(),
@@ -1071,7 +1071,7 @@ pub(crate) fn load_root_store(path: &Path, role: &str) -> Result<RootCertStore> 
         })?
         .collect::<std::result::Result<Vec<_>, _>>()
         .map_err(|e| {
-            crate::error::Error::Internal(format!(
+            crate::error::Error::Tls(format!(
                 "Failed to parse {} certificates from '{}': {}",
                 role,
                 path.display(),
@@ -1080,7 +1080,7 @@ pub(crate) fn load_root_store(path: &Path, role: &str) -> Result<RootCertStore> 
         })?;
 
     if ca_certs.is_empty() {
-        return Err(crate::error::Error::Internal(format!(
+        return Err(crate::error::Error::Tls(format!(
             "The {} file '{}' contains no certificates",
             role,
             path.display()
@@ -1090,7 +1090,7 @@ pub(crate) fn load_root_store(path: &Path, role: &str) -> Result<RootCertStore> 
     let mut roots = RootCertStore::empty();
     for cert in ca_certs {
         roots.add(cert).map_err(|e| {
-            crate::error::Error::Internal(format!(
+            crate::error::Error::Tls(format!(
                 "Failed to add {} certificate from '{}' to trust store: {}",
                 role,
                 path.display(),
@@ -1122,7 +1122,7 @@ pub fn build_client_verifier(
     }
 
     builder.build().map_err(|e| {
-        crate::error::Error::Internal(format!(
+        crate::error::Error::Tls(format!(
             "Failed to build client certificate verifier: {}",
             e
         ))
@@ -1145,7 +1145,7 @@ pub fn load_server_config(tls_config: &TlsConfig) -> Result<Arc<ServerConfig>> {
     let cert_chain: Vec<rustls::pki_types::CertificateDer<'static>> =
         CertificateDer::pem_file_iter(&tls_config.cert_path)
             .map_err(|e| {
-                crate::error::Error::Internal(format!(
+                crate::error::Error::Tls(format!(
                     "Failed to open TLS cert file '{}': {}",
                     tls_config.cert_path.display(),
                     e
@@ -1153,18 +1153,18 @@ pub fn load_server_config(tls_config: &TlsConfig) -> Result<Arc<ServerConfig>> {
             })?
             .collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| {
-                crate::error::Error::Internal(format!("Failed to parse TLS certificates: {}", e))
+                crate::error::Error::Tls(format!("Failed to parse TLS certificates: {}", e))
             })?;
 
     if cert_chain.is_empty() {
-        return Err(crate::error::Error::Internal(
+        return Err(crate::error::Error::Tls(
             "TLS cert file contains no certificates".to_string(),
         ));
     }
 
     // Read private key (first PEM-encoded key found in the file)
     let key = PrivateKeyDer::from_pem_file(&tls_config.key_path).map_err(|e| {
-        crate::error::Error::Internal(format!(
+        crate::error::Error::Tls(format!(
             "Failed to parse TLS private key from '{}': {}",
             tls_config.key_path.display(),
             e
@@ -1205,7 +1205,7 @@ pub fn load_server_config(tls_config: &TlsConfig) -> Result<Arc<ServerConfig>> {
     }
     .with_single_cert(cert_chain, key)
     .map_err(|e| {
-        crate::error::Error::Internal(format!("Failed to build TLS server config: {}", e))
+        crate::error::Error::Tls(format!("Failed to build TLS server config: {}", e))
     })?;
 
     // Advertise ALPN so the listener answers a client's protocol offer during
@@ -1400,6 +1400,129 @@ mod tests {
         let optional_roots = load_client_ca_roots(file.path()).expect("roots");
         build_client_verifier(optional_roots, true)
             .expect("a verifier allowing unauthenticated clients must build");
+    }
+
+    /// A configuration failure must not present itself as an internal fault.
+    ///
+    /// These errors reach an operator verbatim: a downstream service wraps the
+    /// string into its own boot message, so an `Internal server error:` prefix
+    /// tells them to suspect the framework instead of their own `cert_path`.
+    mod error_taxonomy {
+        use super::*;
+
+        fn config_pointing_at(cert: &Path, key: &Path) -> TlsConfig {
+            TlsConfig {
+                enabled: true,
+                cert_path: cert.to_path_buf(),
+                key_path: key.to_path_buf(),
+                client_ca_path: None,
+                client_auth_optional: false,
+                reload_interval_secs: None,
+                reload_on_sighup: false,
+                handshake_timeout_secs: None,
+            }
+        }
+
+        #[test]
+        fn a_missing_cert_file_is_a_tls_error_not_an_internal_one() {
+            let key = write_temp(&generate_cert("localhost").key_pem);
+            let config = config_pointing_at(Path::new("/nonexistent/server.crt"), key.path());
+
+            let err = load_server_config(&config).expect_err("a missing cert file must fail");
+
+            assert!(
+                matches!(err, crate::error::Error::Tls(_)),
+                "a missing cert file is an operator configuration mistake, got {err:?}"
+            );
+        }
+
+        #[test]
+        fn the_operator_facing_message_carries_no_internal_prefix() {
+            // The exact shape reported downstream:
+            //   "... TLS configuration is invalid: Internal server error: Failed
+            //    to open TLS cert file '/nonexistent/server.crt': ..."
+            let key = write_temp(&generate_cert("localhost").key_pem);
+            let config = config_pointing_at(Path::new("/nonexistent/server.crt"), key.path());
+
+            let rendered = load_server_config(&config)
+                .expect_err("a missing cert file must fail")
+                .to_string();
+
+            assert!(
+                !rendered.contains("Internal server error"),
+                "a boot-time config failure must not read as an internal fault: {rendered}"
+            );
+            assert!(
+                rendered.starts_with("TLS configuration error:"),
+                "the prefix must name the real category: {rendered}"
+            );
+            assert!(
+                rendered.contains("/nonexistent/server.crt"),
+                "the message must still name the offending path: {rendered}"
+            );
+        }
+
+        #[test]
+        fn an_empty_cert_file_is_a_tls_error() {
+            let cert = write_temp("# no certificates here\n");
+            let key = write_temp(&generate_cert("localhost").key_pem);
+
+            let err = load_server_config(&config_pointing_at(cert.path(), key.path()))
+                .expect_err("a cert file with no certificates must fail");
+
+            assert!(
+                matches!(err, crate::error::Error::Tls(_)),
+                "an empty cert bundle is a configuration mistake, got {err:?}"
+            );
+        }
+
+        #[test]
+        fn an_unparseable_key_is_a_tls_error() {
+            let server = generate_cert("localhost");
+            let cert = write_temp(&server.cert_pem);
+            let key = write_temp("-----BEGIN PRIVATE KEY-----\nnot base64\n");
+
+            let err = load_server_config(&config_pointing_at(cert.path(), key.path()))
+                .expect_err("an unparseable key must fail");
+
+            assert!(
+                matches!(err, crate::error::Error::Tls(_)),
+                "an unparseable key is a configuration mistake, got {err:?}"
+            );
+        }
+
+        #[test]
+        fn a_zero_handshake_timeout_is_a_tls_error() {
+            // Config-value validation, not material loading, but the same
+            // category: the operator wrote something that cannot work.
+            let server = generate_cert("localhost");
+            let cert = write_temp(&server.cert_pem);
+            let key = write_temp(&server.key_pem);
+            let mut config = config_pointing_at(cert.path(), key.path());
+            config.handshake_timeout_secs = Some(0);
+
+            let err = validate_handshake_timeout(&config, "[tls]")
+                .expect_err("a zero handshake timeout must be refused");
+
+            assert!(
+                matches!(err, crate::error::Error::Tls(_)),
+                "a nonsensical config value is a configuration mistake, got {err:?}"
+            );
+        }
+
+        #[test]
+        fn a_tls_error_still_maps_to_500_if_it_reaches_a_response() {
+            use axum::response::IntoResponse;
+
+            // These normally refuse startup and never reach a response. If one
+            // somehow surfaces mid-request it is a server-side fault like any
+            // other, and the operator detail must not go out on the wire.
+            let response =
+                crate::error::Error::Tls("cert_path '/etc/secret.pem' unreadable".to_string())
+                    .into_response();
+
+            assert_eq!(response.status(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #105.

## The bug

`load_server_config` wrapped every boot-time TLS configuration failure in `Error::Internal`, whose `Display` is `Internal server error: {0}`. These are operator mistakes — a bad path, an unparseable PEM, an empty certificate file — and they happen at boot, not while serving. The prefix leaked verbatim into downstream operator-facing boot messages:

```
API-listener TLS configuration is invalid: Internal server error: Failed to
open TLS cert file '/nonexistent/server.crt': No such file or directory
```

Wrong twice over, as the issue says: it is a config error, not an internal one, and it tells an operator to suspect the framework instead of their own `cert_path`.

## The fix

Added `Error::Tls(String)`, displayed as `TLS configuration error: {0}`, exactly as #105 proposed. `Error::Config` could not carry these — it is `Config(Box<figment::Error>)`, and none of them originate from figment.

Migrated **27** construction sites: 13 in `tls.rs`, 14 in `client_tls.rs` for outbound identity material.

HTTP mapping is unchanged per the issue: still 500 if one somehow surfaces mid-request, with the operator detail staying in the log rather than going out on the wire. There is a test for that.

### What I deliberately left as `Internal`

Seven sites, none of which is a configuration mistake:

- `tls.rs:628` — SIGHUP handler install failure. An OS fault, not config.
- `client_tls.rs:947,1088,1109` — gRPC endpoint shape (`must use https`, `not a valid TLS server name`, `has no host`). These are about the endpoint a caller passed, not TLS material.
- `client_tls.rs:1119,1127,1137` — connect, `TCP_NODELAY`, and handshake failures. Runtime faults against a live peer.

The issue scopes itself to boot-time config and "outbound-identity material", and these fall outside that. Happy to widen if you read it differently — it is a one-line change per site.

## `#[non_exhaustive]` — the reason this wants 0.34.0

`Error` is not `#[non_exhaustive]` and has 52 variants. Adding one is a breaking change for any downstream matching exhaustively, so this fix **cannot** ship as a patch release.

Since 0.34.0 is already a breaking boundary (it is already required by #111 and #113), I marked `Error` `#[non_exhaustive]` in the same change. That is itself breaking, so this is the free window for it — and after this, every future variant is additive. Doing it later would cost another minor bump on its own.

Verified `cargo clippy --workspace` stays clean, so `acton-cli` does not match exhaustively.

## Tests

Six new tests in `tls::tests::error_taxonomy`:

- a missing cert file yields `Error::Tls`, not `Error::Internal`
- the rendered message contains no `Internal server error`, starts with `TLS configuration error:`, and still names the offending path — this reproduces the exact downstream string from the issue
- an empty cert bundle and an unparseable key are both `Error::Tls`
- a zero `handshake_timeout_secs` is `Error::Tls` (config-value validation, same category)
- an `Error::Tls` reaching `IntoResponse` is still a 500

## Gates

- `cargo nextest run --workspace --features full` — 865/865
- `cargo clippy --workspace --all-targets --features full -- -D warnings` — clean

Rebased onto `main` after #114 and #115.