### PR TITLE
fix(tls): serve the HTTP/2 the TLS listener advertises (#120) + release 0.34.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,10 +232,13 @@ jobs:
   # guards (database/turso/surrealdb, crypto-aws-lc-rs/crypto-ring) reject it by
   # design, so narrow combinations are the only way to reach cfg-gated code.
   #
-  # These run clippy without nextest. The `full` legs above already own test
-  # coverage; what is missing is a compiler that ever *looks* at code behind a
-  # narrower gate. Adding legs here is cheap -- extend the list whenever a new
-  # feature introduces its own cfg-gated paths.
+  # These run clippy only, unless a leg sets `test: true`. The `full` legs
+  # above already own test coverage; what is usually missing is a compiler that
+  # ever *looks* at code behind a narrower gate. A leg opts into nextest when
+  # the narrower feature set changes runtime behaviour and not just what
+  # compiles, which the `full` legs would then never exercise. Adding legs here
+  # is cheap -- extend the list whenever a new feature introduces its own
+  # cfg-gated paths.
   feature-combos:
     name: lint ${{ matrix.combo }}
     needs: changes
@@ -249,9 +252,13 @@ jobs:
           - combo: minimal
             features: "http,crypto-aws-lc-rs"
           # TLS without gRPC. This combination is what let two dead-code
-          # warnings survive in client_tls.rs until #76.
+          # warnings survive in client_tls.rs until #76, and it is the only one
+          # that can catch #120: with gRPC compiled in, tonic pulls
+          # hyper-util/http2 and the HTTP listener serves h2 whether or not the
+          # workspace asked for it. So this leg runs the tests too.
           - combo: tls-no-grpc
             features: "http,tls,crypto-aws-lc-rs"
+            test: true
           # The mirror image: gRPC transport with no TLS material.
           - combo: grpc-no-tls
             features: "http,grpc,crypto-aws-lc-rs"
@@ -277,10 +284,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: combo-${{ matrix.combo }}
+      - uses: taiki-e/install-action@nextest
+        if: matrix.test
       - name: Clippy
         run: |
           cargo clippy -p acton-service --all-targets \
             --no-default-features --features "${{ matrix.features }}" -- -D warnings
+      # Only for legs that opt in with `test: true`. A combination earns this
+      # when its behaviour differs from the `full` legs rather than merely
+      # compiling differently -- otherwise clippy is enough and cheaper.
+      - name: Nextest
+        if: matrix.test
+        run: |
+          cargo nextest run -p acton-service \
+            --no-default-features --features "${{ matrix.features }}"
 
   # Builds the documentation site so that broken Markdoc fails the pull request
   # rather than reaching the deploy job after the merge has already landed on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [acton-service-v0.34.1] - 2026-08-03
+
+A TLS listener compiled without the `grpc` feature dropped every HTTP/2
+client on the floor and logged nothing about it (#120). The listener
+advertises `h2` in ALPN, but the server behind it was built without HTTP/2
+support, so any ALPN-honouring client — curl at its defaults, browsers, Go's
+`net/http` — took the offer, sent the HTTP/2 connection preface, and had its
+connection closed before a span ever opened. Nothing appeared in the server
+log at any level, and the client-side error looks like a TLS fault, so an
+operator following an mTLS runbook reads it as "my certificates are wrong".
+
+### Fixed
+
+- **tls**: Enable axum's `http2` feature so the HTTP listener serves the
+  protocol it advertises. `http2` is not in axum's default set, and it is
+  what turns on `hyper-util/http2` beneath `axum::serve`; without it that
+  auto server is HTTP/1.1-only while `load_server_config` offers
+  `[h2, http/1.1]`. Services compiling `grpc` were never affected — tonic
+  enables the same hyper-util feature transitively — which is what confined
+  the defect to TLS-without-gRPC builds and hid it from the `full` test legs.
+  `reqwest` without its own `http2` feature negotiates `http/1.1` and kept
+  working throughout, which is why no existing test saw it.
+- **http**: A side effect worth knowing about: the plaintext listener now also
+  answers an h2c client that connects with prior knowledge, because the same
+  hyper-util auto server sniffs the preface whether or not TLS is in front of
+  it. Nothing that worked before behaves differently — HTTP/1.1 clients are
+  untouched, and there is no h2c upgrade dance, only prior knowledge.
+
+### Added
+
+- **tests**: `tls_alpn_http2.rs` drives the TLS listener with a hand-rolled
+  h2 client over `tokio-rustls` and requires the connection preface to be
+  answered with a SETTINGS frame, alongside an HTTP/1.1 leg that must keep
+  working. It deliberately adds no HTTP client dependency: anything that
+  speaks h2 turns `hyper-util/http2` on for the build under test and would
+  mask the very regression it exists to catch. CI runs it on the
+  `tls-no-grpc` combination, which is now the one feature leg that runs
+  tests as well as clippy.
+
 ## [acton-service-v0.34.0] - 2026-08-02
 
 Closes every open issue on the tracker. The headline is mutual-TLS caller

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "acton-cli"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "acton-service",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["acton-service", "acton-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.34.0"
+version = "0.34.1"
 edition = "2021"
 authors = ["roland@govcraft.ai"]
 license = "MIT"
@@ -18,7 +18,12 @@ tokio = { version = "1.48.0", features = ["net", "rt", "rt-multi-thread", "signa
 tokio-stream = { version = "0.1", features = ["net"] }
 
 # HTTP framework
-axum = { version = "0.8.6", features = ["macros", "ws"] }
+# `http2` is not in axum's default feature set and is not optional here: the TLS
+# listener advertises `h2` in ALPN (see `tls::load_server_config`), so the server
+# `axum::serve` builds must be able to answer a client that takes the offer.
+# Without it every ALPN-honouring client — curl at its defaults, browsers, Go's
+# `net/http` — negotiates h2 and has its connection dropped with nothing logged.
+axum = { version = "0.8.6", features = ["http2", "macros", "ws"] }
 tower = { version = "0.5.2", features = ["util", "timeout", "limit", "buffer", "make"] }
 tower-http = { version = "0.6.6", features = [
     "trace",

--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-acton-service = { path = "../acton-service", version = "0.34.0" }
+acton-service = { path = "../acton-service", version = "0.34.1" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/acton-docs/src/app/docs/tls/page.md
+++ b/acton-docs/src/app/docs/tls/page.md
@@ -37,6 +37,20 @@ key_path = "./certs/server-key.pem"    # PEM-encoded private key
 whose certificate or key cannot be loaded is a hard failure at startup — the
 service refuses to bind rather than silently falling back to plaintext.
 
+### Negotiated protocols
+
+The listener advertises `h2` and `http/1.1` in ALPN and serves both, so a
+client picks whichever it prefers: `curl` at its defaults and every browser
+take h2, and a client that offers no ALPN at all still works because the
+server sniffs the protocol. Nothing configures this and nothing needs to.
+
+Before 0.34.1 the HTTP listener advertised `h2` without being able to serve
+it, so an ALPN-honouring client had its connection dropped mid-request with
+no server-side log line, and only clients that chose `http/1.1` worked. If
+you are on 0.34.0 or earlier and `curl --http1.1` succeeds against a
+verification step where plain `curl` fails, that is this defect and not your
+certificates. Upgrade; there is no configuration workaround.
+
 ## Mutual TLS (verifying client certificates)
 
 Point `client_ca_path` at a PEM bundle of CA certificates to require

--- a/acton-docs/src/lib/version.ts
+++ b/acton-docs/src/lib/version.ts
@@ -2,4 +2,4 @@
  * Version information for acton-service
  * This should match the version in the root Cargo.toml workspace.package.version
  */
-export const VERSION = '0.34.0'
+export const VERSION = '0.34.1'

--- a/acton-docs/src/markdoc/config.js
+++ b/acton-docs/src/markdoc/config.js
@@ -4,7 +4,7 @@ import { siteConfig } from '../lib/config'
 
 // Extract version from workspace Cargo.toml
 // This should be kept in sync with the workspace version
-const ACTON_VERSION = '0.34.0'
+const ACTON_VERSION = '0.34.1'
 
 // Single source of truth mapping camelCase aliases to the real Cargo feature
 // lists. Used by both the `dep()` function and the `$dep.*` variables so a

--- a/acton-docs/src/markdoc/functions.js
+++ b/acton-docs/src/markdoc/functions.js
@@ -1,5 +1,5 @@
 // Markdoc functions for version management
-const ACTON_VERSION = '0.34.0'
+const ACTON_VERSION = '0.34.1'
 
 export const version = {
   transform() {

--- a/acton-service/src/tls.rs
+++ b/acton-service/src/tls.rs
@@ -1217,6 +1217,17 @@ pub fn load_server_config(tls_config: &TlsConfig) -> Result<Arc<ServerConfig>> {
     // both (hyper auto-detects the protocol), rustls picks the best mutual
     // protocol so h2 wins for a gRPC client, and a client that offers no ALPN is
     // unaffected because protocol sniffing still applies.
+    //
+    // The HTTP listener serves h2 only because the workspace enables axum's
+    // `http2` feature, which is not in its default set and which is what turns
+    // on `hyper-util/http2` underneath `axum::serve`. Advertising a protocol
+    // the listener cannot speak is silent: rustls completes the handshake, the
+    // client sends the HTTP/2 preface, and the connection dies before any span
+    // opens (#120). Dropping that feature therefore means dropping `h2` from
+    // this list. `tests/tls_alpn_http2.rs` holds the two together, but only in
+    // a build where nothing else supplies h2 — compiling `grpc` pulls the same
+    // hyper-util feature in through tonic, which is why the CI leg that runs
+    // those tests is `tls-no-grpc`.
     let mut config = config;
     config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
 

--- a/acton-service/tests/tls_alpn_http2.rs
+++ b/acton-service/tests/tls_alpn_http2.rs
@@ -1,0 +1,202 @@
+//! The TLS listener must serve every protocol it advertises in ALPN.
+//!
+//! `tls::load_server_config` offers `[h2, http/1.1]`. A client that honours
+//! ALPN — curl at its defaults, any browser, Go's `net/http` — takes the h2
+//! offer and sends the HTTP/2 connection preface. If the server `axum::serve`
+//! builds cannot answer that preface the failure is silent on both ends: the
+//! handshake succeeds, then the connection is dropped before any span opens, so
+//! the server logs nothing at any level and the operator sees only a
+//! TLS-looking error client-side.
+//!
+//! Whether the listener speaks h2 is decided by `hyper-util`'s `http2` feature,
+//! which reaches the auto server through axum's `http2` feature (see the
+//! workspace `Cargo.toml`). That makes this file's coverage fragile in a
+//! specific way: any dependency that turns `hyper-util/http2` on for the test
+//! build — `reqwest/http2`, `tonic`, a plain `hyper` client with h2 — also
+//! turns it on for the server under test, and these tests would then pass
+//! whatever the workspace declared. The h2 client here is therefore hand-rolled
+//! over `tokio-rustls` and this file adds no dependency of its own. Keep it
+//! that way, and run it at least once with `--no-default-features --features
+//! http,tls,crypto-aws-lc-rs` where nothing else supplies h2.
+#![cfg(feature = "tls")]
+
+use std::io::Write as _;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use acton_service::config::TlsConfig;
+use acton_service::tls::{load_server_config, TlsListener};
+use axum::routing::get;
+use axum::Router;
+use rustls_pki_types::pem::PemObject;
+use rustls_pki_types::{CertificateDer, ServerName};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// The HTTP/2 connection preface every h2 client sends first (RFC 9113 §3.4).
+const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+/// An empty SETTINGS frame: 24-bit length, type, flags, 31-bit stream id.
+const H2_EMPTY_SETTINGS: &[u8] = &[0, 0, 0, 0x04, 0, 0, 0, 0, 0];
+/// Frame type SETTINGS, which a real h2 server must send before anything else.
+const H2_FRAME_TYPE_SETTINGS: u8 = 0x04;
+
+/// Bound generously: this only has to outlast a loopback round trip, and a
+/// server with no h2 support answers (or hangs up) immediately.
+const REPLY_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn write_temp(contents: &str) -> tempfile::NamedTempFile {
+    let mut file = tempfile::NamedTempFile::new().expect("temp file");
+    file.write_all(contents.as_bytes()).expect("write temp");
+    file.flush().expect("flush temp");
+    file
+}
+
+/// Serves `GET /health` over TLS on an ephemeral loopback port.
+///
+/// Returns the bound address and the certificate the client must trust. The
+/// serving task is detached; it ends with the test process.
+async fn serve_tls() -> (SocketAddr, String) {
+    let certified =
+        rcgen::generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+            .expect("self-signed cert generation");
+    let cert_pem = certified.cert.pem();
+    let cert_file = write_temp(&cert_pem);
+    let key_file = write_temp(&certified.signing_key.serialize_pem());
+
+    let tls_config = TlsConfig {
+        enabled: true,
+        cert_path: cert_file.path().to_path_buf(),
+        key_path: key_file.path().to_path_buf(),
+        client_ca_path: None,
+        client_auth_optional: false,
+        reload_interval_secs: None,
+        reload_on_sighup: false,
+        handshake_timeout_secs: None,
+    };
+    // Also installs the process-wide crypto provider the client below needs.
+    let server_config = load_server_config(&tls_config).expect("server config builds");
+
+    let tcp = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback");
+    let addr = tcp.local_addr().expect("local addr");
+    let listener = TlsListener::new(tcp, server_config);
+
+    let app = Router::new().route("/health", get(|| async { "ok" }));
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app.into_make_service()).await;
+    });
+
+    (addr, cert_pem)
+}
+
+/// Completes a TLS handshake offering exactly `alpn`, and reports what the
+/// listener selected alongside the connected stream.
+async fn connect(
+    addr: SocketAddr,
+    cert_pem: &str,
+    alpn: &[&[u8]],
+) -> (tokio_rustls::client::TlsStream<TcpStream>, Option<Vec<u8>>) {
+    let mut roots = rustls::RootCertStore::empty();
+    roots
+        .add(CertificateDer::from_pem_slice(cert_pem.as_bytes()).expect("parse test cert"))
+        .expect("trust test cert");
+
+    let mut config = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    config.alpn_protocols = alpn.iter().map(|p| p.to_vec()).collect();
+
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(config));
+    let tcp = TcpStream::connect(addr).await.expect("connect loopback");
+    let stream = connector
+        .connect(ServerName::try_from("localhost").expect("server name"), tcp)
+        .await
+        .expect("TLS handshake");
+
+    let negotiated = stream.get_ref().1.alpn_protocol().map(<[u8]>::to_vec);
+    (stream, negotiated)
+}
+
+/// The regression this file exists for.
+///
+/// The client offers `[h2, http/1.1]`, the listener answers `h2`, and the
+/// listener must then behave like an HTTP/2 server: a real one replies to the
+/// preface with its own SETTINGS frame. A listener built without h2 support
+/// hands the preface to its HTTP/1.1 parser, which rejects it — the connection
+/// closes or answers in HTTP/1.1 text, and either way no SETTINGS frame
+/// arrives.
+#[tokio::test]
+async fn tls_listener_serves_http2_when_alpn_selects_it() {
+    let (addr, cert_pem) = serve_tls().await;
+    let (mut stream, negotiated) = connect(addr, &cert_pem, &[b"h2", b"http/1.1"]).await;
+
+    assert_eq!(
+        negotiated.as_deref(),
+        Some(b"h2".as_ref()),
+        "the listener must select h2 for a client that offers it"
+    );
+
+    stream.write_all(H2_PREFACE).await.expect("write preface");
+    stream
+        .write_all(H2_EMPTY_SETTINGS)
+        .await
+        .expect("write client SETTINGS");
+    stream.flush().await.expect("flush");
+
+    let mut header = [0u8; 9];
+    let read = tokio::time::timeout(REPLY_TIMEOUT, stream.read_exact(&mut header)).await;
+
+    match read {
+        Err(_) => panic!(
+            "the listener selected h2 and then never answered the HTTP/2 preface: \
+             it is serving HTTP/1.1 only"
+        ),
+        Ok(Err(e)) => panic!(
+            "the listener selected h2 and then dropped the connection ({e}): \
+             it is serving HTTP/1.1 only"
+        ),
+        Ok(Ok(_)) => assert_eq!(
+            header[3], H2_FRAME_TYPE_SETTINGS,
+            "an HTTP/2 server answers the preface with a SETTINGS frame, \
+             got frame type {:#04x} (bytes {header:?})",
+            header[3]
+        ),
+    }
+}
+
+/// Serving h2 must not cost the clients that ask for HTTP/1.1.
+#[tokio::test]
+async fn tls_listener_still_serves_http1_clients() {
+    let (addr, cert_pem) = serve_tls().await;
+    let (mut stream, negotiated) = connect(addr, &cert_pem, &[b"http/1.1"]).await;
+
+    assert_eq!(
+        negotiated.as_deref(),
+        Some(b"http/1.1".as_ref()),
+        "the listener must still select http/1.1 for a client that offers only that"
+    );
+
+    stream
+        .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .await
+        .expect("write request");
+    stream.flush().await.expect("flush");
+
+    let mut response = Vec::new();
+    tokio::time::timeout(REPLY_TIMEOUT, stream.read_to_end(&mut response))
+        .await
+        .expect("the listener must answer an http/1.1 request")
+        .expect("read response");
+
+    let text = String::from_utf8_lossy(&response);
+    assert!(
+        text.starts_with("HTTP/1.1 200 OK"),
+        "expected a 200 over HTTP/1.1, got: {text}"
+    );
+    assert!(
+        text.ends_with("ok"),
+        "expected the handler body, got: {text}"
+    );
+}


### PR DESCRIPTION
Fixes #120. Patch release 0.34.1.

## What was broken

The HTTPS listener advertises `[h2, http/1.1]` in ALPN (`tls.rs:1221`) but was
built without HTTP/2 support, so any ALPN-honouring client took the h2 offer,
sent the connection preface, and had its connection dropped before a span ever
opened. The server logged nothing at any level; client-side it looks like a TLS
fault. An operator following an mTLS runbook reads that as "my certificates are
wrong", which is exactly how it was found.

## Root cause, refined from the issue

The issue names axum's missing `http2` feature, which is right, but the switch
is one layer down: `axum::serve` always builds a `hyper_util` **auto** server,
and that server's h2 support is gated on `hyper-util/http2`. axum's `http2`
feature is what turns it on (`axum/http2 -> hyper-util/http2`), and it is not in
axum's default set.

That explains the blast radius precisely:

| build | `hyper-util/http2` | HTTP listener |
|---|---|---|
| `grpc` compiled in | on, via `tonic -> hyper-util/server-auto` | served h2 fine, never affected |
| TLS without `grpc` | **off** | advertised h2, could not serve it |

So the defect only ever reached TLS-without-gRPC services — the reporter's exact
configuration — and the `full` CI legs could not have caught it, because `full`
includes `grpc`.

## The fix

`axum = { ..., features = ["http2", "macros", "ws"] }` in the workspace manifest,
with a comment at the declaration and at the ALPN site tying the two together.
Verified with `cargo add` that `http2` is a real feature of the pinned 0.8.6.

## The test, and why it is shaped oddly

`acton-service/tests/tls_alpn_http2.rs` stands up the real `TlsListener` under
`axum::serve`, completes a handshake offering `[h2, http/1.1]`, asserts the
listener selected `h2`, then sends the HTTP/2 preface and requires a SETTINGS
frame back. A second test keeps the HTTP/1.1 path honest.

The h2 client is hand-rolled over `tokio-rustls` and the file adds **no**
dependency. That is deliberate and load-bearing: my first attempt used a
`reqwest/http2` dev-dependency, and it passed with the fix reverted — because
`reqwest/http2` enables `hyper-util/http2` for the whole test build and hands h2
to the server under test. Any HTTP client that speaks h2 masks this bug. Feature
unification makes it untestable from a build unit that contains one.

Verified both directions:

```
# fix reverted, --no-default-features --features http,tls,crypto-aws-lc-rs
FAIL tls_listener_serves_http2_when_alpn_selects_it
  the listener selected h2 and then dropped the connection
  (peer closed connection without sending TLS close_notify): it is serving HTTP/1.1 only

# fix applied
PASS tls_listener_serves_http2_when_alpn_selects_it
PASS tls_listener_still_serves_http1_clients
```

That reproduces the reporter's `unexpected eof` symptom exactly.

## CI

The `tls-no-grpc` combo leg was lint-only, and it is the only combination where
this test can fail. Feature legs can now opt into nextest with `test: true`; that
leg does. Everything else stays clippy-only.

## Also in this PR

- Version 0.34.0 -> 0.34.1 across the workspace, `acton-cli`, and the three
  `acton-docs` version files.
- CHANGELOG entry.
- A "Negotiated protocols" section on the TLS docs page, including the
  `curl --http1.1 works, plain curl does not` signature so anyone on 0.34.0 or
  earlier can identify this from the symptom rather than suspecting their certs.

## Note on scope

Enabling `axum/http2` also means the plaintext listener answers an h2c
prior-knowledge client, since the same auto server sniffs the preface with or
without TLS in front of it. Nothing that worked before changes; noted in the
CHANGELOG.
