### PR TITLE
chore(release): prepare 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [acton-service-v0.37.0] - 2026-08-07
+
+One feature, and the config-surface change it carries: a TLS service can now
+be scraped by the plain-HTTP collectors platforms ship, through an opt-in
+second listener that serves only `GET /metrics`. A deployment that does not
+write the new table sees no change at runtime; code that constructs
+`MetricsConfig` as a struct literal must move to the builders.
+
 ### Changed
 
 - **BREAKING — config(metrics)**: `MetricsConfig` gains the public `exporter`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "acton-cli"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "acton-service",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["acton-service", "acton-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 authors = ["roland@govcraft.ai"]
 license = "MIT"

--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-acton-service = { path = "../acton-service", version = "0.36.0" }
+acton-service = { path = "../acton-service", version = "0.37.0" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/acton-docs/src/lib/version.ts
+++ b/acton-docs/src/lib/version.ts
@@ -2,4 +2,4 @@
  * Version information for acton-service
  * This should match the version in the root Cargo.toml workspace.package.version
  */
-export const VERSION = '0.36.0'
+export const VERSION = '0.37.0'

--- a/acton-docs/src/markdoc/config.js
+++ b/acton-docs/src/markdoc/config.js
@@ -4,7 +4,7 @@ import { siteConfig } from '../lib/config'
 
 // Extract version from workspace Cargo.toml
 // This should be kept in sync with the workspace version
-const ACTON_VERSION = '0.36.0'
+const ACTON_VERSION = '0.37.0'
 
 // Single source of truth mapping camelCase aliases to the real Cargo feature
 // lists. Used by both the `dep()` function and the `$dep.*` variables so a

--- a/acton-docs/src/markdoc/functions.js
+++ b/acton-docs/src/markdoc/functions.js
@@ -1,5 +1,5 @@
 // Markdoc functions for version management
-const ACTON_VERSION = '0.36.0'
+const ACTON_VERSION = '0.37.0'
 
 export const version = {
   transform() {


### PR DESCRIPTION
Release prep for 0.37.0 carrying #130 (issue #129): the opt-in plaintext metrics exporter listener, the non_exhaustive metrics config tables, and the CLI scaffold fixes. Version bumps (workspace, acton-cli pin, lockfile), CHANGELOG dated, acton-docs version files synced.