### PR TITLE
feat: support native Windows configuration

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -20,6 +20,12 @@ ignore = [
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
     "RUSTSEC-2026-0104",
+    # h2 0.3.27 unbounded empty DATA frame buffering. h2 0.4 is updated to the
+    # patched 0.4.16; this older line is pinned by optional libsql 0.9.30 via
+    # tonic/hyper, with no patched 0.3.x or newer stable libsql available.
+    # Turso is a client-only path, so exploitation requires a malicious or
+    # compromised upstream. Revisit with the next stable libsql release.
+    "RUSTSEC-2026-0258",
     # rkyv 0.7.46 out-of-bounds reads on archives containing Rc/Arc. The fix is
     # in 0.8.17, and 0.7.46 is the newest 0.7.x, so there is nothing to update
     # to on this line. rkyv reaches the lockfile through `rust_decimal`'s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,29 @@ jobs:
       - name: Nextest
         run: cargo nextest run -p acton-service --no-default-features --features "full,crypto-ring"
 
+  windows:
+    name: Windows native
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: windows
+      - name: Clippy default features
+        run: cargo clippy -p acton-service --all-targets -- -D warnings
+      - name: Test default features
+        run: cargo test -p acton-service
+      - name: Check full feature set
+        run: cargo check -p acton-service --all-targets --features full
+
   # The `full` legs above cover audit with the PostgreSQL storage backend
   # (`database` is in `full`). The optional backends are mutually exclusive
   # with `database`, so each parser/unit path gets its own leg. All storage
@@ -342,7 +365,7 @@ jobs:
   # those PRs, because a skipped job reports nothing at all.
   ci-gate:
     name: ci-gate
-    needs: [changes, aws-lc-rs, ring, audit-storage, feature-combos, docs-build]
+    needs: [changes, aws-lc-rs, ring, windows, audit-storage, feature-combos, docs-build]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **platforms**: Native Windows configuration discovery now uses `%APPDATA%`
+  for per-user configuration and `%PROGRAMDATA%` for system-wide configuration.
+  Windows builds are compiled and tested in CI alongside the existing Linux
+  matrix.
+
+### Changed
+
+- **config**: Removed the Unix-only `xdg` dependency. Unix configuration still
+  follows `XDG_CONFIG_HOME` with the same `$HOME/.config` fallback, while
+  `recommended_path` no longer creates directories as a side effect.
+
 ## [acton-service-v0.37.0] - 2026-08-07
 
 One feature, and the config-surface change it carries: a TLS service can now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **platforms**: Native Windows configuration discovery now uses `%APPDATA%`
   for per-user configuration and `%PROGRAMDATA%` for system-wide configuration.
   Windows builds are compiled and tested in CI alongside the existing Linux
-  matrix.
+  matrix. `acton-reactive` is updated to 9.2.0, the first release in the 9.x
+  line with the matching Windows portability fix.
 
 ### Changed
 
 - **config**: Removed the Unix-only `xdg` dependency. Unix configuration still
   follows `XDG_CONFIG_HOME` with the same `$HOME/.config` fallback, while
   `recommended_path` no longer creates directories as a side effect.
+- **security**: Updated the locked `h2` version to 0.4.16, fixing
+  RUSTSEC-2026-0258 (unbounded empty DATA frame buffering).
 
 ## [acton-service-v0.37.0] - 2026-08-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "acton-macro"
-version = "9.0.0"
+version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021cb5de9e92528317235055767a188f0c7e80dd72ef53c18d6bdb3c67bc7fbe"
+checksum = "3455bf95bd29e53e4df3191a632c65e28cf8aec26981583eb907001dfe39216c"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "acton-reactive"
-version = "9.0.0"
+version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cd74fcaa1fe56d0b53972661592d8aa9727095748832f5c6ce1d57c8a0600a"
+checksum = "fbfc962789188ed1574a75ddfc7dc705b7c050cae9d330e28a1c4563e85ec20f"
 dependencies = [
  "acton-ern",
  "acton-macro",
@@ -305,7 +305,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -316,7 +316,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2185,7 +2185,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2407,7 +2407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2995,9 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3369,7 +3369,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -3457,7 +3457,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4559,7 +4559,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5709,7 +5709,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5748,7 +5748,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6502,7 +6502,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6597,7 +6597,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6797,7 +6797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7147,7 +7147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7404,7 +7404,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7816,7 +7816,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7834,7 +7834,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7844,7 +7844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8214,7 +8214,7 @@ dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -9266,7 +9266,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "xdg 2.5.2",
+ "xdg",
 ]
 
 [[package]]
@@ -165,7 +165,6 @@ dependencies = [
  "uuid",
  "webpki-roots 1.0.9",
  "x509-parser",
- "xdg 3.0.0",
  "zeroize",
 ]
 
@@ -9805,12 +9804,6 @@ name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
-
-[[package]]
-name = "xdg"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yansi"

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ async fn list_products(State(state): State<AppState>) -> Result<Json<Vec<Product
 
 ### Zero-Configuration Defaults
 
-Configuration follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html):
+On Unix, configuration follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html):
 
 ```
 ~/.config/acton-service/
@@ -476,6 +476,10 @@ ACTON_SERVICE_PORT=9090 cargo run
 # Production config location
 ~/.config/acton-service/my-service/config.toml
 ```
+
+On Windows, the equivalent user configuration is
+`%APPDATA%\acton-service\my-service\config.toml`; system-wide configuration is
+loaded from `%PROGRAMDATA%\acton-service\my-service\config.toml`.
 
 **Custom Config Extensions**: Extend the framework configuration with your own application-specific fields that are automatically loaded from the same `config.toml`:
 

--- a/acton-service/Cargo.toml
+++ b/acton-service/Cargo.toml
@@ -87,9 +87,6 @@ async-trait = { workspace = true }
 
 # HTTP types
 http = { workspace = true }
-
-# Other dependencies
-xdg = "3.0.0"
 utoipa = { version = "5.4.0", features = ["axum_extras"], optional = true }
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum"], optional = true }
 tonic-health = { version = "0.14.2", optional = true }

--- a/acton-service/Cargo.toml
+++ b/acton-service/Cargo.toml
@@ -97,7 +97,7 @@ tower-resilience-bulkhead = { workspace = true, optional = true }
 cedar-policy = { version = "4.7.0", default-features = false, features = ["datetime", "ipaddr"], optional = true }
 regex = "1.12.2"
 mti = "1.0.0"
-acton-reactive = "9.0.0"
+acton-reactive = "9.2.0"
 tokio-util = "0.7.17"
 dashmap = "6.1.0"
 anyhow.workspace = true

--- a/acton-service/src/config.rs
+++ b/acton-service/src/config.rs
@@ -3,8 +3,8 @@
 //! Configuration is loaded from multiple sources with the following precedence (highest to lowest):
 //! 1. Environment variables (prefix: ACTON_)
 //! 2. Current working directory: ./config.toml
-//! 3. XDG config directory: ~/.config/acton-service/{service_name}/config.toml
-//! 4. System directory: /etc/acton-service/{service_name}/config.toml
+//! 3. Platform user config directory (`XDG_CONFIG_HOME` on Unix, `APPDATA` on Windows)
+//! 4. Platform system directory (`/etc` on Unix, `PROGRAMDATA` on Windows)
 //! 5. Default values
 
 use figment::{
@@ -13,7 +13,7 @@ use figment::{
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::error::Result;
@@ -1806,6 +1806,77 @@ fn default_cedar_policy_cache_ttl() -> u64 {
     300 // Cache for 5 minutes
 }
 
+#[cfg(unix)]
+fn platform_user_config_root(
+    xdg_config_home: Option<PathBuf>,
+    home: Option<PathBuf>,
+) -> Option<PathBuf> {
+    xdg_config_home
+        .filter(|path| path.is_absolute())
+        .or_else(|| home.map(|path| path.join(".config")))
+}
+
+#[cfg(windows)]
+fn platform_user_config_root(
+    app_data: Option<PathBuf>,
+    profile: Option<PathBuf>,
+) -> Option<PathBuf> {
+    app_data.or_else(|| profile.map(|path| path.join("AppData").join("Roaming")))
+}
+
+#[cfg(unix)]
+fn user_config_root() -> Option<PathBuf> {
+    platform_user_config_root(
+        std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from),
+        std::env::var_os("HOME").map(PathBuf::from),
+    )
+}
+
+#[cfg(windows)]
+fn user_config_root() -> Option<PathBuf> {
+    platform_user_config_root(
+        std::env::var_os("APPDATA").map(PathBuf::from),
+        std::env::var_os("USERPROFILE").map(PathBuf::from),
+    )
+}
+
+#[cfg(not(any(unix, windows)))]
+fn user_config_root() -> Option<PathBuf> {
+    None
+}
+
+fn user_config_path(service_name: &str) -> Option<PathBuf> {
+    user_config_root().map(|root| {
+        root.join("acton-service")
+            .join(service_name)
+            .join("config.toml")
+    })
+}
+
+#[cfg(unix)]
+fn system_config_path(service_name: &str) -> Option<PathBuf> {
+    Some(
+        PathBuf::from("/etc/acton-service")
+            .join(service_name)
+            .join("config.toml"),
+    )
+}
+
+#[cfg(windows)]
+fn system_config_path(service_name: &str) -> Option<PathBuf> {
+    std::env::var_os("PROGRAMDATA").map(|root| {
+        PathBuf::from(root)
+            .join("acton-service")
+            .join(service_name)
+            .join("config.toml")
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn system_config_path(_service_name: &str) -> Option<PathBuf> {
+    None
+}
+
 impl<T> Config<T>
 where
     T: Serialize + DeserializeOwned + Clone + Default + Send + Sync + 'static,
@@ -1814,8 +1885,8 @@ where
     ///
     /// Searches for config files in this order (first found is used):
     /// 1. Current working directory: ./config.toml
-    /// 2. XDG config directory: ~/.config/acton-service/{service_name}/config.toml
-    /// 3. System directory: /etc/acton-service/{service_name}/config.toml
+    /// 2. Platform user config directory (`XDG_CONFIG_HOME` or `APPDATA`)
+    /// 3. Platform system config directory (`/etc` or `PROGRAMDATA`)
     ///
     /// Environment variables (ACTON_ prefix) override all file-based configs.
     ///
@@ -1883,7 +1954,7 @@ where
     ///
     /// Returns paths in priority order (highest first):
     /// 1. Current working directory
-    /// 2. XDG config directory
+    /// 2. User config directory
     /// 3. System directory
     fn find_config_paths(service_name: &str) -> Vec<PathBuf> {
         let mut paths = Vec::new();
@@ -1891,20 +1962,16 @@ where
         // 1. Current working directory (highest priority for dev/testing)
         paths.push(PathBuf::from("config.toml"));
 
-        // 2. XDG config directory (~/.config/acton-service/{service_name}/config.toml)
-        // Use find_config_file instead of place_config_file to avoid creating directories
-        let xdg_dirs = xdg::BaseDirectories::with_prefix("acton-service");
-        let config_file_path = Path::new(service_name).join("config.toml");
-        if let Some(path) = xdg_dirs.find_config_file(&config_file_path) {
+        // 2. Platform user config directory. Only include an existing file so
+        // loading configuration remains side-effect free.
+        if let Some(path) = user_config_path(service_name).filter(|path| path.is_file()) {
             paths.push(path);
         }
 
-        // 3. System-wide directory (/etc/acton-service/{service_name}/config.toml)
-        paths.push(
-            PathBuf::from("/etc/acton-service")
-                .join(service_name)
-                .join("config.toml"),
-        );
+        // 3. Platform system-wide directory.
+        if let Some(path) = system_config_path(service_name) {
+            paths.push(path);
+        }
 
         paths
     }
@@ -1912,40 +1979,34 @@ where
     /// Get the recommended config path for a service
     ///
     /// This is where the config file should be placed in production.
-    /// Returns: ~/.config/acton-service/{service_name}/config.toml
+    /// On Unix this follows `XDG_CONFIG_HOME` and falls back to
+    /// `~/.config`. On Windows it follows `APPDATA` and falls back to
+    /// `%USERPROFILE%\AppData\Roaming`.
     pub fn recommended_path(service_name: &str) -> PathBuf {
-        let xdg_dirs = xdg::BaseDirectories::with_prefix("acton-service");
-        let config_file_path = Path::new(service_name).join("config.toml");
-
-        // place_config_file creates parent directories if needed
-        xdg_dirs
-            .place_config_file(&config_file_path)
-            .unwrap_or_else(|_| {
-                // Fallback to manual path construction if place_config_file fails
-                PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| String::from("~")))
-                    .join(".config/acton-service")
-                    .join(service_name)
-                    .join("config.toml")
-            })
+        user_config_path(service_name).unwrap_or_else(|| {
+            PathBuf::from("acton-service")
+                .join(service_name)
+                .join("config.toml")
+        })
     }
 
     /// Create the config directory structure for a service
     ///
-    /// Creates ~/.config/acton-service/{service_name}/ if it doesn't exist
+    /// Creates the platform user configuration directory if it doesn't exist.
     pub fn create_config_dir(service_name: &str) -> Result<PathBuf> {
-        let xdg_dirs = xdg::BaseDirectories::with_prefix("acton-service");
-        let config_file_path = Path::new(service_name).join("config.toml");
+        let config_path = Self::recommended_path(service_name);
+        let config_dir = config_path
+            .parent()
+            .ok_or_else(|| crate::error::Error::Internal("Invalid config path".to_string()))?;
 
-        // place_config_file creates all necessary parent directories
-        let config_path = xdg_dirs.place_config_file(&config_file_path).map_err(|e| {
-            crate::error::Error::Internal(format!("Failed to create config directory: {}", e))
+        std::fs::create_dir_all(config_dir).map_err(|e| {
+            crate::error::Error::Internal(format!(
+                "Failed to create config directory {}: {e}",
+                config_dir.display()
+            ))
         })?;
 
-        // Return the directory path, not the file path
-        Ok(config_path
-            .parent()
-            .ok_or_else(|| crate::error::Error::Internal("Invalid config path".to_string()))?
-            .to_path_buf())
+        Ok(config_dir.to_path_buf())
     }
 
     /// Get database URL
@@ -2074,6 +2135,53 @@ where
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[cfg(unix)]
+    #[test]
+    fn user_config_root_prefers_an_absolute_xdg_path() {
+        let root = platform_user_config_root(
+            Some(PathBuf::from("/var/lib/example-config")),
+            Some(PathBuf::from("/home/example")),
+        );
+
+        assert_eq!(root, Some(PathBuf::from("/var/lib/example-config")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn user_config_root_ignores_a_relative_xdg_path() {
+        let root = platform_user_config_root(
+            Some(PathBuf::from("relative/config")),
+            Some(PathBuf::from("/home/example")),
+        );
+
+        assert_eq!(root, Some(PathBuf::from("/home/example/.config")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn user_config_root_prefers_app_data() {
+        let root = platform_user_config_root(
+            Some(PathBuf::from(r"C:\Users\example\AppData\Roaming")),
+            Some(PathBuf::from(r"C:\Users\example")),
+        );
+
+        assert_eq!(
+            root,
+            Some(PathBuf::from(r"C:\Users\example\AppData\Roaming"))
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn user_config_root_falls_back_to_the_user_profile() {
+        let root = platform_user_config_root(None, Some(PathBuf::from(r"C:\Users\example")));
+
+        assert_eq!(
+            root,
+            Some(PathBuf::from(r"C:\Users\example\AppData\Roaming"))
+        );
+    }
 
     #[test]
     fn test_default_config() {

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,13 @@ ignore = [
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
     "RUSTSEC-2026-0104",
+    # h2 0.3.27 unbounded empty DATA frame buffering. The directly used h2
+    # line is upgraded to 0.4.16; 0.3.27 remains only through optional
+    # libsql 0.9.30 -> tonic/hyper. There is no patched 0.3.x release and the
+    # latest stable libsql still pins that stack. Turso endpoints are not
+    # exposed HTTP/2 servers, limiting this low-severity issue to a malicious
+    # or compromised upstream. Re-evaluate with the next stable libsql release.
+    "RUSTSEC-2026-0258",
 ]
 
 # Control which licenses are allowed


### PR DESCRIPTION
## Summary

- replace the direct Unix-only `xdg` dependency with platform-native configuration path resolution
- use `%APPDATA%` and `%PROGRAMDATA%` on Windows while preserving XDG behavior on Unix
- add native Windows CI for default tests, Clippy, and full-feature compilation
- document the Windows configuration locations

## Validation

- `cargo clippy -p acton-service --all-targets -- -D warnings`
- `cargo nextest run -p acton-service` (162 passed)
- `cargo check -p acton-service --all-targets --features full`
- `git diff --check`