### PR TITLE
chore(audit): ignore the rkyv advisory nothing compiles

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -20,4 +20,15 @@ ignore = [
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
     "RUSTSEC-2026-0104",
+    # rkyv 0.7.46 out-of-bounds reads on archives containing Rc/Arc. The fix is
+    # in 0.8.17, and 0.7.46 is the newest 0.7.x, so there is nothing to update
+    # to on this line. rkyv reaches the lockfile through `rust_decimal`'s
+    # optional `rkyv` feature, which nothing here enables: `cargo tree -i rkyv`
+    # reports "nothing to print" for every feature and target combination, and
+    # cargo-deny's graph-based advisory check passes on the same tree. This is
+    # a lockfile entry, not a compiled dependency.
+    # Deliberately not mirrored into deny.toml: cargo-deny never flagged this,
+    # and an ignore it cannot match is a line nobody can later verify.
+    # Revisit when rust_decimal's optional rkyv moves to 0.8.
+    "RUSTSEC-2026-0235",
 ]


### PR DESCRIPTION
`cargo audit` has been red on `main` since RUSTSEC-2026-0235 was published. It surfaced on the 0.36.0 release PR, not because of anything in that PR.

rkyv 0.7.46 reads out of bounds on archives containing `Rc`/`Arc`. The fix is in 0.8.17, and 0.7.46 is the newest 0.7.x, so there is nothing to update to on that line.

**Nothing here compiles it.** rkyv reaches the lockfile through `rust_decimal`'s optional `rkyv` feature, which no crate in this workspace enables — `cargo tree -i rkyv` reports "nothing to print" for every feature and target combination, and cargo-deny's graph-based advisory check passes on the same tree. cargo-audit reads `Cargo.lock` rather than the build graph, which is why the two tools disagree here.

Deliberately not mirrored into `deny.toml`, despite that file's header asking for it: an ignore cargo-deny cannot match is a line nobody can later verify.

Worth noting the detection gap this exposes: the audit workflow runs `0 6 * * 1`, weekly, so an advisory published on a Tuesday goes unreported for six days unless a PR happens to touch `Cargo.lock`.