### PR TITLE
chore(release): prepare 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,121 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [acton-service-v0.34.0] - 2026-08-02
+
+Closes every open issue on the tracker. The headline is mutual-TLS caller
+authorization (#109): until now `[tls].client_ca_path` decided whose
+certificates were *accepted* and nothing decided which of those callers
+could *proceed*, so every principal a fleet CA had ever issued to could
+reach every mTLS route of every peer. Alongside it, a root-level catch-all
+that no longer requires the `htmx` feature (#110), and fixes for three
+defects that were each invisible in their own way: a latency histogram that
+looked healthy while unable to distinguish a fast request from a slow one
+(#107), operator config mistakes reported as internal framework errors
+(#105), and a gRPC channel that could stall forever on a peer that connected
+and then went quiet (#103).
+
+`Error` is now `#[non_exhaustive]`, which is why this is 0.34.0.
+
+### Added
+
+- **caller_auth**: Transport-level admission control for mutual-TLS callers,
+  gated on `tls`. `CallerSan` names a caller from its leaf certificate's
+  `subjectAltName` (DNS or URI, byte-exact within its kind; no wildcard,
+  suffix or subdomain matching, and a wildcard SAN inside a certificate is
+  dropped rather than matched). `CallerAllowlist` cannot be constructed
+  empty, because an allowlist admitting everyone is how this control fails
+  open. `authorize(policy, leaf_der, bearer_present)` is the whole decision
+  as a pure function naming no transport type, so HTTP and gRPC share it.
+  Configured under `[caller_auth]` with `mode`, `allowlist` and
+  `public_paths`.
+- **caller_auth**: `CallerAuthMode` of `bearer` | `mtls` | `mtls-or-bearer`.
+  The third exists so a fleet can cut over caller-by-caller: a caller with
+  no certificate yet, or one not yet allowlisted, keeps working on its
+  token. Under that mode an allowlisted certificate waives the token
+  requirement for that request; under `mtls` the certificate is an
+  *additional* requirement and a configured token layer still demands a
+  valid token.
+- **caller_auth**: Configuration that would look like protection without
+  being it is refused at startup rather than ignored: a certificate mode on
+  a listener with no `client_ca_path` (`[tls]` and `[grpc.tls]` are checked
+  separately and the error names which one to fix), an `allowlist` under
+  `mode = "bearer"` where nothing would consult it, an empty `allowlist`
+  under a certificate mode, and unknown keys in the section.
+- **routing**: `VersionedApiBuilder::with_fallback` and
+  `with_fallback_service` — a root-level catch-all with no feature gate. The
+  only prior route to one was `with_frontend_routes`, which is
+  `#[cfg(feature = "htmx")]`, so a proxy with no frontend and no templates
+  had to compile `axum-htmx` to attach a catch-all or drop off
+  `ServiceBuilder` entirely and lose the whole middleware stack. Two methods
+  because a transparent proxy forwards to a `tower::Service`, not an axum
+  handler. Applied after health, frontend and versioned routes, so the
+  catch-all shadows nothing.
+- **client-tls**: `ClientIdentityConfig::connect_timeout_secs` and the
+  exported `DEFAULT_CLIENT_CONNECT_TIMEOUT` (30s), mirroring the listener's
+  `handshake_timeout_secs`. One budget spans both the TCP connect and the
+  handshake rather than one each, since a stall can sit in either and two
+  independent bounds would let a peer burn both in sequence. A configured
+  `0` resolves to the default rather than failing every connection.
+- **error**: `Error::Tls(String)`, displayed as
+  `TLS configuration error: {0}`.
+
+### Changed
+
+- **Breaking**: `Error` is now `#[non_exhaustive]`. Adding the `Tls` variant
+  to a 52-variant exhaustive enum is itself breaking, so this is the free
+  window to make every future variant additive.
+- **observability**: Histograms declared with `.with_unit("s")` are now
+  bucketed with seconds-scaled boundaries via a metric view. This enables
+  `opentelemetry_sdk`'s `spec_unstable_metrics_views` feature, the only
+  route to registering a view; the `unstable` marker is the OTel Rust SDK's
+  flag for spec features not yet stabilized, so an SDK upgrade could move
+  this API.
+- **client-tls**: The `grpc_channel` docs no longer tell callers to wrap
+  their first RPC in `tokio::time::timeout`. That was a workaround for the
+  missing bound this release adds.
+- **ci**: Clippy now runs on ten feature combinations rather than two. The
+  `audit-storage` matrix gained a lint step, and a new lint-only
+  `feature-combos` job covers seven combinations no test job compiles
+  (`minimal`, `tls-no-grpc`, `grpc-no-tls`, `tokens`, `frontend`, `graphql`,
+  `audit-nodb`). Lints in cfg-gated code were previously unreachable by CI,
+  and `--all-features` is not a substitute because the crate's
+  mutual-exclusion `compile_error!` guards reject it by design.
+
+### Fixed
+
+- **observability**: Seconds-valued histograms were bucketed against the
+  SDK's default boundaries, `[0, 5, 10, 25, …, 7500, 10000]`, which are
+  chosen for milliseconds. Every observation under five seconds landed in
+  the first bucket. Nothing warned, and the exposition looked well-formed.
+  The new boundaries are the OTel semantic-convention set for
+  `http.server.request.duration` extended downward with two sub-5ms values,
+  not replaced, so existing dashboards and alerts still line up. The view
+  selects on the instrument's *unit* rather than its name, so any histogram
+  following the semantic conventions is bucketed correctly without its
+  author knowing the view exists.
+- **tls**: Boot-time TLS configuration failures were wrapped in
+  `Error::Internal`, whose `Display` is `Internal server error: {0}`. A bad
+  path or an unparseable PEM told an operator to suspect the framework
+  instead of their own `cert_path`. 27 construction sites now yield
+  `Error::Tls`: 13 in `tls.rs`, 14 in `client_tls.rs` for outbound identity
+  material. Runtime and OS faults stay `Internal`. HTTP mapping is
+  unchanged at 500, with the operator detail staying in the log rather than
+  going out on the wire.
+- **client-tls**: `grpc_channel` had no connect or handshake bound. #97
+  switched it to `Channel::new` to bypass tonic's scheme-inspecting
+  connector wrapper, but that wrapper is also where tonic applies
+  `Endpoint::connect_timeout`, so the setting was silently dropped and tonic
+  exposes no getter to read it back. A peer that completed the TCP connect
+  and then stalled the handshake held the attempt open indefinitely.
+- **client-tls**: The `tls` field and `tls_config_with_alpn` were ungated
+  though their only non-test consumer is `#[cfg(feature = "grpc")]`,
+  producing dead-code warnings under `tls`-without-`grpc`.
+- **audit**: `let mut kinds` in `event.rs` where nothing extends it unless
+  `login-lockout` or `accounts` is enabled.
+- **docs**: Two unresolved rustdoc links in `checks.rs` pointing at
+  `crate::service` instead of `crate::service_builder`.
+
 ## [acton-service-v0.33.0] - 2026-07-24
 
 A healthy dependency can now speak. `CheckOutcome::Ready` carries no

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "acton-cli"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "acton-service",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["acton-service", "acton-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 authors = ["roland@govcraft.ai"]
 license = "MIT"

--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-acton-service = { path = "../acton-service", version = "0.33.0" }
+acton-service = { path = "../acton-service", version = "0.34.0" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/acton-docs/src/app/docs/observability/page.md
+++ b/acton-docs/src/app/docs/observability/page.md
@@ -257,6 +257,37 @@ scrape_configs:
 `/metrics` is unauthenticated, like `/health`. It exposes route names, traffic volumes, and latency distributions — no request payloads or secrets — but if that surface matters in your deployment, restrict access at the network layer. The route is excluded from audit logging by default.
 {% /callout %}
 
+### Histogram Bucket Boundaries
+
+Declare a duration histogram with the semantic-convention unit and it is bucketed in seconds automatically:
+
+```rust
+use acton_service::observability::get_meter;
+
+if let Some(meter) = get_meter() {
+    let histogram = meter
+        .f64_histogram("db.client.operation.duration")
+        .with_unit("s")      // <- this is what selects the seconds boundaries
+        .build();
+    histogram.record(elapsed.as_secs_f64(), &[]);
+}
+```
+
+The framework registers a metric view that selects on the instrument's **unit**, not its name, so any histogram following the OpenTelemetry semantic conventions gets the right boundaries without wiring anything up:
+
+```
+0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1,
+0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0
+```
+
+This is the semconv set for `http.server.request.duration`, extended downward with two sub-5ms boundaries rather than replaced, so dashboards and alerts written against the standard values still line up.
+
+{% callout type="warning" title="Declare the unit" %}
+A histogram with no unit, or one declared in milliseconds, keeps the SDK's default boundaries — `[0, 5, 10, 25, …, 7500, 10000]`, which are chosen for milliseconds. Feed those seconds-valued observations and every request under five seconds lands in the first bucket. Nothing warns, and the exposition still looks well-formed, so the histogram appears healthy while being unable to tell a fast request from a slow one.
+{% /callout %}
+
+`MetricsConfig::latency_buckets_ms` is unrelated: it configures the built-in HTTP middleware's own instruments, not histograms you create through `get_meter()`.
+
 ---
 
 ## Structured Logging

--- a/acton-docs/src/app/docs/tls/page.md
+++ b/acton-docs/src/app/docs/tls/page.md
@@ -331,6 +331,36 @@ silently ignoring them — a misspelled field like `reload_interval_sec`
 certificate rotation.
 {% /callout %}
 
+## Outbound connect timeout
+
+The handshake timeout above bounds connections this service *accepts*. The
+mirror image, for connections it *makes*, is `connect_timeout_secs` on
+`ClientIdentityConfig`:
+
+```toml
+[client_identity]
+enabled = true
+cert_path = "./certs/client.pem"
+key_path = "./certs/client-key.pem"
+root_ca_path = "./certs/peer-ca.pem"
+connect_timeout_secs = 30
+```
+
+One budget spans both the TCP connect and the TLS handshake, not one each. A
+stall can sit in either phase, and two independent bounds would let a peer
+burn both in sequence.
+
+Omit the field for the built-in default of 30 seconds
+(`client_tls::DEFAULT_CLIENT_CONNECT_TIMEOUT`). Unlike the listener's
+`handshake_timeout_secs`, a configured `0` resolves to the default rather than
+being rejected: `[client_identity]` is deserialized per peer by your code, not
+by the framework `Config`, so there is no startup hook to refuse it, and "no
+override" is the only reading under which the channel still works.
+
+The default is deliberately generous. It exists to stop an indefinite stall,
+not to enforce latency — a per-RPC deadline is still the `Endpoint`'s
+`timeout`.
+
 ## Related
 
 - [Feature Flags](/docs/feature-flags#tls) — what the `tls` feature enables, including outbound mutual TLS

--- a/acton-docs/src/lib/version.ts
+++ b/acton-docs/src/lib/version.ts
@@ -2,4 +2,4 @@
  * Version information for acton-service
  * This should match the version in the root Cargo.toml workspace.package.version
  */
-export const VERSION = '0.31.2'
+export const VERSION = '0.34.0'

--- a/acton-docs/src/markdoc/config.js
+++ b/acton-docs/src/markdoc/config.js
@@ -4,7 +4,7 @@ import { siteConfig } from '../lib/config'
 
 // Extract version from workspace Cargo.toml
 // This should be kept in sync with the workspace version
-const ACTON_VERSION = '0.31.2'
+const ACTON_VERSION = '0.34.0'
 
 // Single source of truth mapping camelCase aliases to the real Cargo feature
 // lists. Used by both the `dep()` function and the `$dep.*` variables so a

--- a/acton-docs/src/markdoc/functions.js
+++ b/acton-docs/src/markdoc/functions.js
@@ -1,5 +1,5 @@
 // Markdoc functions for version management
-const ACTON_VERSION = '0.31.2'
+const ACTON_VERSION = '0.34.0'
 
 export const version = {
   transform() {


### PR DESCRIPTION
Release prep for 0.34.0. Nothing functional changes here: version bump, CHANGELOG, docs version sync, and two doc sections the auto-sync workflow did not cover.

## What is in the release

Every open issue on the tracker, closed.

| PR | Issue | |
| --- | --- | --- |
| #111 | #109 | mutual-TLS caller authorization by certificate SAN |
| #113 | #110 | feature-independent root-level fallback |
| #114 | #76 | per-combo clippy in CI, plus the two lints it surfaced |
| #115 | #107 | seconds-valued histograms bucketed in seconds |
| #116 | #105 | `Error::Tls` instead of `Internal` for config mistakes |
| #117 | #103 | connect and handshake bound on the gRPC channel path |

## Why 0.34.0 and not 0.33.1

`Error` was a 52-variant exhaustive enum. #116 added `Tls` to it, which breaks any downstream matching exhaustively, so this could not have shipped as a patch. #116 also marked the enum `#[non_exhaustive]` in the same change, since that is breaking too and this was the free window. After this release every future variant is additive.

`cargo clippy --workspace` stays clean, so `acton-cli` does not match `Error` exhaustively.

## The docs version files were two releases behind

`version.ts`, `markdoc/config.js` and `markdoc/functions.js` were all still on **0.31.2**. They missed 0.32.0 and 0.33.0 entirely, so the install snippets the site rendered have been stale since 20 July. This brings all three to 0.34.0 and catches up the gap.

Worth a look at whether that sync belongs in CI rather than in a release checklist, since it has now silently drifted twice. Not doing it here.

## Two docs sections added

`docs-sync-on-merge.yml` fired for each merge and opened nothing for #115, #116 or #117. #111 and #113 carried their own docs, so the gap is real but narrow:

- **TLS page, "Outbound connect timeout"** — `connect_timeout_secs`, the outbound mirror of the existing handshake-timeout section. Covers why one budget spans both phases rather than one each, and why a configured `0` resolves to the default here when the listener rejects it at boot.
- **Observability page, "Histogram Bucket Boundaries"** — that `.with_unit("s")` is what selects the seconds boundaries, the boundary list, and a warning that an unmarked histogram keeps the millisecond defaults and will look healthy while unable to distinguish a fast request from a slow one.

`Error::Tls` is not documented on the site: it is an internal taxonomy correction with no configuration surface, and the improvement is visible in the message an operator already reads.

## Gates

- `cargo clippy --workspace --all-targets --features full -- -D warnings` — clean
- `cargo nextest run --workspace --features full` — 869/869
- Version consistency: workspace `Cargo.toml`, `acton-cli`'s path dependency, `Cargo.lock` and all three docs constants agree on 0.34.0
- Markdoc `callout type="warning"` verified against the tag schema; the `get_meter()` snippet matches the real signature (`Option<Meter>`, no argument)

## Still deferred

Three feature-gated rustdoc broken links (`crypto.rs:21`; `middleware/paseto.rs:41`, same pattern in `jwt.rs`, `jwt_generator.rs`, `paseto_generator.rs`). Each needs `cfg_attr`'d doc text and a walk of the feature matrix. Not a release blocker and out of scope for a prep PR.

## After merge

Tag `acton-service-v0.34.0` and publish.