### PR TITLE
feat(metrics)!: serve /metrics on an opt-in plaintext exporter listener

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,9 +248,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # The floor: no optional subsystem at all.
+          # The floor: no optional subsystem at all. This leg runs the tests
+          # too, because #129 gave the floor its own runtime behaviour: with
+          # `prometheus-metrics` absent, a configured
+          # `[middleware.metrics.exporter]` must be *refused at startup* rather
+          # than ignored. That refusal only exists in this cfg, so the `full`
+          # legs can never reach it and clippy alone would not notice if it
+          # stopped firing.
           - combo: minimal
             features: "http,crypto-aws-lc-rs"
+            test: true
           # TLS without gRPC. This combination is what let two dead-code
           # warnings survive in client_tls.rs until #76, and it is the only one
           # that can catch #120: with gRPC compiled in, tonic pulls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **config(metrics)**: `[middleware.metrics.exporter]` opens a dedicated,
+  plaintext listener that serves only `GET /metrics` (#129). The main
+  listener's `/metrics` route inherits that listener's TLS, auth and
+  middleware, which is right for an application surface and wrong for a scrape
+  target: managed collectors — Fly.io's `[[metrics]]` block, GKE managed
+  collection, the defaults of most `PodMonitor`/`ServiceMonitor` resources —
+  speak plain HTTP to a declared port and expose no TLS knobs, so a service
+  terminating TLS could not be scraped through any of them without stopping
+  terminating TLS.
+
+  The second socket serves the same bytes, from the same registry, through the
+  same handler, so the two cannot drift. It carries no TLS, no authentication
+  and no other middleware by design, and every path other than `GET /metrics`
+  is a 404 — bind it to a private scrape network.
+
+  Both `bind` and `port` are required; there is no default address to open
+  unasked. A `port` of `0`, a port shared with the HTTP or separate-port gRPC
+  listener, or the table appearing in a build without the `prometheus-metrics`
+  feature are all refused before anything binds. The listener binds ahead of
+  the service's own listeners, so a clash refuses to start, and drains after
+  them, so the last scrape still observes the drain. Absent table, absent
+  listener: nothing changes for a config that does not write it.
+
+### Fixed
+
+- **cli**: `acton new --observability` generated a `config.toml` whose
+  `[middleware.metrics]` table set `export_interval_secs`, a key that has never
+  existed. Since 0.36.0 made that table `deny_unknown_fields`, every service
+  the CLI generated with observability enabled failed at startup on its own
+  scaffold. The key is removed.
+- **cli**: generated Kubernetes manifests declared a `metrics` container port,
+  a Service port and a `ServiceMonitor` scraping 9090 — a port nothing had ever
+  listened on. The generated config now writes a matching
+  `[middleware.metrics.exporter]` table, and the generated project enables the
+  `prometheus-metrics` feature that table requires, so the manifest describes
+  something real.
+
 ## [acton-service-v0.36.0] - 2026-08-05
 
 A single fix, and a breaking one: `[middleware.metrics]` now reaches the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING — config(metrics)**: `MetricsConfig` gains the public `exporter`
+  field and is now `#[non_exhaustive]`, so struct-literal construction of it no
+  longer compiles downstream. Construct it with
+  `MetricsConfig::new().with_latency_buckets_ms(..).with_exporter(..)`; every
+  field has a setter. The one-time cost buys additivity: future keys on this
+  table will not break anyone again. `MetricsExporterConfig` is
+  `#[non_exhaustive]` from birth for the same reason — construct it with
+  `MetricsExporterConfig::new(bind, port)`.
+
 ### Added
 
 - **config(metrics)**: `[middleware.metrics.exporter]` opens a dedicated,

--- a/acton-cli/src/templates/config.rs
+++ b/acton-cli/src/templates/config.rs
@@ -183,10 +183,23 @@ bulkhead_max_concurrent = 100
     if template.observability {
         content.push_str(
             r#"# HTTP Metrics (OpenTelemetry)
+# This table rejects keys it cannot honour, so every key here reaches the
+# instrumentation. Metrics are pushed to the OTLP endpoint above and served
+# for scraping on the exporter listener below.
 [middleware.metrics]
 enabled = true
-export_interval_secs = 60
-# Metrics exported to OTLP endpoint above
+
+# A dedicated, plaintext listener serving only GET /metrics, separate from the
+# application listener. Managed collectors -- Fly.io's [[metrics]] block, GKE
+# managed collection, most PodMonitor/ServiceMonitor defaults -- speak plain
+# HTTP to a declared port and offer no TLS knobs, so they cannot scrape an
+# application listener that terminates TLS. This socket carries no TLS and no
+# authentication by design: bind it to a private scrape network, never an
+# internet-facing interface. The generated Kubernetes manifests declare a
+# container port, a Service port and a ServiceMonitor matching this table.
+[middleware.metrics.exporter]
+bind = "::"
+port = 9090
 
 "#,
         );

--- a/acton-cli/src/templates/deployment.rs
+++ b/acton-cli/src/templates/deployment.rs
@@ -103,6 +103,9 @@ spec:
         - name: http
           containerPort: 8080
           protocol: TCP
+        # Served by [middleware.metrics.exporter] in config.toml, which binds
+        # :: on 9090. Plaintext and unauthenticated by design -- keep it on the
+        # pod network and do not add it to an Ingress.
         - name: metrics
           containerPort: 9090
           protocol: TCP
@@ -172,6 +175,8 @@ spec:
     port: 80
     targetPort: http
     protocol: TCP
+  # ClusterIP only. The exporter behind this port carries no TLS and no auth,
+  # so it must stay reachable from inside the cluster and nowhere else.
   - name: metrics
     port: 9090
     targetPort: metrics
@@ -298,6 +303,10 @@ spec:
     matchLabels:
       app: {service_name}
   endpoints:
+  # Scrapes the exporter listener from [middleware.metrics.exporter], not the
+  # application listener. That separation is the point: this endpoint keeps
+  # working when the application listener terminates TLS, which the Prometheus
+  # operator's default scrape configuration cannot follow.
   - port: metrics
     interval: 30s
     path: /metrics

--- a/acton-cli/src/templates/mod.rs
+++ b/acton-cli/src/templates/mod.rs
@@ -84,6 +84,14 @@ impl ServiceTemplate {
 
         if self.observability {
             features.push("observability".to_string());
+            // `observability` alone carries traces and logs, not metrics: the
+            // Prometheus registry lives behind `prometheus-metrics`. The
+            // generated config writes a `[middleware.metrics.exporter]` table
+            // and the generated Kubernetes manifest declares a ServiceMonitor
+            // scraping it, and both are refused at startup without this
+            // feature -- so it is not optional for a scaffold that is meant to
+            // boot as generated.
+            features.push("prometheus-metrics".to_string());
         }
 
         if self.resilience {

--- a/acton-docs/src/app/docs/feature-flags/page.md
+++ b/acton-docs/src/app/docs/feature-flags/page.md
@@ -674,10 +674,13 @@ The same OpenTelemetry HTTP metrics, exposed for a direct Prometheus scrape — 
 
 **Provides**:
 - `GET /metrics` in Prometheus text-exposition format, mounted alongside `/health` and `/ready`
+- An optional second listener, `[middleware.metrics.exporter]`, serving only `GET /metrics` in plaintext on a port of its own
 - The same request metrics as `otel-metrics`, plus any application metrics registered through `get_meter()`
 - Independent of `otel-metrics`: enable either or both; with both, one meter provider feeds both exporters
 
 The endpoint is unauthenticated like `/health` — it exposes route names and traffic statistics, so restrict access at the network layer if that matters in your deployment. `/metrics` is excluded from audit-logged routes by default.
+
+This feature gates two things, and the second is opt-in twice over: the route on the main router, and the separate exporter listener. The exporter exists because managed collectors (Fly.io `[[metrics]]`, GKE managed collection, most `PodMonitor`/`ServiceMonitor` defaults) scrape plain HTTP and offer no TLS knobs, so they cannot reach a main listener that terminates TLS. It appears only when `[middleware.metrics.exporter]` is written, and writing that table in a build *without* this feature is a startup error rather than a silent no-op — there would be no registry to serve. See [Observability](/docs/observability) for the configuration.
 
 ```toml
 {% $dep.prometheusMetrics %}
@@ -1046,7 +1049,7 @@ Some features work better together:
 | `cedar-authz` | `cache` | Policy decision caching dramatically improves performance (10-50ms → 1-5ms) |
 | `cache` | `governor` | Distributed rate limiting needs Redis |
 | `otel-metrics` | `observability` | Metrics require tracing foundation |
-| `prometheus-metrics` | `http` | The `/metrics` scrape endpoint is served by the HTTP router |
+| `prometheus-metrics` | `http` | The `/metrics` scrape endpoint is served by the HTTP router, and the optional `[middleware.metrics.exporter]` listener serves the same route |
 | `journald` | `observability` | Journald layer works alongside OTLP tracing |
 | `resilience` | `http` or `grpc` | Resilience patterns apply to HTTP/gRPC calls |
 | `openapi` | `http` | OpenAPI docs are for HTTP endpoints |

--- a/acton-docs/src/app/docs/observability/page.md
+++ b/acton-docs/src/app/docs/observability/page.md
@@ -255,6 +255,69 @@ scrape_configs:
 
 {% callout type="note" title="Endpoint exposure" %}
 `/metrics` is unauthenticated, like `/health`. It exposes route names, traffic volumes, and latency distributions — no request payloads or secrets — but if that surface matters in your deployment, restrict access at the network layer. The route is excluded from audit logging by default.
+
+This applies to both places the endpoint can appear: the route on your main listener, and the separate exporter listener below. The exporter is the more exposed of the two, because it carries no TLS and no auth even when your main listener carries both — put it on a private scrape network and never behind an Ingress.
+{% /callout %}
+
+### Exporter listener
+
+The route above inherits whatever your main listener is: TLS, authentication, CORS, body limits. That is correct for an application surface and wrong for a scrape target, because the collectors that matter in practice speak plain HTTP to a declared port and offer no TLS knobs at all — Fly.io's `[[metrics]]` block, GKE managed collection, and the defaults of most `PodMonitor`/`ServiceMonitor` resources. Terminate TLS on your main listener and none of them can scrape you.
+
+`[middleware.metrics.exporter]` is the other answer: an opt-in second socket carrying the same bytes, from the same registry, through the same handler.
+
+```toml
+[middleware.metrics]
+enabled = true
+
+[middleware.metrics.exporter]
+bind = "::"
+port = 9090
+```
+
+```bash
+# Plain HTTP, even when the main listener is HTTPS.
+curl http://localhost:9090/metrics
+```
+
+Both keys are required — a plaintext socket is a security-relevant act, so there is no default address to open unasked. Every path other than `GET /metrics` returns 404, and the listener carries no middleware of any kind: no CORS, no compression, no tracing, no timeout, no body limit.
+
+Absent table, absent listener. Nothing changes for a deployment that does not write it.
+
+**Fly.io** — the collector scrapes your instance over the private 6PN network, so bind `::`:
+
+```toml
+# fly.toml
+[[metrics]]
+port = 9090
+path = "/metrics"
+```
+
+**Kubernetes** — the container port, the Service port and the `ServiceMonitor` all name the exporter, not the application listener:
+
+```yaml
+ports:
+  - name: metrics
+    containerPort: 9090
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+spec:
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+```
+
+These are refused at startup, before anything binds, rather than surfacing later as a scrape that silently never arrives:
+
+- `port = 0`, which asks the OS for an ephemeral port that no scrape job can name and that changes on every restart.
+- A port shared with the HTTP listener or the separate-port gRPC listener. The check is on the port alone, deliberately: `::` and `0.0.0.0` overlap on the same port under Linux's dual-stack default, so a differing bind address is not a reliable escape.
+- The table appearing in a build without the `prometheus-metrics` feature, where there is no registry to serve and every scrape would answer 503.
+
+The exporter binds *before* the service's own listeners, so a port clash refuses to start rather than leaving a half-serving process; it drains *after* them, so the final scrape still observes the drain.
+
+{% callout type="note" title="`enabled = false` is not a contradiction here" %}
+`[middleware.metrics] enabled = false` suppresses the HTTP request instruments, not the registry — API-version counters and anything your application records through `get_meter()` still land there. So an exporter alongside `enabled = false` is legitimate and starts normally; it just serves a document with no `http_server_*` families in it. The service logs one warning at startup saying so, rather than refusing.
 {% /callout %}
 
 ### Histogram Bucket Boundaries

--- a/acton-service/examples/observability/test-prometheus-metrics.rs
+++ b/acton-service/examples/observability/test-prometheus-metrics.rs
@@ -14,6 +14,11 @@
 //!   curl http://localhost:8080/api/v1/hello
 //!   curl http://localhost:8080/metrics
 //!
+//! The same document is also served by the dedicated plaintext exporter
+//! listener this example opts into (the surface a platform collector such as
+//! Fly.io `[[metrics]]` or a `PodMonitor` would scrape):
+//!   curl http://localhost:9091/metrics
+//!
 //! The `/metrics` output includes HTTP server metrics (request counts and
 //! latencies) plus the per-version `api.version.requests` counter.
 
@@ -37,10 +42,16 @@ async fn main() -> Result<()> {
     // is self-contained regardless of any config.toml on disk.
     let mut config = Config::<()>::default();
     config.service.name = "prometheus-metrics-example".to_string();
-    config.middleware.metrics = Some(acton_service::config::MetricsConfig {
-        enabled: true,
-        latency_buckets_ms: vec![5.0, 25.0, 100.0, 500.0, 1000.0],
-    });
+    config.middleware.metrics = Some(
+        MetricsConfig::new()
+            .with_latency_buckets_ms(vec![5.0, 25.0, 100.0, 500.0, 1000.0])
+            // The optional second socket: plaintext, GET /metrics only, for
+            // platform collectors that cannot speak TLS to the main listener.
+            .with_exporter(MetricsExporterConfig::new(
+                std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                9091,
+            )),
+    );
 
     let routes = VersionedApiBuilder::new()
         .with_base_path("/api")

--- a/acton-service/src/config.rs
+++ b/acton-service/src/config.rs
@@ -1448,8 +1448,12 @@ impl ResilienceConfig {
 ///
 /// The one nested table, `exporter`, is a real key that reaches a real
 /// listener; see [`MetricsExporterConfig`].
+///
+/// `#[non_exhaustive]`, so future keys on this table are additive: construct
+/// it with [`MetricsConfig::new`] and the `with_*` setters.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct MetricsConfig {
     /// Enable metrics collection
     #[serde(default = "default_true")]
@@ -1553,8 +1557,12 @@ impl MetricsConfig {
 ///
 /// Both keys are required. A plaintext socket is a security-relevant act, so
 /// there is no default address to open unasked.
+///
+/// `#[non_exhaustive]` from birth, so future keys on this table are additive:
+/// construct it with [`MetricsExporterConfig::new`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct MetricsExporterConfig {
     /// IP address the exporter listener binds. Required; there is no default.
     ///

--- a/acton-service/src/config.rs
+++ b/acton-service/src/config.rs
@@ -12,7 +12,7 @@ use figment::{
     Figment,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -1445,6 +1445,9 @@ impl ResilienceConfig {
 /// metric its name claims. `service_name` was never a key of this table -- the
 /// resource-level `service.name` comes from `[service] name`, which is where a
 /// service is named once for traces, metrics and logs alike.
+///
+/// The one nested table, `exporter`, is a real key that reaches a real
+/// listener; see [`MetricsExporterConfig`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetricsConfig {
@@ -1462,6 +1465,13 @@ pub struct MetricsConfig {
     /// down at boot.
     #[serde(default = "default_latency_buckets")]
     pub latency_buckets_ms: Vec<f64>,
+
+    /// Optional plaintext exporter listener. Absent means no second socket.
+    ///
+    /// The one nested table this section permits; its own keys are as strict
+    /// as this table's.
+    #[serde(default)]
+    pub exporter: Option<MetricsExporterConfig>,
 }
 
 impl Default for MetricsConfig {
@@ -1469,6 +1479,7 @@ impl Default for MetricsConfig {
         Self {
             enabled: true,
             latency_buckets_ms: default_latency_buckets(),
+            exporter: None,
         }
     }
 }
@@ -1490,6 +1501,13 @@ impl MetricsConfig {
     #[must_use]
     pub fn with_latency_buckets_ms(mut self, buckets_ms: Vec<f64>) -> Self {
         self.latency_buckets_ms = buckets_ms;
+        self
+    }
+
+    /// Install a plaintext exporter listener serving only `GET /metrics`.
+    #[must_use]
+    pub fn with_exporter(mut self, exporter: MetricsExporterConfig) -> Self {
+        self.exporter = Some(exporter);
         self
     }
 
@@ -1515,6 +1533,49 @@ impl MetricsConfig {
                 .map(|ms| ms / 1000.0)
                 .collect()
         })
+    }
+}
+
+/// A dedicated, plaintext listener that serves only `GET /metrics`.
+///
+/// Absent table means absent listener: nothing changes for a deployment that
+/// does not write `[middleware.metrics.exporter]`. When present, the service
+/// binds one additional TCP socket at `bind:port` and serves the same
+/// Prometheus document as the main listener's `/metrics` route, rendered from
+/// the same registry. Every other path is 404.
+///
+/// This listener speaks HTTP only -- no TLS, no auth, no other middleware --
+/// which is the point: managed platform collectors (Fly.io `[[metrics]]`, GKE
+/// managed collection, most `PodMonitor`/`ServiceMonitor` defaults) scrape
+/// plain HTTP against a declared port and offer no TLS knobs, so a service
+/// whose main listener is TLS cannot be scraped through it. Bind this to a
+/// private scrape network, never an internet-facing interface.
+///
+/// Both keys are required. A plaintext socket is a security-relevant act, so
+/// there is no default address to open unasked.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsExporterConfig {
+    /// IP address the exporter listener binds. Required; there is no default.
+    ///
+    /// `::` is dual-stack on Linux by OS default and v6-only on some BSDs.
+    pub bind: IpAddr,
+
+    /// TCP port the exporter listener binds. Required; there is no default.
+    ///
+    /// Must not be `0` and must not collide with the HTTP or gRPC listener.
+    pub port: u16,
+}
+
+impl MetricsExporterConfig {
+    /// Create an exporter configuration for the given address.
+    pub fn new(bind: IpAddr, port: u16) -> Self {
+        Self { bind, port }
+    }
+
+    /// The address the exporter listener binds.
+    pub fn socket_addr(&self) -> SocketAddr {
+        SocketAddr::new(self.bind, self.port)
     }
 }
 
@@ -2117,6 +2178,82 @@ mod tests {
             ]),
             "omitting the key must leave the boundaries exactly where they were \
              before this table was honoured"
+        );
+        assert!(
+            metrics.exporter.is_none(),
+            "an absent exporter table must mean an absent listener"
+        );
+    }
+
+    #[test]
+    fn metrics_exporter_table_round_trips_through_figment() {
+        // Through Figment rather than serde_json because the real load path
+        // seeds `Serialized::defaults(Config::default())` first, and the
+        // exporter's `None` default must survive that merge.
+        let toml = r#"
+[middleware.metrics]
+enabled = true
+
+[middleware.metrics.exporter]
+bind = "::"
+port = 9091
+"#;
+        let config: Config<()> = Figment::new()
+            .merge(Serialized::defaults(Config::<()>::default()))
+            .merge(Toml::string(toml))
+            .extract()
+            .expect("a bind + port exporter table must deserialize");
+
+        let exporter = config
+            .middleware
+            .metrics
+            .as_ref()
+            .and_then(|m| m.exporter.as_ref())
+            .expect("the exporter table must reach the config");
+        assert_eq!(
+            exporter.socket_addr(),
+            "[::]:9091".parse::<SocketAddr>().expect("valid addr")
+        );
+    }
+
+    #[test]
+    fn metrics_exporter_table_requires_bind() {
+        // A defaulted bind would let a typo'd table open an interface unasked.
+        // That the omission fails here proves serde enforces it, not a runtime
+        // check that could drift.
+        let json = r#"{ "port": 9091 }"#;
+
+        assert!(
+            serde_json::from_str::<MetricsExporterConfig>(json).is_err(),
+            "an exporter table without `bind` must be a parse error"
+        );
+    }
+
+    #[test]
+    fn metrics_exporter_table_refuses_keys_it_cannot_honour() {
+        // The parent table's rule is inherited by intent: a key that reaches
+        // nothing must fail at startup, not be quietly dropped.
+        let json = r#"{ "bind": "127.0.0.1", "port": 9091, "tls": true }"#;
+
+        assert!(
+            serde_json::from_str::<MetricsExporterConfig>(json).is_err(),
+            "an unknown key in [middleware.metrics.exporter] must be a parse error"
+        );
+    }
+
+    #[test]
+    fn metrics_config_builder_sets_the_exporter() {
+        let metrics = MetricsConfig::new().with_exporter(MetricsExporterConfig::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            9091,
+        ));
+
+        assert_eq!(
+            metrics.exporter,
+            Some(MetricsExporterConfig::new(
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                9091
+            ))
         );
     }
 

--- a/acton-service/src/lib.rs
+++ b/acton-service/src/lib.rs
@@ -114,6 +114,8 @@ pub mod events;
 #[cfg(feature = "clickhouse")]
 pub mod clickhouse_backend;
 
+pub mod metrics_exporter;
+
 pub mod observability;
 
 #[cfg(feature = "openapi")]
@@ -258,6 +260,12 @@ pub mod prelude {
 
     #[cfg(feature = "_metrics")]
     pub use crate::middleware::{metric_labels, metric_names, MetricsConfig};
+
+    #[cfg(feature = "_metrics")]
+    pub use crate::config::MetricsExporterConfig;
+
+    #[cfg(feature = "prometheus-metrics")]
+    pub use crate::metrics_exporter::MetricsExporter;
 
     #[cfg(feature = "governor")]
     pub use crate::middleware::{GovernorConfig, GovernorRateLimit, RateLimitExceeded};

--- a/acton-service/src/metrics_exporter.rs
+++ b/acton-service/src/metrics_exporter.rs
@@ -1,0 +1,483 @@
+//! A dedicated, plaintext listener that serves only `GET /metrics`.
+//!
+//! The main listener's `/metrics` route inherits whatever that listener is:
+//! TLS, auth, CORS, compression, body limits. That is correct for an
+//! application surface and wrong for a scrape target, because the collectors
+//! that matter in practice — Fly.io's `[[metrics]]` block, GKE managed
+//! collection, the defaults of most `PodMonitor`/`ServiceMonitor` resources —
+//! speak plain HTTP to a declared port and expose no TLS knobs at all. A
+//! service that terminates TLS on its main listener therefore cannot be
+//! scraped through it, and the usual workaround is to stop terminating TLS.
+//!
+//! This module offers the other answer: an opt-in second socket carrying the
+//! same bytes, from the same registry, through the same
+//! [`crate::observability::metrics_handler`]. It is configured by
+//! `[middleware.metrics.exporter]` and is absent unless that table is written.
+//!
+//! ```toml
+//! [middleware.metrics.exporter]
+//! bind = "::"
+//! port = 9090
+//! ```
+//!
+//! Both keys are required, the listener carries no TLS and no authentication,
+//! and every path other than `GET /metrics` is a 404. Bind it to a private
+//! scrape network.
+
+use std::net::SocketAddr;
+
+use crate::config::MetricsConfig;
+use crate::error::{Error, Result};
+
+/// The section name used in every diagnostic this module emits.
+const SECTION: &str = "[middleware.metrics.exporter]";
+
+/// Resolve the exporter listener address from `[middleware.metrics]`.
+///
+/// Returns `Ok(None)` when no exporter is configured, which is the common case
+/// and not a problem. Returns the validated address otherwise.
+///
+/// Pure: derives its verdict solely from its arguments; performs no I/O and
+/// reads no globals. Callers run it before binding anything, so a rejected
+/// configuration refuses to start rather than surfacing as a scrape that
+/// silently never arrives.
+///
+/// # Errors
+///
+/// - The table is configured but the `prometheus-metrics` feature is not
+///   compiled in, so there is no registry to serve and the socket would answer
+///   nothing useful.
+/// - `port = 0`, which binds an OS-assigned ephemeral port that no scrape
+///   configuration can name.
+/// - The port collides with the HTTP listener or the separate-port gRPC
+///   listener. The check is on the port alone, deliberately: `::` and `0.0.0.0`
+///   overlap on the same port under Linux's dual-stack default, so "a different
+///   address" is not a reliable escape, and no legitimate deployment wants the
+///   exporter racing another listener for a bind.
+pub(crate) fn resolve_exporter_addr(
+    metrics: Option<&MetricsConfig>,
+    http_addr: SocketAddr,
+    grpc_addr: Option<SocketAddr>,
+) -> Result<Option<SocketAddr>> {
+    let Some(exporter) = metrics.and_then(|m| m.exporter.as_ref()) else {
+        return Ok(None);
+    };
+
+    #[cfg(not(feature = "prometheus-metrics"))]
+    {
+        let _ = (exporter, http_addr, grpc_addr);
+        Err(Error::Internal(format!(
+            "{SECTION} is configured, but this binary was built without the \
+             `prometheus-metrics` feature. There is no Prometheus registry to serve, so the \
+             exporter listener would answer every scrape with 503 and the configuration would \
+             be silently untrue. To fix, rebuild with `--features prometheus-metrics` (or \
+             `--features full`), or remove the {SECTION} table."
+        )))
+    }
+
+    #[cfg(feature = "prometheus-metrics")]
+    {
+        if exporter.port == 0 {
+            return Err(Error::Internal(format!(
+                "{SECTION} sets `port = 0`. Port 0 asks the operating system for an arbitrary \
+                 ephemeral port, which no scrape configuration can name and which changes on \
+                 every restart. Set an explicit port."
+            )));
+        }
+
+        let addr = exporter.socket_addr();
+
+        if exporter.port == http_addr.port() {
+            return Err(Error::Internal(format!(
+                "{SECTION} sets `port = {}`, the same port the HTTP listener binds ({http_addr}). \
+                 Two listeners cannot share a port, and a differing bind address is not an \
+                 escape: `::` and `0.0.0.0` overlap on the same port under Linux's dual-stack \
+                 default. Give the exporter a port of its own, or remove the {SECTION} table and \
+                 scrape `/metrics` on the main listener.",
+                exporter.port
+            )));
+        }
+
+        if let Some(grpc_addr) = grpc_addr {
+            if exporter.port == grpc_addr.port() {
+                return Err(Error::Internal(format!(
+                    "{SECTION} sets `port = {}`, the same port the separate-port gRPC listener \
+                     binds ({grpc_addr}). Two listeners cannot share a port. Give the exporter a \
+                     port of its own, or change `[grpc] port`.",
+                    exporter.port
+                )));
+            }
+        }
+
+        Ok(Some(addr))
+    }
+}
+
+/// Warn when the exporter will serve a document with no HTTP instruments in it.
+///
+/// `[middleware.metrics] enabled = false` suppresses the HTTP metrics *layer*,
+/// not the registry: `init_meter_provider` still installs the Prometheus reader,
+/// and API-version counters plus anything an application records through
+/// `get_meter()` still land there. So the combination is legitimate rather than
+/// contradictory, and must not refuse to start — but an operator who configured
+/// an exporter and then finds no `http_server_*` families should be told why
+/// once, at startup, instead of going looking.
+///
+/// Pure: derives its verdict solely from its argument.
+pub(crate) fn exporter_without_http_instruments(metrics: Option<&MetricsConfig>) -> bool {
+    metrics.is_some_and(|m| m.exporter.is_some() && !m.enabled)
+}
+
+/// Emit the [`exporter_without_http_instruments`] warning if it applies.
+pub(crate) fn warn_if_http_instruments_are_absent(metrics: Option<&MetricsConfig>) {
+    if exporter_without_http_instruments(metrics) {
+        tracing::warn!(
+            "{SECTION} is configured while `[middleware.metrics] enabled = false`. The exporter \
+             will serve, but the HTTP request instruments are not installed, so the scrape will \
+             carry only API-version and application metrics."
+        );
+    }
+}
+
+#[cfg(feature = "prometheus-metrics")]
+pub use runtime::{exporter_router, MetricsExporter};
+
+#[cfg(feature = "prometheus-metrics")]
+mod runtime {
+    use super::SECTION;
+    use crate::error::{Error, Result};
+    use std::net::SocketAddr;
+    use std::time::Duration;
+    use tokio::sync::oneshot;
+    use tokio::task::JoinHandle;
+
+    /// How long [`MetricsExporter::shutdown`] waits for in-flight scrapes.
+    ///
+    /// A scrape is one in-memory encode of the registry, so it completes in
+    /// microseconds. Anything approaching this bound is a stuck peer holding
+    /// the connection open, not a slow render, and shutdown must not wait on
+    /// it.
+    const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// The exporter's entire route table: `GET /metrics`, nothing else.
+    ///
+    /// Deliberately unlayered. No CORS, no compression, no tracing, no timeout,
+    /// no body limit, no connect-info: every one of those exists to serve an
+    /// application surface, and none of them helps a scraper. Unmatched paths
+    /// get axum's 404 and a non-`GET` `/metrics` gets 405.
+    ///
+    /// The handler is [`crate::observability::metrics_handler`] itself — the
+    /// same function the main listener's route uses — so the two sockets cannot
+    /// drift into serving different documents.
+    pub fn exporter_router() -> axum::Router {
+        axum::Router::new().route(
+            "/metrics",
+            axum::routing::get(crate::observability::metrics_handler),
+        )
+    }
+
+    /// A bound, running exporter listener.
+    ///
+    /// Created by [`MetricsExporter::start`], which binds before returning, and
+    /// stopped by [`MetricsExporter::shutdown`]. Dropping the handle without
+    /// calling `shutdown` aborts the serving task, so a cancelled `serve`
+    /// future cannot leave the socket open.
+    pub struct MetricsExporter {
+        addr: SocketAddr,
+        stop: Option<oneshot::Sender<()>>,
+        task: Option<JoinHandle<std::io::Result<()>>>,
+    }
+
+    impl MetricsExporter {
+        /// Bind `addr` and start serving.
+        ///
+        /// Binding happens here rather than inside the spawned task so that a
+        /// port already in use is a refusal to start, reported to the caller,
+        /// rather than a background task that logs an error into a process
+        /// which then runs on believing it is observable.
+        ///
+        /// # Errors
+        ///
+        /// Returns [`Error::Internal`] if the address cannot be bound. The
+        /// message names the address and the config section, which the bare
+        /// `std::io::Error` ("Address already in use (os error 98)") does not.
+        pub async fn start(addr: SocketAddr) -> Result<Self> {
+            let listener = tokio::net::TcpListener::bind(addr).await.map_err(|e| {
+                Error::Internal(format!(
+                    "the Prometheus exporter listener could not bind {addr}, configured by \
+                     {SECTION}: {e}"
+                ))
+            })?;
+
+            // `local_addr` rather than `addr`: they differ when the caller
+            // asked for port 0, which `resolve_exporter_addr` rejects for
+            // configuration but which tests legitimately use.
+            let addr = listener.local_addr().unwrap_or(addr);
+
+            if crate::observability::PROMETHEUS_REGISTRY.get().is_none() {
+                tracing::warn!(
+                    %addr,
+                    "Prometheus exporter is starting but no registry has been initialised; \
+                     scrapes will return 503 until `observability::init_meter_provider` runs. \
+                     The `ServiceBuilder` path calls it during `build()`; a bare `Server` does \
+                     not, and must call it itself."
+                );
+            }
+
+            let (stop, stopped) = oneshot::channel();
+            let task = tokio::spawn(async move {
+                axum::serve(listener, exporter_router().into_make_service())
+                    .with_graceful_shutdown(async move {
+                        let _ = stopped.await;
+                    })
+                    .await
+            });
+
+            tracing::info!(
+                %addr,
+                "Prometheus exporter listening (plaintext, GET /metrics only)"
+            );
+
+            Ok(Self {
+                addr,
+                stop: Some(stop),
+                task: Some(task),
+            })
+        }
+
+        /// The address the listener actually bound.
+        pub fn local_addr(&self) -> SocketAddr {
+            self.addr
+        }
+
+        /// Stop serving and wait for in-flight scrapes, bounded by
+        /// `DRAIN_TIMEOUT`.
+        ///
+        /// Callers drain the exporter *after* the service's own listeners have
+        /// finished, so the final scrape can still observe the drain.
+        pub async fn shutdown(mut self) {
+            // Taken, so `Drop` sees `None` and does not abort a task that
+            // finished on its own terms.
+            let Some(task) = self.task.take() else {
+                return;
+            };
+            drop(self.stop.take());
+
+            match tokio::time::timeout(DRAIN_TIMEOUT, task).await {
+                Ok(Ok(Ok(()))) => tracing::info!("Prometheus exporter shutdown complete"),
+                Ok(Ok(Err(e))) => tracing::warn!(error = %e, "Prometheus exporter stopped with an error"),
+                Ok(Err(e)) => tracing::warn!(error = %e, "Prometheus exporter task did not join cleanly"),
+                Err(_) => tracing::warn!(
+                    timeout_secs = DRAIN_TIMEOUT.as_secs(),
+                    "Prometheus exporter did not drain in time; abandoning it"
+                ),
+            }
+        }
+    }
+
+    impl Drop for MetricsExporter {
+        fn drop(&mut self) {
+            // Only reached when `shutdown` was not called — a cancelled
+            // `serve` future, or a caller that dropped the handle. Abort rather
+            // than signal: there is no runtime guarantee left to await on.
+            if let Some(task) = self.task.take() {
+                task.abort();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::MetricsExporterConfig;
+    use std::net::{IpAddr, Ipv4Addr};
+    #[cfg(feature = "prometheus-metrics")]
+    use std::net::Ipv6Addr;
+
+    fn http_addr(port: u16) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port)
+    }
+
+    fn metrics_with_exporter(bind: IpAddr, port: u16) -> MetricsConfig {
+        MetricsConfig::new().with_exporter(MetricsExporterConfig::new(bind, port))
+    }
+
+    /// No `[middleware.metrics]` at all is the default posture and must stay
+    /// silent: the exporter is opt-in twice over.
+    #[test]
+    fn absent_metrics_section_resolves_to_no_exporter() {
+        let resolved = resolve_exporter_addr(None, http_addr(8080), None)
+            .expect("an absent section is not an error");
+        assert_eq!(resolved, None);
+    }
+
+    /// The metrics table without the sub-table is the pre-existing config of
+    /// every deployment on 0.36 and earlier. It must keep meaning "one socket".
+    #[test]
+    fn metrics_section_without_exporter_resolves_to_no_exporter() {
+        let metrics = MetricsConfig::new();
+        let resolved = resolve_exporter_addr(Some(&metrics), http_addr(8080), None)
+            .expect("an absent sub-table is not an error");
+        assert_eq!(resolved, None);
+    }
+
+    #[cfg(feature = "prometheus-metrics")]
+    #[test]
+    fn configured_exporter_resolves_to_exactly_the_requested_address() {
+        let metrics = metrics_with_exporter(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 9090);
+        let resolved = resolve_exporter_addr(Some(&metrics), http_addr(8080), None)
+            .expect("a valid exporter resolves");
+        assert_eq!(
+            resolved,
+            Some(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 9090)),
+            "the resolved address must be what was configured, not a normalised form"
+        );
+    }
+
+    /// Port 0 binds an ephemeral port that changes every restart, so no scrape
+    /// job could ever name it. Accepting it would produce a listener that is
+    /// running and unreachable, the hardest shape of failure to diagnose.
+    #[cfg(feature = "prometheus-metrics")]
+    #[test]
+    fn port_zero_is_refused() {
+        let metrics = metrics_with_exporter(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+        let error = resolve_exporter_addr(Some(&metrics), http_addr(8080), None)
+            .expect_err("port 0 must be refused");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("port = 0"),
+            "the error must name the offending setting, got: {message}"
+        );
+        assert!(
+            message.contains(SECTION),
+            "the error must name the section to fix, got: {message}"
+        );
+    }
+
+    /// The dual-stack case the port-only rule exists for: a different bind
+    /// address does not make the port free.
+    #[cfg(feature = "prometheus-metrics")]
+    #[test]
+    fn colliding_with_the_http_port_is_refused_even_on_a_different_bind() {
+        let metrics = metrics_with_exporter(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 8080);
+        let error = resolve_exporter_addr(Some(&metrics), http_addr(8080), None)
+            .expect_err("sharing the HTTP port must be refused");
+
+        let message = error.to_string();
+        assert!(
+            message.contains(SECTION),
+            "the error must name the exporter section, got: {message}"
+        );
+        assert!(
+            message.contains("HTTP listener"),
+            "the error must name the listener it collides with, got: {message}"
+        );
+    }
+
+    #[cfg(feature = "prometheus-metrics")]
+    #[test]
+    fn colliding_with_the_separate_port_grpc_listener_is_refused() {
+        let metrics = metrics_with_exporter(IpAddr::V4(Ipv4Addr::LOCALHOST), 50051);
+        let error =
+            resolve_exporter_addr(Some(&metrics), http_addr(8080), Some(http_addr(50051)))
+                .expect_err("sharing the gRPC port must be refused");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("gRPC"),
+            "the error must name the gRPC listener, got: {message}"
+        );
+    }
+
+    /// A gRPC listener on its own port must not make an unrelated exporter port
+    /// look like a collision.
+    #[cfg(feature = "prometheus-metrics")]
+    #[test]
+    fn a_distinct_grpc_port_is_not_a_collision() {
+        let metrics = metrics_with_exporter(IpAddr::V4(Ipv4Addr::LOCALHOST), 9090);
+        let resolved =
+            resolve_exporter_addr(Some(&metrics), http_addr(8080), Some(http_addr(50051)))
+                .expect("distinct ports resolve");
+        assert_eq!(resolved, Some(http_addr(9090)));
+    }
+
+    /// Without the feature there is no registry, so the socket would serve 503
+    /// forever. The refusal names the feature, because "why is my scrape 503"
+    /// is otherwise unanswerable from the config alone.
+    #[cfg(not(feature = "prometheus-metrics"))]
+    #[test]
+    fn an_exporter_without_the_feature_is_refused() {
+        let metrics = metrics_with_exporter(IpAddr::V4(Ipv4Addr::LOCALHOST), 9090);
+        let error = resolve_exporter_addr(Some(&metrics), http_addr(8080), None)
+            .expect_err("an exporter without the feature must be refused");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("prometheus-metrics"),
+            "the error must name the missing feature, got: {message}"
+        );
+    }
+
+    /// `enabled = false` plus an exporter is legal, not fatal — but it is worth
+    /// one warning, and this is the predicate that decides it.
+    #[test]
+    fn exporter_with_the_http_layer_disabled_warrants_a_warning() {
+        let metrics = metrics_with_exporter(IpAddr::V4(Ipv4Addr::LOCALHOST), 9090)
+            .with_enabled(false);
+        assert!(exporter_without_http_instruments(Some(&metrics)));
+    }
+
+    #[test]
+    fn exporter_with_the_http_layer_enabled_warrants_no_warning() {
+        let metrics = metrics_with_exporter(IpAddr::V4(Ipv4Addr::LOCALHOST), 9090);
+        assert!(!exporter_without_http_instruments(Some(&metrics)));
+    }
+
+    #[test]
+    fn a_disabled_metrics_layer_without_an_exporter_warrants_no_warning() {
+        let metrics = MetricsConfig::new().with_enabled(false);
+        assert!(!exporter_without_http_instruments(Some(&metrics)));
+    }
+
+    /// The route table is the security boundary: anything reachable here is
+    /// reachable without TLS and without auth, so assert what is *not* there.
+    #[cfg(feature = "prometheus-metrics")]
+    #[tokio::test]
+    async fn the_exporter_router_serves_metrics_and_nothing_else() {
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode};
+        use tower::ServiceExt as _;
+
+        let status_for = |method: &'static str, path: &'static str| async move {
+            exporter_router()
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri(path)
+                        .body(Body::empty())
+                        .expect("request builds"),
+                )
+                .await
+                .expect("router responds")
+                .status()
+        };
+
+        assert_ne!(
+            status_for("GET", "/metrics").await,
+            StatusCode::NOT_FOUND,
+            "GET /metrics must be routed"
+        );
+        assert_eq!(
+            status_for("GET", "/healthz").await,
+            StatusCode::NOT_FOUND,
+            "the exporter must not carry the application's routes"
+        );
+        assert_eq!(
+            status_for("POST", "/metrics").await,
+            StatusCode::METHOD_NOT_ALLOWED,
+            "the exporter is read-only"
+        );
+    }
+}

--- a/acton-service/src/server.rs
+++ b/acton-service/src/server.rs
@@ -75,6 +75,20 @@ impl Server {
             None => crate::tls::DEFAULT_HANDSHAKE_TIMEOUT,
         };
 
+        // And the optional plaintext exporter listener: a collision or a
+        // feature this build lacks is a refusal to start, reported before any
+        // listener binds. This path has no gRPC listener to collide with.
+        let metrics_exporter_addr = crate::metrics_exporter::resolve_exporter_addr(
+            self.config.middleware.metrics.as_ref(),
+            addr,
+            None,
+        )?;
+        #[cfg(not(feature = "prometheus-metrics"))]
+        let _ = metrics_exporter_addr;
+        crate::metrics_exporter::warn_if_http_instruments_are_absent(
+            self.config.middleware.metrics.as_ref(),
+        );
+
         // Log middleware configuration
         self.log_middleware_config();
 
@@ -138,6 +152,17 @@ impl Server {
 
         tracing::info!("Server listening on {}", addr);
 
+        // Bound after the main listener so its port takes precedence in a
+        // race, drained after the serve calls below return. On an error return
+        // the handle's abort-on-drop backstop closes the socket instead.
+        #[cfg(feature = "prometheus-metrics")]
+        let metrics_exporter = match metrics_exporter_addr {
+            Some(exporter_addr) => {
+                Some(crate::metrics_exporter::MetricsExporter::start(exporter_addr).await?)
+            }
+            None => None,
+        };
+
         // Serve with graceful shutdown -- TLS or plain TCP
         //
         // The TLS listener exposes `TlsConnectInfo` (remote address plus any
@@ -172,6 +197,10 @@ impl Server {
                 )
                 .with_graceful_shutdown(shutdown_signal())
                 .await?;
+                #[cfg(feature = "prometheus-metrics")]
+                if let Some(exporter) = metrics_exporter {
+                    exporter.shutdown().await;
+                }
                 tracing::info!("Server shutdown complete");
                 return Ok(());
             }
@@ -183,6 +212,11 @@ impl Server {
         )
         .with_graceful_shutdown(shutdown_signal())
         .await?;
+
+        #[cfg(feature = "prometheus-metrics")]
+        if let Some(exporter) = metrics_exporter {
+            exporter.shutdown().await;
+        }
 
         tracing::info!("Server shutdown complete");
 
@@ -245,6 +279,20 @@ impl Server {
             }
         } else {
             tracing::info!("  - HTTP metrics: not configured");
+        }
+
+        match self
+            .config
+            .middleware
+            .metrics
+            .as_ref()
+            .and_then(|m| m.exporter.as_ref())
+        {
+            Some(exporter) => tracing::info!(
+                "  - Metrics exporter: {} (plaintext, GET /metrics only)",
+                exporter.socket_addr()
+            ),
+            None => tracing::info!("  - Metrics exporter: not configured"),
         }
 
         if let Some(ref governor) = self.config.middleware.governor {

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -2013,6 +2013,37 @@ where
             record_startup_error(&mut startup_error, err);
         }
 
+        // Resolve the optional plaintext exporter listener against every
+        // listener this config will bind. Caught here, so `try_build()` /
+        // `serve()` report a collision or a feature this build lacks without
+        // binding anything. The gRPC peer only exists in separate-port mode.
+        #[cfg(feature = "grpc")]
+        let grpc_listener_addr = config.grpc.as_ref().and_then(|g| {
+            (g.enabled && g.use_separate_port)
+                .then(|| std::net::SocketAddr::new(g.effective_bind(config.service.bind), g.port))
+        });
+        #[cfg(not(feature = "grpc"))]
+        let grpc_listener_addr: Option<std::net::SocketAddr> = None;
+
+        let metrics_exporter_addr = match crate::metrics_exporter::resolve_exporter_addr(
+            config.middleware.metrics.as_ref(),
+            listener_addr,
+            grpc_listener_addr,
+        ) {
+            Ok(addr) => addr,
+            Err(err) => {
+                tracing::error!("{}", err);
+                record_startup_error(&mut startup_error, err);
+                None
+            }
+        };
+        #[cfg(not(feature = "prometheus-metrics"))]
+        let _ = metrics_exporter_addr;
+
+        crate::metrics_exporter::warn_if_http_instruments_are_absent(
+            config.middleware.metrics.as_ref(),
+        );
+
         #[cfg(feature = "grpc")]
         let grpc_router: Option<axum::Router> = match self.grpc_services {
             Some(routes) => {
@@ -2083,6 +2114,8 @@ where
             config,
             state: state_clone,
             listener_addr,
+            #[cfg(feature = "prometheus-metrics")]
+            metrics_exporter_addr,
             app,
             #[cfg(feature = "grpc")]
             grpc_routes: grpc_router,
@@ -2511,6 +2544,11 @@ where
     config: Config<T>,
     state: AppState<T>,
     listener_addr: std::net::SocketAddr,
+    /// Validated address for the plaintext exporter listener, from
+    /// `[middleware.metrics.exporter]`. `serve()` binds it before the service
+    /// listeners and drains it after them.
+    #[cfg(feature = "prometheus-metrics")]
+    metrics_exporter_addr: Option<std::net::SocketAddr>,
     app: Router,
     #[cfg(feature = "grpc")]
     grpc_routes: Option<axum::Router>,
@@ -2678,6 +2716,13 @@ where
     /// - Single-port mode (default): Both HTTP and gRPC on same port, routed by content-type
     /// - Dual-port mode: HTTP on configured port, gRPC on separate port
     ///
+    /// # Metrics exporter
+    ///
+    /// When `[middleware.metrics.exporter]` is configured, this also runs the
+    /// plaintext exporter listener. It binds *before* the service listeners,
+    /// so a taken port refuses startup, and drains *after* they finish, so the
+    /// final scrape can still observe the drain.
+    ///
     /// # Example
     ///
     /// ```rust,ignore
@@ -2689,17 +2734,40 @@ where
     ///
     /// service.serve().await?;
     /// ```
-    #[cfg_attr(not(feature = "grpc"), allow(unused_mut))]
     pub async fn serve(mut self) -> crate::error::Result<()> {
-        use tokio::net::TcpListener;
-        use tokio::signal;
-
         // Fail before any socket binds. A misconfiguration that would force a
         // weaker posture than configured (TLS that could not load, invalid token
         // auth) must never reach the point of accepting connections.
         if let Some(e) = self.startup_error.take() {
             return Err(e);
         }
+
+        #[cfg(feature = "prometheus-metrics")]
+        let exporter = match self.metrics_exporter_addr.take() {
+            Some(addr) => Some(crate::metrics_exporter::MetricsExporter::start(addr).await?),
+            None => None,
+        };
+
+        let result = self.serve_listeners().await;
+
+        #[cfg(feature = "prometheus-metrics")]
+        if let Some(exporter) = exporter {
+            exporter.shutdown().await;
+        }
+
+        result
+    }
+
+    /// The serve body proper: every service listener, every return path.
+    ///
+    /// Split from [`serve`](Self::serve) so that start-before/drain-after
+    /// bracketing (the startup-error check, the metrics exporter) lives in
+    /// exactly one place instead of being threaded through the five return
+    /// paths below.
+    #[cfg_attr(not(feature = "grpc"), allow(unused_mut))]
+    async fn serve_listeners(mut self) -> crate::error::Result<()> {
+        use tokio::net::TcpListener;
+        use tokio::signal;
 
         // Start credential rotation before binding, so a certificate that
         // rotates during startup is picked up rather than missed. The guard is

--- a/acton-service/tests/metrics_exporter_requires_the_feature.rs
+++ b/acton-service/tests/metrics_exporter_requires_the_feature.rs
@@ -1,0 +1,69 @@
+//! A configured exporter in a build without `prometheus-metrics` must refuse
+//! to start, and must refuse *before* binding anything.
+//!
+//! Without the feature there is no registry, so the socket would answer 503
+//! forever -- a listener that is running and useless, the hardest shape of
+//! failure to diagnose from the outside. The refusal happens at config
+//! resolution, which these tests prove by occupying the service port first:
+//! if the code bound before validating, the error would be "address in use"
+//! instead of the one naming the feature.
+//!
+//! This file only executes in a build without `prometheus-metrics`; the
+//! `minimal` CI leg is what runs it.
+
+#![cfg(not(feature = "prometheus-metrics"))]
+
+use acton_service::config::{Config, MetricsConfig, MetricsExporterConfig};
+use acton_service::prelude::{Server, ServiceBuilder};
+use axum::Router;
+use std::net::{IpAddr, Ipv4Addr};
+
+const LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+fn config_with_exporter(service_port: u16) -> Config<()> {
+    let mut config = Config::<()>::default();
+    config.service.bind = LOOPBACK;
+    config.service.port = service_port;
+    config.middleware.metrics =
+        Some(MetricsConfig::new().with_exporter(MetricsExporterConfig::new(LOOPBACK, 9091)));
+    config
+}
+
+#[tokio::test]
+async fn try_build_refuses_an_exporter_this_build_cannot_serve() {
+    let error = ServiceBuilder::new()
+        .with_config(config_with_exporter(8080))
+        .try_build()
+        .err()
+        .expect("an exporter table without the feature must be a startup error");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("prometheus-metrics"),
+        "the error must name the missing feature, got: {message}"
+    );
+    assert!(
+        message.contains("[middleware.metrics.exporter]"),
+        "the error must name the section to fix, got: {message}"
+    );
+}
+
+#[tokio::test]
+async fn server_refuses_the_exporter_before_binding() {
+    // Held open across the call: if `serve` bound its listener before
+    // validating the exporter table, this occupation would surface as
+    // "address in use" rather than the refusal under test.
+    let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("occupy a port");
+    let port = occupied.local_addr().expect("occupied addr").port();
+
+    let error = Server::new(config_with_exporter(port))
+        .serve(Router::new())
+        .await
+        .expect_err("an exporter table without the feature must refuse to start");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("prometheus-metrics"),
+        "the refusal must precede the bind and name the feature, got: {message}"
+    );
+}

--- a/acton-service/tests/metrics_exporter_requires_the_feature.rs
+++ b/acton-service/tests/metrics_exporter_requires_the_feature.rs
@@ -29,7 +29,10 @@ fn config_with_exporter(service_port: u16) -> Config<()> {
     config
 }
 
-#[tokio::test]
+// Multi-thread flavor: in builds that carry the `audit` feature, the default
+// config enables the audit agent, whose own current-thread-runtime guard would
+// otherwise be recorded first and mask the refusal under test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn try_build_refuses_an_exporter_this_build_cannot_serve() {
     let error = ServiceBuilder::new()
         .with_config(config_with_exporter(8080))

--- a/acton-service/tests/metrics_exporter_scrapes_beside_tls.rs
+++ b/acton-service/tests/metrics_exporter_scrapes_beside_tls.rs
@@ -1,0 +1,129 @@
+//! The defect issue #129 describes, as a test: a service whose main listener
+//! is TLS must still be scrapeable in plain HTTP through the exporter.
+//!
+//! This is the one test in the suite that fails before the exporter existed:
+//! the full `ServiceBuilder::serve` path runs with `[tls]` enabled and a
+//! `[middleware.metrics.exporter]` table, and a cleartext client -- the shape
+//! of a Fly.io or `PodMonitor` collector, which has no TLS knobs -- scrapes
+//! the exporter while the same bytes are refused by the main listener.
+//!
+//! TLS material follows `tls_alpn_http2.rs` (rcgen + tempfile); the client is
+//! a raw `TcpStream` for the same reason as there: cleartext on the wire is
+//! the property under test, and a client library would hide it.
+
+#![cfg(all(feature = "prometheus-metrics", feature = "tls"))]
+
+use std::io::Write as _;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::Duration;
+
+use acton_service::config::{Config, MetricsConfig, MetricsExporterConfig, TlsConfig};
+use acton_service::prelude::ServiceBuilder;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+const LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+/// Bounds every wait in this file; loopback answers in microseconds.
+const REPLY_TIMEOUT: Duration = Duration::from_secs(5);
+/// How long the spawned `serve` gets to bind both listeners.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn write_temp(contents: &str) -> tempfile::NamedTempFile {
+    let mut file = tempfile::NamedTempFile::new().expect("temp file");
+    file.write_all(contents.as_bytes()).expect("write temp");
+    file.flush().expect("flush temp");
+    file
+}
+
+/// Two distinct free loopback ports, reserved together so the second cannot
+/// be handed the first's port back.
+fn two_free_ports() -> (u16, u16) {
+    let first = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve first port");
+    let second = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve second port");
+    (
+        first.local_addr().expect("first addr").port(),
+        second.local_addr().expect("second addr").port(),
+    )
+}
+
+/// One cleartext HTTP/1.1 GET /metrics, response returned verbatim.
+async fn raw_scrape(addr: SocketAddr) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect(addr).await?;
+    let request = format!("GET /metrics HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    stream.write_all(request.as_bytes()).await?;
+
+    let mut response = Vec::new();
+    tokio::time::timeout(REPLY_TIMEOUT, stream.read_to_end(&mut response))
+        .await
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "no reply"))??;
+    Ok(String::from_utf8_lossy(&response).into_owned())
+}
+
+// Multi-thread flavor: the default config enables the audit agent, which
+// `build()` refuses on a current-thread runtime.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_tls_service_is_scrapeable_in_plaintext_through_the_exporter() {
+    let certified =
+        rcgen::generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+            .expect("self-signed cert generation");
+    let cert_file = write_temp(&certified.cert.pem());
+    let key_file = write_temp(&certified.signing_key.serialize_pem());
+
+    let (http_port, exporter_port) = two_free_ports();
+
+    let mut config = Config::<()>::default();
+    config.service.name = "tls-exporter-e2e".to_string();
+    config.service.bind = LOOPBACK;
+    config.service.port = http_port;
+    config.tls = Some(TlsConfig {
+        enabled: true,
+        cert_path: cert_file.path().to_path_buf(),
+        key_path: key_file.path().to_path_buf(),
+        client_ca_path: None,
+        client_auth_optional: false,
+        reload_interval_secs: None,
+        reload_on_sighup: false,
+        handshake_timeout_secs: None,
+    });
+    config.middleware.metrics = Some(
+        MetricsConfig::new().with_exporter(MetricsExporterConfig::new(LOOPBACK, exporter_port)),
+    );
+
+    let service = ServiceBuilder::new().with_config(config).build();
+    let server = tokio::spawn(service.serve());
+
+    // The exporter binds before the service listeners, so once it scrapes the
+    // whole startup ordering has held.
+    let exporter_addr = SocketAddr::new(LOOPBACK, exporter_port);
+    let deadline = tokio::time::Instant::now() + STARTUP_TIMEOUT;
+    let scrape = loop {
+        match raw_scrape(exporter_addr).await {
+            Ok(response) => break response,
+            Err(_) if tokio::time::Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+            Err(e) => panic!("the exporter never came up: {e}"),
+        }
+    };
+
+    assert!(
+        scrape.starts_with("HTTP/1.1 200"),
+        "the plaintext scrape must succeed while the main listener is TLS, got: {scrape}"
+    );
+    assert!(
+        scrape.contains("text/plain"),
+        "the scrape must be the Prometheus text exposition, got: {scrape}"
+    );
+
+    // The same cleartext bytes against the main listener must NOT produce an
+    // HTTP success: that listener speaks TLS, and `GET ` is not a TLS record.
+    let main_addr = SocketAddr::new(LOOPBACK, http_port);
+    let refused = raw_scrape(main_addr).await;
+    let plaintext_worked = matches!(&refused, Ok(response) if response.starts_with("HTTP/1.1 200"));
+    assert!(
+        !plaintext_worked,
+        "the main listener must stay TLS-only; a cleartext 200 means the posture leaked: {refused:?}"
+    );
+
+    server.abort();
+}

--- a/acton-service/tests/metrics_exporter_serves_plaintext.rs
+++ b/acton-service/tests/metrics_exporter_serves_plaintext.rs
@@ -1,0 +1,126 @@
+//! The exporter listener must speak plain HTTP, serve exactly one route, and
+//! stop with the service.
+//!
+//! The client is a raw `TcpStream` writing literal HTTP/1.1 bytes, following
+//! `tls_alpn_http2.rs`: writing the request in cleartext and reading a parseable
+//! response is what *proves* the listener is not TLS -- an HTTP client library
+//! would hide exactly the property under test. This file adds no dependency of
+//! its own.
+//!
+//! One test per file-process concern: the meter provider is a process-wide
+//! `OnceCell` (see `metrics_config_reaches_the_scrape.rs`), and nextest's
+//! process-per-test isolation is what makes initializing it per test workable.
+
+#![cfg(feature = "prometheus-metrics")]
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use acton_service::metrics_exporter::MetricsExporter;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Bounds a loopback round trip; a healthy exporter answers immediately.
+const REPLY_TIMEOUT: Duration = Duration::from_secs(5);
+
+async fn start_exporter() -> MetricsExporter {
+    MetricsExporter::start("127.0.0.1:0".parse().expect("loopback addr"))
+        .await
+        .expect("the exporter binds an ephemeral loopback port")
+}
+
+/// One cleartext HTTP/1.1 request, response returned verbatim.
+async fn raw_get(addr: SocketAddr, path: &str) -> String {
+    let mut stream = TcpStream::connect(addr).await.expect("connect exporter");
+    let request = format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write request");
+
+    let mut response = Vec::new();
+    tokio::time::timeout(REPLY_TIMEOUT, stream.read_to_end(&mut response))
+        .await
+        .expect("the exporter must answer within the bound")
+        .expect("read response");
+    String::from_utf8_lossy(&response).into_owned()
+}
+
+#[tokio::test]
+async fn a_plaintext_scrape_returns_the_prometheus_document() {
+    let mut config = acton_service::config::Config::<()>::default();
+    config.service.name = "exporter-plaintext-e2e".to_string();
+    acton_service::observability::init_meter_provider(&config).expect("meter provider initializes");
+
+    // One recorded measurement, so the assertion below is about a document
+    // with content rather than a technically-200 empty registry.
+    acton_service::observability::get_meter()
+        .expect("the meter provider was just initialized")
+        .u64_counter("exporter_e2e_probe")
+        .build()
+        .add(1, &[]);
+
+    let exporter = start_exporter().await;
+    let response = raw_get(exporter.local_addr(), "/metrics").await;
+
+    assert!(
+        response.starts_with("HTTP/1.1 200"),
+        "a cleartext scrape must succeed, got: {response}"
+    );
+    assert!(
+        response.contains("text/plain"),
+        "the response must carry the Prometheus text exposition content type, got: {response}"
+    );
+    let body = response.split("\r\n\r\n").nth(1).unwrap_or("");
+    assert!(
+        body.contains("exporter_e2e_probe"),
+        "the scrape must render the registry the service records into, got: {body}"
+    );
+
+    exporter.shutdown().await;
+}
+
+#[tokio::test]
+async fn every_other_path_is_404() {
+    let exporter = start_exporter().await;
+
+    let response = raw_get(exporter.local_addr(), "/health").await;
+
+    assert!(
+        response.starts_with("HTTP/1.1 404"),
+        "the exporter must not carry the application's routes, got: {response}"
+    );
+
+    exporter.shutdown().await;
+}
+
+#[tokio::test]
+async fn shutdown_closes_the_listener() {
+    let exporter = start_exporter().await;
+    let addr = exporter.local_addr();
+
+    exporter.shutdown().await;
+
+    assert!(
+        TcpStream::connect(addr).await.is_err(),
+        "a drained exporter must refuse new connections"
+    );
+}
+
+#[tokio::test]
+async fn dropping_the_handle_also_closes_the_listener() {
+    let exporter = start_exporter().await;
+    let addr = exporter.local_addr();
+
+    // The abort-on-drop backstop for a cancelled serve future. Abort lands
+    // asynchronously, so poll rather than assert the very next instant.
+    drop(exporter);
+
+    for _ in 0..200 {
+        if TcpStream::connect(addr).await.is_err() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("the listener must close after its handle is dropped");
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -139,6 +139,32 @@ enabled = true
 # histogram in the service.
 latency_buckets_ms = [1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0, 7500.0, 10000.0]
 
+# A dedicated, plaintext listener that serves only GET /metrics.
+# Requires feature: prometheus-metrics. Absent table means absent listener.
+#
+# The main listener's /metrics route inherits whatever that listener is: TLS,
+# auth, CORS, compression, body limits. That is right for an application
+# surface and wrong for a scrape target, because the collectors that matter in
+# practice speak plain HTTP to a declared port and offer no TLS knobs:
+# Fly.io's [[metrics]] block, GKE managed collection, and the defaults of most
+# PodMonitor / ServiceMonitor resources. A service terminating TLS on its main
+# listener cannot be scraped through any of them.
+#
+# This table is the other answer: a second socket carrying the same bytes,
+# from the same registry, through the same handler. It has NO TLS and NO
+# authentication, and it is not meant to. Bind it to a private scrape network
+# -- a pod interface, a WireGuard address, loopback -- never an
+# internet-facing one.
+#
+# Both keys are required; there is no default address to open unasked. The
+# port must not be 0 (an ephemeral port no scrape job can name) and must not
+# collide with the HTTP or separate-port gRPC listener. Either mistake is a
+# refusal to start, reported before anything binds.
+#
+# [middleware.metrics.exporter]
+# bind = "::"     # dual-stack on Linux by OS default; v6-only on some BSDs
+# port = 9090
+
 # ----------------------------------------------------------------------------
 # Local Rate Limiting (Governor)
 # Requires feature: governor


### PR DESCRIPTION
Closes #129.

## What

`[middleware.metrics.exporter]` (both `bind` and `port` required, no defaults) opts a service into one additional plaintext TCP socket serving exactly `GET /metrics` — the same document, from the same registry, through the same `metrics_handler` as the main listener's route, so the two surfaces cannot drift. Every other path is 404, a non-GET `/metrics` is 405, and the router is deliberately unlayered. Absent table means absent listener; nothing changes for existing deployments.

Startup refusals, all reported before anything binds, on both the `ServiceBuilder` and `Server` paths:

- the table present in a build without `prometheus-metrics` (the error names the feature)
- `port = 0` (an ephemeral port no scrape job can name)
- a port shared with the HTTP or separate-port gRPC listener — checked on the port alone, because `::` and `0.0.0.0` collide on dual-stack hosts

Lifecycle: the exporter binds before the service listeners (a taken port refuses startup) and drains after them (the final scrape can observe the drain), with a 5s drain bound and an abort-on-drop backstop for a cancelled serve future. `ServiceBuilder::serve` was split into a thin wrapper plus `serve_listeners` so the bracketing lives in one place instead of being threaded through five return paths.

`enabled = false` plus an exporter is legal, not fatal (the registry exists independently of the HTTP metrics layer); it logs one startup warning explaining the scrape will lack the `http_server_*` families.

## Also fixed (same table, found while implementing)

- **CLI scaffold startup failure**: `acton new --observability` emitted `export_interval_secs = 60`, a key `[middleware.metrics]` has rejected since 0.36.0's `deny_unknown_fields` — every generated observability project failed at startup on its own config.
- **CLI manifests scraped a dead port**: the generated Kubernetes manifests already declared a `metrics` container port, Service port and ServiceMonitor on 9090 that nothing listened on. The generated config now emits a matching exporter table, and the scaffold enables `prometheus-metrics` (which `observability` alone does not imply — without this the generated config would trip the feature-absent refusal above).

## Tests

- Unit: pure `resolve_exporter_addr` table (all four refusals plus the non-collision case), router route-table assertions, config round-trip through figment, serde-enforced required `bind`, inherited `deny_unknown_fields`.
- Integration: raw-`TcpStream` cleartext scrapes (a client library would hide exactly the property under test) — 200 + text exposition, 404 elsewhere, listener closed after `shutdown()` and after drop; the issue's actual defect as a test (`[tls]` service scrapeable in plaintext through the exporter while the main listener refuses the same bytes); feature-absent refusals proven to precede the bind by occupying the port first.
- CI: the minimal leg (`http,crypto-aws-lc-rs`) now runs tests — the feature-absent refusal only exists in that cfg.

`cargo clippy --all-targets -D warnings` clean on `full`, `http,crypto-aws-lc-rs`, and `http,tls,prometheus-metrics,crypto-aws-lc-rs`; nextest 898/898 (full), 159/159 (minimal), 6/6 (acton-cli).

## Semver

Next release should be **0.37.0**: `MetricsConfig` has public fields and no `#[non_exhaustive]`, and gains `exporter` — downstream struct literals stop compiling (the in-repo example proved it). Migration is one builder call or `exporter: None`. Bundled: `MetricsConfig` is now also `#[non_exhaustive]` (and `MetricsExporterConfig` from birth), so future keys on these tables are additive; construct them with `new()` and the `with_*` setters.
