### PR TITLE
fix(metrics): let [middleware.metrics] reach the instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **config(metrics)**: `[middleware.metrics] latency_buckets_ms` now reaches the
+  histogram. It was parsed, carried into a second struct of the same name, and
+  then dropped: the layer was built as
+  `HTTPMetricsLayerBuilder::builder().with_meter(meter).build()`, with nothing
+  else from the configuration reaching it. An operator who tuned buckets to
+  their SLO thresholds got the defaults back, with no warning at startup or in
+  the scrape.
+
+  Passing the boundaries would not have been enough on its own. The seconds
+  histogram view added in #107 matches on unit, and a view that matches an
+  instrument *overrules* that instrument's own boundaries — the SDK consults
+  them only when no view matched. The view now declines
+  `http.server.request.duration`, which is the instrument that carries a
+  configured value.
+
+  The default for the key is the view's own boundary set, so a config that omits
+  it keeps exactly the buckets it had.
+
+### Changed
+
+- **config(metrics)**: `[middleware.metrics]` is `deny_unknown_fields`, and
+  `include_path`, `include_method` and `include_status` are removed. All three
+  parsed and did nothing; they now fail startup, as does `service_name`, which
+  was never a key of this table. The metrics layer records
+  `http.request.method`, `http.route` and `http.response.status_code` because
+  the semantic conventions require them, and a service is named once under
+  `[service]`.
+- **config(metrics)**: `middleware::metrics::MetricsConfig` is now a re-export of
+  `config::MetricsConfig` rather than a second type with a hand-written
+  conversion between them. The conversion is where the configured values were
+  lost. `with_service_name`, `with_include_*` and `latency_buckets_as_duration`
+  are gone; `with_latency_buckets` is `with_latency_buckets_ms`.
+- **server**: the startup banner reports HTTP metrics as enabled only when they
+  are. A present `[middleware.metrics]` table with `enabled = false` was
+  announced as enabled, sending operators looking for a scrape that was never
+  going to appear.
+- **metrics**: `metric_names` and `metric_labels` now name what the layer emits.
+  `HTTP_SERVER_REQUEST_COUNT` named an instrument that has never existed — the
+  count is the duration histogram's `_count` — and the size constants and every
+  label used pre-1.0 semantic-convention spellings (`http.method`,
+  `http.status_code`) that no instrument records. A dashboard built on them
+  queried nothing. Both modules are now asserted against a live scrape rather
+  than against their own literals, which is all the previous tests did.
+
 ## [acton-service-v0.35.0] - 2026-08-03
 
 Upgrades to acton-reactive 9.0 and closes the gaps that version exposed in how

--- a/acton-docs/src/app/docs/observability/page.md
+++ b/acton-docs/src/app/docs/observability/page.md
@@ -286,7 +286,24 @@ This is the semconv set for `http.server.request.duration`, extended downward wi
 A histogram with no unit, or one declared in milliseconds, keeps the SDK's default boundaries — `[0, 5, 10, 25, …, 7500, 10000]`, which are chosen for milliseconds. Feed those seconds-valued observations and every request under five seconds lands in the first bucket. Nothing warns, and the exposition still looks well-formed, so the histogram appears healthy while being unable to tell a fast request from a slow one.
 {% /callout %}
 
-`MetricsConfig::latency_buckets_ms` is unrelated: it configures the built-in HTTP middleware's own instruments, not histograms you create through `get_meter()`.
+### Boundaries for the HTTP request-duration histogram
+
+The view above applies to every seconds-valued histogram except one: `http.server.request.duration`, which takes its boundaries from configuration instead.
+
+```toml
+[middleware.metrics]
+enabled = true
+# Milliseconds; the instrument is in seconds and these are converted on the way in.
+latency_buckets_ms = [50.0, 150.0, 250.0, 400.0, 750.0]
+```
+
+The exclusion is what makes the key work at all. A view that matches an instrument does not supply a default for it — it overrules whatever that instrument asked for, because the SDK reads an instrument's own boundaries only on the branch it takes when no view matched. Omit the key and you get the same boundaries the view applies, so nothing moves until you ask it to.
+
+Boundaries must be finite, positive and strictly increasing. Anything else is logged and ignored in favour of the instrumentation library's defaults, on the same principle as everything else here: a mis-bucketed metric must not take a service down at boot.
+
+{% callout type="note" title="This table rejects what it cannot honour" %}
+`[middleware.metrics]` once accepted `include_path`, `include_method`, `include_status` and `service_name`, parsed them, and built the layer without them. They are now startup errors rather than silent no-ops. Method, route and status are always recorded — the semantic conventions require them — and a service is named once, under `[service]`, for traces, metrics and logs alike.
+{% /callout %}
 
 ---
 

--- a/acton-service/examples/observability/test-metrics.rs
+++ b/acton-service/examples/observability/test-metrics.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create metrics configuration
     let metrics_config = MetricsConfig::new()
         .with_enabled(true)
-        .with_service_name("test-metrics");
+        .with_latency_buckets_ms(vec![5.0, 25.0, 100.0, 500.0, 1000.0]);
 
     // Create metrics layer - should work now with in-memory provider
     println!("Creating metrics layer...");

--- a/acton-service/examples/observability/test-prometheus-metrics.rs
+++ b/acton-service/examples/observability/test-prometheus-metrics.rs
@@ -39,9 +39,6 @@ async fn main() -> Result<()> {
     config.service.name = "prometheus-metrics-example".to_string();
     config.middleware.metrics = Some(acton_service::config::MetricsConfig {
         enabled: true,
-        include_path: true,
-        include_method: true,
-        include_status: true,
         latency_buckets_ms: vec![5.0, 25.0, 100.0, 500.0, 1000.0],
     });
 

--- a/acton-service/src/config.rs
+++ b/acton-service/src/config.rs
@@ -1431,35 +1431,90 @@ impl ResilienceConfig {
 }
 
 /// HTTP metrics configuration (OpenTelemetry)
+///
+/// Every key here reaches the instrumentation. `deny_unknown_fields` is what
+/// keeps that true: this table once accepted `include_path`, `include_method`,
+/// `include_status` and `service_name`, parsed them, and built the layer
+/// without them, so a config could ask for something and be told nothing. A key
+/// that cannot be honoured must fail at startup, not be quietly dropped.
+///
+/// The three `include_*` keys are gone rather than implemented. The metrics
+/// layer emits `http.request.method`, `http.route` and
+/// `http.response.status_code` because the OpenTelemetry semantic conventions
+/// require them; suppressing them would produce a metric that is no longer the
+/// metric its name claims. `service_name` was never a key of this table -- the
+/// resource-level `service.name` comes from `[service] name`, which is where a
+/// service is named once for traces, metrics and logs alike.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MetricsConfig {
     /// Enable metrics collection
     #[serde(default = "default_true")]
     pub enabled: bool,
 
-    /// Include request path in metrics
-    #[serde(default = "default_true")]
-    pub include_path: bool,
-
-    /// Include request method in metrics
-    #[serde(default = "default_true")]
-    pub include_method: bool,
-
-    /// Include status code in metrics
-    #[serde(default = "default_true")]
-    pub include_status: bool,
-
-    /// Histogram buckets for latency (in milliseconds)
+    /// Explicit histogram bucket boundaries for HTTP request duration, in
+    /// milliseconds.
+    ///
+    /// The instrument itself is in seconds, per semantic convention; these are
+    /// divided by 1000 on the way in. Boundaries must be finite, positive and
+    /// strictly increasing -- anything else is reported and ignored in favour
+    /// of the default, because a mis-bucketed metric must not take a service
+    /// down at boot.
     #[serde(default = "default_latency_buckets")]
     pub latency_buckets_ms: Vec<f64>,
 }
 
+impl Default for MetricsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            latency_buckets_ms: default_latency_buckets(),
+        }
+    }
+}
+
 impl MetricsConfig {
-    pub fn latency_buckets_as_duration(&self) -> Vec<Duration> {
-        self.latency_buckets_ms
-            .iter()
-            .map(|&ms| Duration::from_millis(ms as u64))
-            .collect()
+    /// Create a metrics configuration carrying the defaults.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set whether the HTTP metrics layer is installed.
+    #[must_use]
+    pub fn with_enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    /// Set the latency histogram boundaries, in milliseconds.
+    #[must_use]
+    pub fn with_latency_buckets_ms(mut self, buckets_ms: Vec<f64>) -> Self {
+        self.latency_buckets_ms = buckets_ms;
+        self
+    }
+
+    /// The configured boundaries in seconds, the unit the instrument declares.
+    ///
+    /// Returns `None` when the list is empty or not strictly increasing through
+    /// finite, positive values; the caller falls back to the instrumentation
+    /// library's own defaults and says so.
+    pub fn latency_buckets_seconds(&self) -> Option<Vec<f64>> {
+        let usable = !self.latency_buckets_ms.is_empty()
+            && self
+                .latency_buckets_ms
+                .iter()
+                .all(|ms| ms.is_finite() && *ms > 0.0)
+            && self
+                .latency_buckets_ms
+                .windows(2)
+                .all(|pair| pair[0] < pair[1]);
+
+        usable.then(|| {
+            self.latency_buckets_ms
+                .iter()
+                .map(|ms| ms / 1000.0)
+                .collect()
+        })
     }
 }
 
@@ -1629,9 +1684,19 @@ fn default_bulkhead_max_wait_ms() -> u64 {
 }
 
 // Metrics default functions
+/// The seconds-histogram boundaries this service already applies, in
+/// milliseconds.
+///
+/// Deliberately the same set as `observability::SECONDS_HISTOGRAM_BOUNDARIES`,
+/// which a view applies to every seconds-valued histogram. Before this table
+/// was honoured, that view is what the HTTP duration histogram actually got;
+/// keeping the default identical means turning the key on changes nothing until
+/// an operator sets it, and no dashboard moves underneath one who does not. A
+/// test pins the two lists together.
 fn default_latency_buckets() -> Vec<f64> {
     vec![
-        5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0,
+        1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0,
+        7500.0, 10000.0,
     ]
 }
 
@@ -2009,6 +2074,49 @@ mod tests {
         assert!(
             !policy.requires_client_ca(),
             "the default must not silently start demanding certificates"
+        );
+    }
+
+    #[test]
+    fn metrics_config_refuses_keys_it_cannot_honour() {
+        // Each of these parsed happily and reached nothing. `include_*` asked
+        // the layer to drop semantic-convention attributes it will always
+        // record; `service_name` belongs to [service], which names the process
+        // once for traces, metrics and logs together.
+        for key in [
+            r#""include_path": true"#,
+            r#""include_method": true"#,
+            r#""include_status": true"#,
+            r#""service_name": "whatever""#,
+        ] {
+            let json = format!(r#"{{ "enabled": true, {key} }}"#);
+
+            assert!(
+                serde_json::from_str::<MetricsConfig>(&json).is_err(),
+                "{key} must fail startup rather than be accepted and ignored"
+            );
+        }
+    }
+
+    #[test]
+    fn metrics_config_defaults_to_the_buckets_already_in_effect() {
+        let metrics: MetricsConfig =
+            serde_json::from_str("{}").expect("every key in the table has a default");
+
+        assert!(metrics.enabled);
+        assert_eq!(
+            metrics.latency_buckets_ms.first().copied(),
+            Some(1.0),
+            "the default must start at 1ms, as the seconds view does"
+        );
+        assert_eq!(
+            metrics.latency_buckets_seconds(),
+            Some(vec![
+                0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5,
+                5.0, 7.5, 10.0
+            ]),
+            "omitting the key must leave the boundaries exactly where they were \
+             before this table was honoured"
         );
     }
 

--- a/acton-service/src/middleware/metrics.rs
+++ b/acton-service/src/middleware/metrics.rs
@@ -3,121 +3,60 @@
 //! Provides OpenTelemetry metrics integration for tracking
 //! request counts, latencies, and status codes.
 
-use std::time::Duration;
-
 #[cfg(feature = "_metrics")]
 use opentelemetry_instrumentation_tower::HTTPMetricsLayerBuilder;
 
-/// Configuration for HTTP metrics
-#[derive(Debug, Clone)]
-pub struct MetricsConfig {
-    /// Enable metrics collection
-    pub enabled: bool,
-    /// Service name for metrics
-    pub service_name: String,
-    /// Include request path in metrics
-    pub include_path: bool,
-    /// Include request method in metrics
-    pub include_method: bool,
-    /// Include status code in metrics
-    pub include_status: bool,
-    /// Histogram buckets for latency (in milliseconds)
-    pub latency_buckets: Vec<f64>,
-}
+/// Configuration for HTTP metrics.
+///
+/// This is [`crate::config::MetricsConfig`] itself, not a copy of it. There used
+/// to be two structs of this name -- one parsed from `[middleware.metrics]`, one
+/// consumed here -- with a hand-written conversion between them. Every field
+/// that conversion carried across was then dropped on the floor by the layer
+/// builder, and nothing could tell you so, because the two types agreeing is not
+/// the same as the layer honouring them. One type has no gap to fall into.
+pub use crate::config::MetricsConfig;
 
-impl Default for MetricsConfig {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            service_name: "acton-service".to_string(),
-            include_path: true,
-            include_method: true,
-            include_status: true,
-            // Default buckets: 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s
-            latency_buckets: vec![
-                5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0,
-            ],
-        }
-    }
-}
-
-impl MetricsConfig {
-    /// Create a new metrics configuration
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Set metrics enabled
-    pub fn with_enabled(mut self, enabled: bool) -> Self {
-        self.enabled = enabled;
-        self
-    }
-
-    /// Set service name
-    pub fn with_service_name(mut self, name: impl Into<String>) -> Self {
-        self.service_name = name.into();
-        self
-    }
-
-    /// Set whether to include path in metrics
-    pub fn with_include_path(mut self, include: bool) -> Self {
-        self.include_path = include;
-        self
-    }
-
-    /// Set whether to include method in metrics
-    pub fn with_include_method(mut self, include: bool) -> Self {
-        self.include_method = include;
-        self
-    }
-
-    /// Set whether to include status code in metrics
-    pub fn with_include_status(mut self, include: bool) -> Self {
-        self.include_status = include;
-        self
-    }
-
-    /// Set custom latency histogram buckets (in milliseconds)
-    pub fn with_latency_buckets(mut self, buckets: Vec<f64>) -> Self {
-        self.latency_buckets = buckets;
-        self
-    }
-
-    /// Convert milliseconds to Duration for latency buckets
-    pub fn latency_buckets_as_duration(&self) -> Vec<Duration> {
-        self.latency_buckets
-            .iter()
-            .map(|&ms| Duration::from_millis(ms as u64))
-            .collect()
-    }
-}
-
-/// Standard metric names following OpenTelemetry conventions
+/// The instruments the HTTP metrics layer actually creates.
+///
+/// These are read back from a live scrape by
+/// `tests/metrics_config_reaches_the_scrape.rs`, because a constant naming a
+/// metric that is never emitted is worse than no constant: it is a dashboard
+/// query that returns nothing, with nothing to say why. There is deliberately
+/// no request-count instrument here -- the count is the duration histogram's
+/// `_count`, and naming one implied an instrument that never existed.
 pub mod metric_names {
-    /// HTTP server request count
-    pub const HTTP_SERVER_REQUEST_COUNT: &str = "http.server.request.count";
-    /// HTTP server request duration
+    /// Duration of HTTP server requests, in seconds.
     pub const HTTP_SERVER_REQUEST_DURATION: &str = "http.server.request.duration";
-    /// HTTP server active requests
+    /// Number of in-flight HTTP server requests.
     pub const HTTP_SERVER_ACTIVE_REQUESTS: &str = "http.server.active_requests";
-    /// HTTP server request size
-    pub const HTTP_SERVER_REQUEST_SIZE: &str = "http.server.request.size";
-    /// HTTP server response size
-    pub const HTTP_SERVER_RESPONSE_SIZE: &str = "http.server.response.size";
+    /// Size of HTTP server request bodies, in bytes.
+    pub const HTTP_SERVER_REQUEST_BODY_SIZE: &str = "http.server.request.body.size";
+    /// Size of HTTP server response bodies, in bytes.
+    pub const HTTP_SERVER_RESPONSE_BODY_SIZE: &str = "http.server.response.body.size";
 }
 
-/// Standard metric labels following OpenTelemetry conventions
+/// The attributes the HTTP metrics layer actually records.
+///
+/// Post-1.0 semantic-convention names. The pre-1.0 spellings (`http.method`,
+/// `http.status_code`) were published here and are not what any instrument
+/// emits.
 pub mod metric_labels {
-    /// HTTP method (GET, POST, etc.)
-    pub const HTTP_METHOD: &str = "http.method";
-    /// HTTP route/path
+    /// HTTP method (GET, POST, ...).
+    pub const HTTP_REQUEST_METHOD: &str = "http.request.method";
+    /// Matched route template, not the request URI -- this is what bounds
+    /// series count to the route table.
     pub const HTTP_ROUTE: &str = "http.route";
-    /// HTTP status code
-    pub const HTTP_STATUS_CODE: &str = "http.status_code";
-    /// Service name
+    /// HTTP response status code.
+    pub const HTTP_RESPONSE_STATUS_CODE: &str = "http.response.status_code";
+    /// Network protocol name (`http`).
+    pub const NETWORK_PROTOCOL_NAME: &str = "network.protocol.name";
+    /// Network protocol version (`1.1`, `2`).
+    pub const NETWORK_PROTOCOL_VERSION: &str = "network.protocol.version";
+    /// URL scheme (`http`, `https`).
+    pub const URL_SCHEME: &str = "url.scheme";
+    /// Service name, carried on the resource rather than per measurement, and
+    /// set from `[service] name`.
     pub const SERVICE_NAME: &str = "service.name";
-    /// Service version
-    pub const SERVICE_VERSION: &str = "service.version";
 }
 
 /// Create the HTTP metrics layer
@@ -142,7 +81,7 @@ pub mod metric_labels {
 /// use tower::ServiceBuilder;
 ///
 /// let config = MetricsConfig::new()
-///     .with_service_name("my-service");
+///     .with_latency_buckets_ms(vec![10.0, 100.0, 1000.0]);
 ///
 /// let layer = create_metrics_layer(&config);
 /// # /*
@@ -168,11 +107,26 @@ pub fn create_metrics_layer(
     // Get the global meter from the meter provider
     let meter = crate::observability::get_meter()?;
 
+    let mut builder = HTTPMetricsLayerBuilder::builder().with_meter(meter);
+
+    // The instrument is declared in seconds; the key is in milliseconds because
+    // that is the scale an operator thinks about a request in.
+    let boundaries = config.latency_buckets_seconds();
+    match &boundaries {
+        Some(seconds) => builder = builder.with_request_duration_bounds(seconds.clone()),
+        None => tracing::warn!(
+            latency_buckets_ms = ?config.latency_buckets_ms,
+            "[middleware.metrics] latency_buckets_ms is empty or not strictly increasing \
+             through finite, positive values; using the instrumentation library's default \
+             boundaries instead"
+        ),
+    }
+
     // Build the metrics layer
-    match HTTPMetricsLayerBuilder::builder().with_meter(meter).build() {
+    match builder.build() {
         Ok(layer) => {
             tracing::info!(
-                service_name = %config.service_name,
+                latency_buckets_seconds = ?boundaries,
                 "HTTP metrics layer initialized"
             );
             Some(layer)
@@ -199,56 +153,58 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_default_config() {
+    fn the_default_config_is_enabled_with_seconds_scaled_buckets() {
         let config = MetricsConfig::default();
+
         assert!(config.enabled);
-        assert!(config.include_path);
-        assert!(config.include_method);
-        assert!(config.include_status);
-        assert_eq!(config.service_name, "acton-service");
+        let seconds = config
+            .latency_buckets_seconds()
+            .expect("the default boundaries must be usable");
+        assert_eq!(seconds.first().copied(), Some(0.001));
+        assert_eq!(seconds.last().copied(), Some(10.0));
     }
 
     #[test]
-    fn test_builder_pattern() {
+    fn the_builder_sets_what_it_says_it_sets() {
         let config = MetricsConfig::new()
             .with_enabled(true)
-            .with_service_name("test-service")
-            .with_include_path(false)
-            .with_latency_buckets(vec![10.0, 50.0, 100.0]);
+            .with_latency_buckets_ms(vec![10.0, 50.0, 100.0]);
 
         assert!(config.enabled);
-        assert_eq!(config.service_name, "test-service");
-        assert!(!config.include_path);
-        assert_eq!(config.latency_buckets, vec![10.0, 50.0, 100.0]);
+        assert_eq!(config.latency_buckets_ms, vec![10.0, 50.0, 100.0]);
     }
 
     #[test]
-    fn test_latency_buckets_conversion() {
-        let config = MetricsConfig::new().with_latency_buckets(vec![10.0, 100.0, 1000.0]);
+    fn milliseconds_become_seconds_without_losing_fractions() {
+        // `2.5` ms is 2.5 ms, not the 2 ms an integer conversion would give.
+        let config = MetricsConfig::new().with_latency_buckets_ms(vec![2.5, 100.0, 1000.0]);
 
-        let durations = config.latency_buckets_as_duration();
-        assert_eq!(durations.len(), 3);
-        assert_eq!(durations[0], Duration::from_millis(10));
-        assert_eq!(durations[1], Duration::from_millis(100));
-        assert_eq!(durations[2], Duration::from_millis(1000));
-    }
-
-    #[test]
-    fn test_metric_names() {
         assert_eq!(
-            metric_names::HTTP_SERVER_REQUEST_COUNT,
-            "http.server.request.count"
-        );
-        assert_eq!(
-            metric_names::HTTP_SERVER_REQUEST_DURATION,
-            "http.server.request.duration"
+            config.latency_buckets_seconds(),
+            Some(vec![0.0025, 0.1, 1.0])
         );
     }
 
     #[test]
-    fn test_metric_labels() {
-        assert_eq!(metric_labels::HTTP_METHOD, "http.method");
-        assert_eq!(metric_labels::HTTP_STATUS_CODE, "http.status_code");
+    fn boundaries_that_no_histogram_can_use_are_refused() {
+        // Each of these would be accepted by serde and rejected by the SDK, or
+        // worse, accepted by both and silently useless.
+        for buckets in [
+            vec![],
+            vec![100.0, 50.0],
+            vec![10.0, 10.0],
+            vec![0.0, 10.0],
+            vec![-1.0, 10.0],
+            vec![10.0, f64::INFINITY],
+            vec![10.0, f64::NAN],
+        ] {
+            let config = MetricsConfig::new().with_latency_buckets_ms(buckets.clone());
+            assert_eq!(
+                config.latency_buckets_seconds(),
+                None,
+                "{buckets:?} must not reach the instrument"
+            );
+        }
     }
 
     #[test]
@@ -271,19 +227,5 @@ mod tests {
             layer.is_none(),
             "Should return None when meter provider is not initialized"
         );
-    }
-
-    #[test]
-    fn test_metrics_config_custom_buckets() {
-        let custom_buckets = vec![1.0, 5.0, 10.0];
-        let config = MetricsConfig::new().with_latency_buckets(custom_buckets.clone());
-
-        assert_eq!(config.latency_buckets, custom_buckets);
-
-        let durations = config.latency_buckets_as_duration();
-        assert_eq!(durations.len(), 3);
-        assert_eq!(durations[0], std::time::Duration::from_millis(1));
-        assert_eq!(durations[1], std::time::Duration::from_millis(5));
-        assert_eq!(durations[2], std::time::Duration::from_millis(10));
     }
 }

--- a/acton-service/src/observability.rs
+++ b/acton-service/src/observability.rs
@@ -27,7 +27,9 @@ use {
 #[cfg(feature = "_metrics")]
 use {
     opentelemetry::metrics::MeterProvider as _,
-    opentelemetry_sdk::metrics::{Aggregation, Instrument, InstrumentKind, SdkMeterProvider, Stream},
+    opentelemetry_sdk::metrics::{
+        Aggregation, Instrument, InstrumentKind, SdkMeterProvider, Stream,
+    },
 };
 
 #[cfg(feature = "otel-metrics")]
@@ -368,6 +370,12 @@ const SECONDS_HISTOGRAM_BOUNDARIES: &[f64] = &[
     0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
 ];
 
+/// The HTTP server duration instrument, which carries boundaries of its own.
+///
+/// Named here so the seconds view can decline it; see [`seconds_histogram_view`].
+#[cfg(feature = "_metrics")]
+const HTTP_SERVER_DURATION_INSTRUMENT: &str = "http.server.request.duration";
+
 /// Re-bucket seconds-valued histograms, leaving every other instrument alone.
 ///
 /// Selects on the instrument's declared unit rather than its name, so any
@@ -376,9 +384,28 @@ const SECONDS_HISTOGRAM_BOUNDARIES: &[f64] = &[
 /// in place, which is what every non-histogram and every other unit wants.
 ///
 /// The returned [`Stream`] sets no name, so the instrument keeps its own.
+///
+/// # Why the HTTP duration histogram is excluded
+///
+/// A view that matches wins outright. The SDK reads an instrument's own
+/// boundaries only on the branch it takes when *no* view matched
+/// (`opentelemetry_sdk::metrics::pipeline`, "Apply implicit default view"), so
+/// this view matching an instrument does not merely supply a default for it --
+/// it overrules whatever that instrument asked for.
+///
+/// The HTTP metrics layer sets its boundaries from `[middleware.metrics]
+/// latency_buckets_ms`. Matching it here would silently discard the operator's
+/// configuration, which is precisely what it did: buckets were configured, the
+/// layer dropped them, and this view then supplied boundaries close enough to
+/// plausible defaults that the loss looked like a default. Declining the
+/// instrument by name is what lets a configured value survive.
 #[cfg(feature = "_metrics")]
 fn seconds_histogram_view(instrument: &Instrument) -> Option<Stream> {
     if instrument.kind() != InstrumentKind::Histogram || instrument.unit() != "s" {
+        return None;
+    }
+
+    if instrument.name() == HTTP_SERVER_DURATION_INSTRUMENT {
         return None;
     }
 
@@ -745,8 +772,20 @@ mod tests {
         /// Record `values` into a histogram declared with `unit`, then return
         /// the `le` upper bounds Prometheus reports for it.
         fn scrape_bounds(name: &'static str, unit: &'static str, values: &[f64]) -> Vec<f64> {
-            let (reader, registry) =
-                prometheus_metric_reader().expect("prometheus reader builds");
+            scrape_bounds_declaring(name, unit, None, values, "probe")
+        }
+
+        /// As above, but the instrument declares `boundaries` of its own and the
+        /// caller says which metric-family substring to read back. Both are what
+        /// the HTTP duration histogram does.
+        fn scrape_bounds_declaring(
+            name: &'static str,
+            unit: &'static str,
+            boundaries: Option<Vec<f64>>,
+            values: &[f64],
+            family_match: &str,
+        ) -> Vec<f64> {
+            let (reader, registry) = prometheus_metric_reader().expect("prometheus reader builds");
 
             // A local provider, never installed globally: these tests must not
             // race the process-wide provider other tests may have set.
@@ -755,7 +794,12 @@ mod tests {
                 .with_view(seconds_histogram_view)
                 .build();
 
-            let histogram = provider.meter("test").f64_histogram(name).with_unit(unit).build();
+            let meter = provider.meter("test");
+            let mut builder = meter.f64_histogram(name).with_unit(unit);
+            if let Some(boundaries) = boundaries {
+                builder = builder.with_boundaries(boundaries);
+            }
+            let histogram = builder.build();
             for value in values {
                 histogram.record(*value, &[]);
             }
@@ -763,11 +807,54 @@ mod tests {
             registry
                 .gather()
                 .iter()
-                .filter(|family| family.name().contains("probe"))
+                .filter(|family| family.name().contains(family_match))
                 .flat_map(|family| family.get_metric().to_vec())
                 .flat_map(|metric| metric.get_histogram().get_bucket().to_vec())
                 .map(|bucket| bucket.upper_bound())
                 .collect()
+        }
+
+        #[test]
+        fn a_matching_view_overrules_the_instruments_own_boundaries() {
+            // The rule the exclusion below exists for. The SDK reads an
+            // instrument's boundaries only when no view matched, so a view is
+            // not a default -- it is the last word. This is why configuring
+            // latency buckets appeared to do nothing: the layer's boundaries,
+            // once passed, would have been discarded here anyway.
+            let asked_for = vec![0.2, 0.4, 0.6];
+            let bounds = scrape_bounds_declaring(
+                "probe.overruled",
+                "s",
+                Some(asked_for.clone()),
+                &[0.3],
+                "probe",
+            );
+
+            assert_ne!(
+                bounds, asked_for,
+                "a matching view must be understood to overrule the instrument"
+            );
+            assert_eq!(bounds, SECONDS_HISTOGRAM_BOUNDARIES);
+        }
+
+        #[test]
+        fn the_http_duration_histogram_keeps_its_configured_boundaries() {
+            // `[middleware.metrics] latency_buckets_ms` reaches the instrument
+            // through the metrics layer. The view must decline it, or the
+            // operator's configuration dies here without a word.
+            let configured = vec![0.05, 0.1, 0.5, 1.0];
+            let bounds = scrape_bounds_declaring(
+                HTTP_SERVER_DURATION_INSTRUMENT,
+                "s",
+                Some(configured.clone()),
+                &[0.075],
+                "http_server_request_duration",
+            );
+
+            assert_eq!(
+                bounds, configured,
+                "the configured boundaries must survive to the scrape"
+            );
         }
 
         #[test]

--- a/acton-service/src/server.rs
+++ b/acton-service/src/server.rs
@@ -231,10 +231,18 @@ impl Server {
         }
 
         if let Some(ref metrics) = self.config.middleware.metrics {
-            tracing::info!("  - HTTP metrics: enabled");
-            tracing::info!("    - Include path: {}", metrics.include_path);
-            tracing::info!("    - Include method: {}", metrics.include_method);
-            tracing::info!("    - Include status: {}", metrics.include_status);
+            if metrics.enabled {
+                tracing::info!("  - HTTP metrics: enabled");
+                tracing::info!(
+                    "    - Latency buckets (ms): {:?}",
+                    metrics.latency_buckets_ms
+                );
+            } else {
+                // The table being present is not the same as the middleware
+                // running, and reporting it as enabled sent operators looking
+                // for a scrape that was never going to appear.
+                tracing::info!("  - HTTP metrics: disabled ([middleware.metrics] enabled = false)");
+            }
         } else {
             tracing::info!("  - HTTP metrics: not configured");
         }

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -2371,13 +2371,7 @@ where
         #[cfg(feature = "_metrics")]
         if let Some(metrics_cfg) = &config.middleware.metrics {
             if metrics_cfg.enabled {
-                let mw_config = crate::middleware::metrics::MetricsConfig::new()
-                    .with_service_name(config.service.name.clone())
-                    .with_include_path(metrics_cfg.include_path)
-                    .with_include_method(metrics_cfg.include_method)
-                    .with_include_status(metrics_cfg.include_status)
-                    .with_latency_buckets(metrics_cfg.latency_buckets_ms.clone());
-                if let Some(layer) = crate::middleware::metrics::create_metrics_layer(&mw_config) {
+                if let Some(layer) = crate::middleware::metrics::create_metrics_layer(metrics_cfg) {
                     app = app.layer(layer);
                 }
             }

--- a/acton-service/tests/metrics_config_reaches_the_scrape.rs
+++ b/acton-service/tests/metrics_config_reaches_the_scrape.rs
@@ -1,0 +1,154 @@
+//! Integration coverage for `[middleware.metrics]` reaching the instruments.
+//!
+//! The defect these cover was reported downstream: an operator set
+//! `latency_buckets_ms` to their SLO thresholds, scraped `/metrics`, and got the
+//! default boundaries back. Nothing failed. Nothing warned. The config parsed,
+//! `--check-config` reported it, and the histogram ignored it.
+//!
+//! It survived because every unit test in reach was true of a config *value*,
+//! and the loss happened between the value and the instrument -- twice over,
+//! once where the layer builder dropped it and once where a meter-provider view
+//! would have overruled it. The only assertion that could have caught it is the
+//! one made here: drive a real request through the real layer and read what the
+//! registry actually holds.
+//!
+//! Routers are driven with `ServiceExt::oneshot` rather than a bound server,
+//! following `governor_integration.rs` and `resilience_router.rs`.
+
+#![cfg(feature = "prometheus-metrics")]
+
+use acton_service::config::{Config, MetricsConfig};
+use acton_service::middleware::metrics::{create_metrics_layer, metric_labels, metric_names};
+use acton_service::observability::{init_meter_provider, PROMETHEUS_REGISTRY};
+use axum::{body::Body, http::Request, routing::post, Router};
+use tower::ServiceExt;
+
+/// The boundaries an operator would plausibly choose: a 250ms SLO, with
+/// resolution either side of it. None of these appear in any default set, so a
+/// passing assertion cannot be a coincidence.
+const CONFIGURED_MS: &[f64] = &[50.0, 150.0, 250.0, 400.0, 750.0];
+
+/// `le` upper bounds Prometheus reports for the HTTP request-duration histogram.
+fn scraped_duration_bounds() -> Vec<f64> {
+    PROMETHEUS_REGISTRY
+        .get()
+        .expect("init_meter_provider installs the registry")
+        .gather()
+        .iter()
+        .filter(|family| family.name().contains("http_server_request_duration"))
+        .flat_map(|family| family.get_metric().to_vec())
+        .flat_map(|metric| metric.get_histogram().get_bucket().to_vec())
+        .map(|bucket| bucket.upper_bound())
+        .collect()
+}
+
+/// Configured milliseconds, in the seconds the instrument is declared in.
+fn configured_bounds_in_seconds() -> Vec<f64> {
+    CONFIGURED_MS.iter().map(|ms| ms / 1000.0).collect()
+}
+
+// One test per process under nextest, which is what lets this touch the
+// process-wide meter provider at all: `METER_PROVIDER` is a `OnceCell` and the
+// first writer wins for the life of the process.
+#[tokio::test]
+async fn configured_latency_buckets_reach_the_scrape() {
+    let metrics = MetricsConfig::new().with_latency_buckets_ms(CONFIGURED_MS.to_vec());
+
+    let mut config = Config::<()>::default();
+    config.service.name = "metrics-config-e2e".to_string();
+    config.middleware.metrics = Some(metrics.clone());
+
+    init_meter_provider(&config).expect("meter provider initializes");
+    let layer = create_metrics_layer(&metrics).expect("the layer builds once a meter exists");
+
+    // A POST carrying Content-Length, so the request-body-size instrument
+    // records too: the layer reads that header, and an empty GET leaves the
+    // instrument with no measurements and therefore absent from the scrape.
+    let app = Router::new()
+        .route("/probe", post(|| async { "ok" }))
+        .layer(layer);
+
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri("/probe")
+            .header("content-length", "2")
+            .body(Body::from("hi"))
+            .expect("request builds"),
+    )
+    .await
+    .expect("router is infallible");
+
+    let bounds = scraped_duration_bounds();
+
+    assert!(
+        !bounds.is_empty(),
+        "the request must have been recorded; got no duration histogram at all"
+    );
+    assert_eq!(
+        bounds,
+        configured_bounds_in_seconds(),
+        "the scrape must show the configured boundaries, not a default set"
+    );
+
+    // The same scrape settles what this crate publishes as metric and attribute
+    // names. They were wrong -- a request-count instrument that does not exist,
+    // and pre-1.0 attribute spellings -- and nothing here could tell, because
+    // every assertion on them compared a constant to its own literal.
+    let scraped = scraped_family_names();
+
+    for name in [
+        metric_names::HTTP_SERVER_REQUEST_DURATION,
+        metric_names::HTTP_SERVER_ACTIVE_REQUESTS,
+        metric_names::HTTP_SERVER_REQUEST_BODY_SIZE,
+        metric_names::HTTP_SERVER_RESPONSE_BODY_SIZE,
+    ] {
+        let prometheus_name = name.replace('.', "_");
+        assert!(
+            scraped
+                .iter()
+                .any(|family| family.starts_with(&prometheus_name)),
+            "{name} names no instrument this layer creates; scraped: {scraped:?}"
+        );
+    }
+
+    for label in [
+        metric_labels::HTTP_REQUEST_METHOD,
+        metric_labels::HTTP_ROUTE,
+        metric_labels::HTTP_RESPONSE_STATUS_CODE,
+        metric_labels::NETWORK_PROTOCOL_NAME,
+        metric_labels::NETWORK_PROTOCOL_VERSION,
+        metric_labels::URL_SCHEME,
+    ] {
+        let prometheus_label = label.replace('.', "_");
+        assert!(
+            scraped_labels().contains(&prometheus_label),
+            "{label} names no attribute this layer records; scraped: {:?}",
+            scraped_labels()
+        );
+    }
+}
+
+/// Metric family names in the registry, as Prometheus spells them.
+fn scraped_family_names() -> Vec<String> {
+    PROMETHEUS_REGISTRY
+        .get()
+        .expect("init_meter_provider installs the registry")
+        .gather()
+        .iter()
+        .map(|family| family.name().to_string())
+        .collect()
+}
+
+/// Every attribute name attached to any measurement in the registry.
+fn scraped_labels() -> Vec<String> {
+    PROMETHEUS_REGISTRY
+        .get()
+        .expect("init_meter_provider installs the registry")
+        .gather()
+        .iter()
+        .flat_map(|family| family.get_metric().to_vec())
+        .flat_map(|metric| metric.get_label().to_vec())
+        .map(|label| label.name().to_string())
+        .collect()
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -124,16 +124,20 @@ bulkhead_max_wait_ms = 5000         # Max wait for a slot (5 seconds)
 # When prometheus-metrics is enabled, metrics are scraped from GET /metrics
 # in Prometheus text-exposition format.
 # ----------------------------------------------------------------------------
+# This table rejects keys it cannot honour, so anything it accepts reaches the
+# instrumentation. `include_path`, `include_method`, `include_status` and
+# `service_name` were once accepted here and silently ignored; they are now
+# startup errors. Method, route and status are always recorded -- the semantic
+# conventions require them -- and a service is named once, under [service].
 [middleware.metrics]
 enabled = true
 
-# Include dimensions in metrics
-include_path = true
-include_method = true
-include_status = true
-
-# Latency histogram buckets (in milliseconds)
-latency_buckets_ms = [5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0]
+# Explicit boundaries for the request-duration histogram, in milliseconds.
+# The instrument is in seconds; these are converted on the way in. Boundaries
+# must be finite, positive and strictly increasing. Omit the key to get the
+# set below, which matches the buckets applied to every other seconds-valued
+# histogram in the service.
+latency_buckets_ms = [1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0, 7500.0, 10000.0]
 
 # ----------------------------------------------------------------------------
 # Local Rate Limiting (Governor)


### PR DESCRIPTION
Closes #124. Reported downstream as AxorumHQ/internal#197.

## The defect

`[middleware.metrics] latency_buckets_ms` was parsed, carried into a second struct of the same name, and then dropped. The layer was built as `HTTPMetricsLayerBuilder::builder().with_meter(meter).build()`, with nothing else from the configuration reaching it. An operator tuning buckets to their SLO thresholds got the defaults back, with no warning at startup or in the scrape.

## Why one fix was not enough

Passing the boundaries to `with_request_duration_bounds` does not, on its own, change the scrape.

The seconds-histogram view from #107 selects on unit, and `http.server.request.duration` is declared in seconds. **A view that matches an instrument overrules that instrument's own boundaries** — `opentelemetry_sdk::metrics::pipeline` reads them only on the branch it takes when no view matched. The value therefore died in two independent places, and repairing either alone leaves the symptom identical, which is the main reason this was worth writing a test for rather than reasoning about.

The view now declines `http.server.request.duration`. It is the one instrument that always carries a configured value, so it never needed the view's default.

The general form is worth remembering: **any view registered on the meter provider silently disables per-instrument bucket configuration for every instrument it matches**, and a unit-selecting view matches broadly by design.

## The other four keys

`include_path`, `include_method` and `include_status` asked the layer to suppress `http.request.method`, `http.route` and `http.response.status_code` — attributes the semantic conventions require, and which the instrumentation records unconditionally. Suppressing them would produce a metric that is no longer the one its name claims. They are removed rather than implemented, and `deny_unknown_fields` turns them from silence into a startup error. Same for `service_name`, which was never a key of this table; `[service] name` names the process once for traces, metrics and logs.

The two `MetricsConfig` structs are collapsed into one. The hand-written conversion between them is where the values were lost, and two types agreeing is not the same as the layer honouring them.

## No dashboard moves

The default for `latency_buckets_ms` is now the view's own boundary set, so a config that omits the key gets precisely the buckets it has today. A test pins the two lists together.

## Also, from reading the scrape

`metric_names::HTTP_SERVER_REQUEST_COUNT` named an instrument that has never existed — the count is the duration histogram's `_count` — and every `metric_labels` entry used pre-1.0 spellings (`http.method`, `http.status_code`) that nothing records. A dashboard built on them queried nothing. Both modules now name what the layer emits, and are asserted against a live scrape rather than against their own literals, which is all the previous tests did.

## Verification

`tests/metrics_config_reaches_the_scrape.rs` drives a real request through the real layer and reads the registry. It was confirmed to fail with each half of the fix reverted independently:

- without the builder call: scrape shows `[0.01, 0.025, …, 300.0]` (library defaults)
- without the view exclusion: scrape shows `[0.001, 0.0025, …, 10.0]` (the view's set)
- with both: scrape shows the configured `[0.05, 0.15, 0.25, 0.4, 0.75]`

`cargo nextest run -p acton-service --features full` — 878 passed. `cargo clippy -p acton-service --all-targets --features full -- -D warnings` — clean. Doctests 105 passed.

## Breaking

- `[middleware.metrics]` rejects `include_path`, `include_method`, `include_status`, `service_name`
- `middleware::metrics::MetricsConfig` is a re-export of `config::MetricsConfig`; `with_service_name`, `with_include_*` and `latency_buckets_as_duration` are gone, and `with_latency_buckets` is `with_latency_buckets_ms`
- `metric_names::HTTP_SERVER_REQUEST_COUNT`, `metric_labels::HTTP_METHOD`, `HTTP_STATUS_CODE`, `SERVICE_VERSION` are removed; the size constants are renamed to their semconv names