### PR TITLE
chore(release): prepare 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [acton-service-v0.36.0] - 2026-08-05
+
+A single fix, and a breaking one: `[middleware.metrics]` now reaches the
+instruments it claimed to configure, and the keys it could never honour fail
+startup instead of being ignored. Anyone whose config sets only `enabled` is
+unaffected, and the boundaries a service already had do not move.
+
 ### Fixed
 
 - **config(metrics)**: `[middleware.metrics] latency_buckets_ms` now reaches the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "acton-cli"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "acton-service",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["acton-service", "acton-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 authors = ["roland@govcraft.ai"]
 license = "MIT"

--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-acton-service = { path = "../acton-service", version = "0.35.0" }
+acton-service = { path = "../acton-service", version = "0.36.0" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/acton-docs/src/lib/version.ts
+++ b/acton-docs/src/lib/version.ts
@@ -2,4 +2,4 @@
  * Version information for acton-service
  * This should match the version in the root Cargo.toml workspace.package.version
  */
-export const VERSION = '0.35.0'
+export const VERSION = '0.36.0'

--- a/acton-docs/src/markdoc/config.js
+++ b/acton-docs/src/markdoc/config.js
@@ -4,7 +4,7 @@ import { siteConfig } from '../lib/config'
 
 // Extract version from workspace Cargo.toml
 // This should be kept in sync with the workspace version
-const ACTON_VERSION = '0.35.0'
+const ACTON_VERSION = '0.36.0'
 
 // Single source of truth mapping camelCase aliases to the real Cargo feature
 // lists. Used by both the `dep()` function and the `$dep.*` variables so a

--- a/acton-docs/src/markdoc/functions.js
+++ b/acton-docs/src/markdoc/functions.js
@@ -1,5 +1,5 @@
 // Markdoc functions for version management
-const ACTON_VERSION = '0.35.0'
+const ACTON_VERSION = '0.36.0'
 
 export const version = {
   transform() {


### PR DESCRIPTION
Releases the fix from #125 so downstream can consume it.

Breaking, pre-1.0, so the minor field moves:

- `[middleware.metrics]` is `deny_unknown_fields` and no longer accepts `include_path`, `include_method`, `include_status` — a config setting any of them now fails startup instead of being silently ignored
- `middleware::metrics::MetricsConfig` is a re-export of `config::MetricsConfig`; `with_service_name`, `with_include_*` and `latency_buckets_as_duration` are gone, `with_latency_buckets` is `with_latency_buckets_ms`
- `metric_names` and `metric_labels` lose the constants that named instruments and attributes nothing emits

A config that sets only `enabled` is unaffected, and no boundaries move: the default for `latency_buckets_ms` is the set the seconds view was already applying.

cargo-semver-checks reports nothing at this bump — a pre-1.0 minor is already a major change, so all 253 lints skip. The classification is from the API surface.

Version synced across `Cargo.toml`, `acton-cli/Cargo.toml` and the three acton-docs files.