### PR TITLE
feat(database): add Microsoft SQL Server support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,6 +214,8 @@ jobs:
         run: cargo test -p acton-service
       - name: Check full feature set
         run: cargo check -p acton-service --all-targets --features full
+      - name: Check Microsoft SQL Server feature set
+        run: cargo check -p acton-service --all-targets --no-default-features --features "mssql,http,grpc,auth,accounts,audit,observability,crypto-aws-lc-rs"
 
   # The `full` legs above cover audit with the PostgreSQL storage backend
   # (`database` is in `full`). The optional backends are mutually exclusive
@@ -249,6 +251,27 @@ jobs:
         run: cargo clippy -p acton-service --all-targets ${{ matrix.features }} -- -D warnings
       - name: Nextest
         run: cargo nextest run -p acton-service ${{ matrix.features }}
+
+  mssql:
+    name: Microsoft SQL Server parity
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: mssql
+      - uses: taiki-e/install-action@nextest
+      - name: Clippy
+        run: cargo clippy -p acton-service --all-targets --no-default-features --features "mssql,http,grpc,auth,accounts,audit,observability,crypto-aws-lc-rs" -- -D warnings
+      - name: Integration tests
+        run: cargo nextest run -p acton-service --no-default-features --features "mssql,http,grpc,auth,accounts,audit,observability,crypto-aws-lc-rs" --test mssql_integration
 
   # Lint-only legs for feature combinations no test job compiles. `--all-features`
   # cannot stand in for these: the crate's mutual-exclusion `compile_error!`
@@ -365,7 +388,7 @@ jobs:
   # those PRs, because a skipped job reports nothing at all.
   ci-gate:
     name: ci-gate
-    needs: [changes, aws-lc-rs, ring, windows, audit-storage, feature-combos, docs-build]
+    needs: [changes, aws-lc-rs, ring, windows, audit-storage, mssql, feature-combos, docs-build]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **database(mssql)**: Added first-class Microsoft SQL Server support through
+  Tiberius and bb8, including agent-managed pooling, retries, readiness and
+  gRPC health checks, pool telemetry, accounts, API keys, refresh tokens,
+  signing-key rotation, and append-only audit storage. SQL Server integration
+  tests run against SQL Server 2022 in CI.
+- **database(postgres)**: Added `postgres` as a descriptive compatibility alias
+  for the existing `database` feature. Existing `database` users are unchanged.
+
 - **platforms**: Native Windows configuration discovery now uses `%APPDATA%`
   for per-user configuration and `%PROGRAMDATA%` for system-wide configuration.
   Windows builds are compiled and tested in CI alongside the existing Linux

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,8 @@ dependencies = [
  "axum 0.8.9",
  "axum-htmx",
  "base64 0.22.1",
+ "bb8",
+ "bb8-tiberius",
  "blake3",
  "bytes",
  "cedar-policy",
@@ -137,7 +139,9 @@ dependencies = [
  "sqlx",
  "surrealdb",
  "tempfile",
+ "testcontainers-modules",
  "thiserror 2.0.18",
+ "tiberius",
  "time",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -305,7 +309,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -316,7 +320,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -535,6 +539,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463"
+dependencies = [
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash 2.1.2",
+ "rustix 1.1.4",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +694,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-native-tls"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d57d4cec3c647232e1094dc013546c0b33ce785d8aeb251e1f20dfaf8a9a13fe"
+dependencies = [
+ "futures-util",
+ "native-tls",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "async-nats"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +772,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -960,6 +1005,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +1023,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bb8"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457d7ed3f888dfd2c7af56d4975cade43c622f74bdcddfed6d4352f57acc6310"
+dependencies = [
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "tokio",
+]
+
+[[package]]
+name = "bb8-tiberius"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a5023b318f47a294d02b46ce0d82ac8e7df0afce2257f041ba7316566d6cd56"
+dependencies = [
+ "bb8",
+ "thiserror 1.0.69",
+ "tiberius",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1152,6 +1228,80 @@ name = "bnum"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
+
+[[package]]
+name = "bollard"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
+dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "bitflags 2.11.1",
+ "bollard-buildkit-proto",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-named-pipe",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "num",
+ "pin-project-lite",
+ "rand 0.9.4",
+ "rustls 0.23.40",
+ "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic 0.14.6",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-buildkit-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
+dependencies = [
+ "prost 0.14.3",
+ "prost-types",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.52.1-rc.29.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-buildkit-proto",
+ "bytes",
+ "prost 0.14.3",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "time",
+]
 
 [[package]]
 name = "borsh"
@@ -1619,6 +1769,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "connection-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
 
 [[package]]
 name = "console"
@@ -2185,7 +2341,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2207,6 +2363,17 @@ checksum = "bb2dfc7a18dffd3ef60a442b72a827126f1557d914620f8fc4d1049916da43c1"
 dependencies = [
  "trice",
  "urlencoding",
+]
+
+[[package]]
+name = "docker_credential"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2384,6 +2551,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,7 +2594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2419,6 +2606,16 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2498,6 +2695,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ferroid"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
+dependencies = [
+ "portable-atomic",
+ "rand 0.10.1",
+ "web-time",
+]
 
 [[package]]
 name = "ff"
@@ -2607,6 +2815,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2893,6 +3116,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -2900,7 +3134,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -3382,6 +3616,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fab3637d6b04a8037af8a266fdf6cf92ea957e8c53981a2bf6136572531025bf"
+dependencies = [
+ "hex",
+ "hyper 1.9.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3457,10 +3705,25 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -4315,6 +4578,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4398,7 +4667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -4434,6 +4703,23 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.2.1",
+ "openssl-sys",
+ "schannel",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "ndarray"
@@ -4559,7 +4845,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4569,6 +4855,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
 dependencies = [
  "rand 0.8.6",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -4645,6 +4945,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
 dependencies = [
  "num-modular",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -4800,6 +5111,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4810,6 +5146,18 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -5046,6 +5394,31 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5453,6 +5826,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty-hex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5679,7 +6058,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -5709,7 +6088,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5748,7 +6127,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5793,6 +6172,19 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
@@ -5825,6 +6217,16 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -5841,6 +6243,15 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -5866,6 +6277,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
 
 [[package]]
 name = "rand_pcg"
@@ -6502,7 +6922,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6597,7 +7017,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6797,7 +7217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7147,7 +7567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7336,7 +7756,7 @@ dependencies = [
  "chrono",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -7404,7 +7824,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7493,6 +7913,29 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "strum"
@@ -7816,7 +8259,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7834,7 +8277,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7844,7 +8287,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
+dependencies = [
+ "astral-tokio-tar",
+ "async-trait",
+ "bollard",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera 0.11.0",
+ "ferroid",
+ "futures",
+ "http 1.4.0",
+ "itertools 0.14.0",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5985fde5befe4ffa77a052e035e16c2da86e8bae301baa9f9904ad3c494d357"
+dependencies = [
+ "testcontainers",
 ]
 
 [[package]]
@@ -7894,6 +8377,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiberius"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1446cb4198848d1562301a3340424b4f425ef79f35ef9ee034769a9dd92c10d"
+dependencies = [
+ "async-native-tls",
+ "async-trait",
+ "asynchronous-codec",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "connection-string",
+ "encoding_rs",
+ "enumflags2",
+ "futures-util",
+ "num-traits",
+ "once_cell",
+ "pin-project-lite",
+ "pretty-hex",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "winauth",
 ]
 
 [[package]]
@@ -8875,6 +9386,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64 0.23.1",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64 0.23.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8898,6 +9436,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -9016,6 +9560,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -9266,7 +9816,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9274,6 +9824,19 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winauth"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f820cd208ce9c6b050812dc2d724ba98c6c1e9db5ce9b3f58d925ae5723a5e6"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "md5",
+ "rand 0.7.3",
+ "winapi",
+]
 
 [[package]]
 name = "windows"
@@ -9797,6 +10360,16 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ acton-service provides a **batteries-included, type-enforced framework** where p
 - **Security & compliance built-in** - BLAKE3 hash-chained audit logging, login lockout, NIST AC-2 account lifecycle, FIPS 140-3 capable crypto
 - **Production observability** - OpenTelemetry tracing, metrics, and structured logging built-in
 - **Resilience patterns** - Circuit breaker, retry logic, and bulkhead patterns included
-- **Multi-database support** - PostgreSQL, Turso/libsql, SurrealDB, plus ClickHouse for analytics
+- **Multi-database support** - PostgreSQL, Microsoft SQL Server, Turso/libsql, SurrealDB, plus ClickHouse for analytics
 - **Zero-config defaults** - XDG-compliant configuration with sensible production defaults and custom config extensions
 - **Kubernetes-ready** - Automatic health/readiness probes for orchestration
 
@@ -425,7 +425,8 @@ Enable `htmx-full` (htmx + askama + sse + in-memory sessions) and you have every
 
 Choose exactly one primary database backend (enforced at compile time), and optionally add ClickHouse for analytics:
 
-- **PostgreSQL** (`database`) - SQLx with compile-time checked queries ([guide](https://govcraft.github.io/acton-service/docs/database))
+- **PostgreSQL** (`database` or `postgres`) - SQLx with compile-time checked queries ([guide](https://govcraft.github.io/acton-service/docs/database))
+- **Microsoft SQL Server** (`mssql`) - Tiberius with bb8 pooling, including auth and audit storage parity
 - **Turso / libsql** (`turso`) - Edge-replicated SQLite ([guide](https://govcraft.github.io/acton-service/docs/turso))
 - **SurrealDB** (`surrealdb`) - Multi-model database
 - **ClickHouse** (`clickhouse`) - Analytical database, composable with any primary backend ([guide](https://govcraft.github.io/acton-service/docs/clickhouse))
@@ -526,7 +527,9 @@ acton-service = { version = "0.37", features = ["grpc", "database", "cache"] }
 
 | Feature | Description |
 |---|---|
-| `database` | PostgreSQL via SQLx |
+| `database` | PostgreSQL via SQLx (backward-compatible feature name) |
+| `postgres` | PostgreSQL via SQLx (alias for `database`) |
+| `mssql` | Microsoft SQL Server via Tiberius and bb8 |
 | `turso` | Turso / libsql |
 | `surrealdb` | SurrealDB |
 | `clickhouse` | ClickHouse analytics (composable with any primary backend) |

--- a/acton-service/Cargo.toml
+++ b/acton-service/Cargo.toml
@@ -139,6 +139,9 @@ hyper-util = { version = "0.1.20", features = ["tokio"], optional = true }
 # signature-checking features (`verify`, `verify-aws`) stay off and no second
 # crypto provider is pulled in.
 x509-parser = { version = "0.18.1", optional = true }
+bb8 = { version = "0.9.1", optional = true }
+bb8-tiberius = { version = "0.16.0", optional = true }
+tiberius = { version = "0.12.3", features = ["chrono"], optional = true }
 
 [features]
 default = ["http", "observability", "crypto-aws-lc-rs"]
@@ -167,6 +170,8 @@ crypto-ring = [
 http = []
 grpc = ["dep:tonic", "dep:prost", "dep:tonic-prost", "dep:tonic-prost-build", "dep:tokio-stream", "dep:tonic-health", "dep:tonic-reflection", "dep:hyper-util"]
 database = ["dep:sqlx"]
+postgres = ["database"]
+mssql = ["dep:bb8", "dep:bb8-tiberius", "dep:tiberius"]
 turso = ["dep:libsql"]
 surrealdb = ["dep:surrealdb"]
 cache = ["dep:redis", "dep:deadpool-redis"]
@@ -256,7 +261,6 @@ graphql = ["dep:async-graphql", "dep:async-graphql-axum", "dep:bytes"]
 # GraphQL with Cedar policy authorization callable from resolvers via
 # `acton_service::graphql::CedarResolverCheck`.
 graphql-cedar = ["graphql", "cedar-authz"]
-
 # Basic examples
 [[example]]
 name = "simple-api"
@@ -344,3 +348,4 @@ tonic-prost-build.workspace = true
 [dev-dependencies]
 rcgen = "0.14.8"
 tempfile = "3.24.0"
+testcontainers-modules = { version = "0.15.0", features = ["mssql_server"] }

--- a/acton-service/src/accounts/storage/mod.rs
+++ b/acton-service/src/accounts/storage/mod.rs
@@ -17,6 +17,9 @@ use crate::error::Error;
 #[cfg(feature = "database")]
 pub mod pg;
 
+#[cfg(feature = "mssql")]
+pub mod mssql;
+
 #[cfg(feature = "turso")]
 pub mod turso;
 

--- a/acton-service/src/accounts/storage/mssql.rs
+++ b/acton-service/src/accounts/storage/mssql.rs
@@ -1,0 +1,181 @@
+//! Microsoft SQL Server account storage.
+use super::AccountStorage;
+use crate::{
+    accounts::types::{Account, AccountId, AccountStatus},
+    error::Error,
+    mssql::{execute, query, MssqlPool},
+};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+/// SQL Server-backed account storage.
+pub struct MssqlAccountStorage {
+    pool: MssqlPool,
+}
+impl MssqlAccountStorage {
+    /// Creates storage and initializes its schema.
+    pub async fn new(pool: MssqlPool) -> Result<Self, Error> {
+        execute(&pool,"IF OBJECT_ID(N'accounts',N'U') IS NULL CREATE TABLE accounts(id NVARCHAR(255) PRIMARY KEY,email NVARCHAR(255) NOT NULL UNIQUE,username NVARCHAR(255) NULL,password_hash NVARCHAR(MAX) NULL,status NVARCHAR(32) NOT NULL,roles NVARCHAR(MAX) NOT NULL,email_verified BIT NOT NULL,email_verified_at DATETIMEOFFSET NULL,last_login_at DATETIMEOFFSET NULL,locked_at DATETIMEOFFSET NULL,locked_reason NVARCHAR(MAX) NULL,disabled_at DATETIMEOFFSET NULL,disabled_reason NVARCHAR(MAX) NULL,expires_at DATETIMEOFFSET NULL,password_changed_at DATETIMEOFFSET NULL,failed_login_count INT NOT NULL,metadata NVARCHAR(MAX) NULL,created_at DATETIMEOFFSET NOT NULL,updated_at DATETIMEOFFSET NOT NULL)",&[]).await?;
+        Ok(Self { pool })
+    }
+}
+fn text(row: &tiberius::Row, name: &str) -> Result<String, Error> {
+    row.get::<&str, _>(name)
+        .map(str::to_owned)
+        .ok_or_else(|| Error::Internal(format!("missing {name}")))
+}
+fn decode(row: &tiberius::Row) -> Result<Account, Error> {
+    let id = text(row, "id")?
+        .parse::<AccountId>()
+        .map_err(|error| Error::Internal(error.to_string()))?;
+    let status = text(row, "status")?
+        .parse::<AccountStatus>()
+        .map_err(|error| Error::Internal(error.to_string()))?;
+    Ok(Account {
+        id,
+        email: text(row, "email")?,
+        username: row.get::<&str, _>("username").map(str::to_owned),
+        password_hash: row.get::<&str, _>("password_hash").map(str::to_owned),
+        status,
+        roles: serde_json::from_str(text(row, "roles")?.as_str()).unwrap_or_default(),
+        email_verified: row.get("email_verified").unwrap_or(false),
+        email_verified_at: row.get("email_verified_at"),
+        last_login_at: row.get("last_login_at"),
+        locked_at: row.get("locked_at"),
+        locked_reason: row.get::<&str, _>("locked_reason").map(str::to_owned),
+        disabled_at: row.get("disabled_at"),
+        disabled_reason: row.get::<&str, _>("disabled_reason").map(str::to_owned),
+        expires_at: row.get("expires_at"),
+        password_changed_at: row.get("password_changed_at"),
+        failed_login_count: row.get::<i32, _>("failed_login_count").unwrap_or(0) as u32,
+        metadata: row
+            .get::<&str, _>("metadata")
+            .and_then(|value| serde_json::from_str(value).ok()),
+        created_at: row
+            .get("created_at")
+            .ok_or_else(|| Error::Internal("missing created_at".to_string()))?,
+        updated_at: row
+            .get("updated_at")
+            .ok_or_else(|| Error::Internal("missing updated_at".to_string()))?,
+    })
+}
+async fn one(pool: &MssqlPool, sql: &str, param: &str) -> Result<Option<Account>, Error> {
+    query(pool, sql, &[&param])
+        .await?
+        .first()
+        .map(decode)
+        .transpose()
+}
+#[async_trait]
+impl AccountStorage for MssqlAccountStorage {
+    async fn create(&self, a: &Account) -> Result<(), Error> {
+        let roles = serde_json::to_string(&a.roles).map_err(|e| Error::Internal(e.to_string()))?;
+        let metadata = a
+            .metadata
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| Error::Internal(e.to_string()))?;
+        let status = a.status.to_string();
+        let failed = a.failed_login_count as i32;
+        execute(&self.pool,"INSERT INTO accounts(id,email,username,password_hash,status,roles,email_verified,email_verified_at,last_login_at,locked_at,locked_reason,disabled_at,disabled_reason,expires_at,password_changed_at,failed_login_count,metadata,created_at,updated_at) VALUES(@P1,@P2,@P3,@P4,@P5,@P6,@P7,@P8,@P9,@P10,@P11,@P12,@P13,@P14,@P15,@P16,@P17,@P18,@P19)",&[&a.id.as_str(),&a.email,&a.username,&a.password_hash,&status,&roles,&a.email_verified,&a.email_verified_at,&a.last_login_at,&a.locked_at,&a.locked_reason,&a.disabled_at,&a.disabled_reason,&a.expires_at,&a.password_changed_at,&failed,&metadata,&a.created_at,&a.updated_at]).await?;
+        Ok(())
+    }
+    async fn get_by_id(&self, id: &str) -> Result<Option<Account>, Error> {
+        one(&self.pool, "SELECT * FROM accounts WHERE id=@P1", id).await
+    }
+    async fn get_by_email(&self, email: &str) -> Result<Option<Account>, Error> {
+        one(&self.pool, "SELECT * FROM accounts WHERE email=@P1", email).await
+    }
+    async fn get_by_username(&self, username: &str) -> Result<Option<Account>, Error> {
+        one(
+            &self.pool,
+            "SELECT * FROM accounts WHERE username=@P1",
+            username,
+        )
+        .await
+    }
+    async fn update(&self, a: &Account) -> Result<(), Error> {
+        let roles = serde_json::to_string(&a.roles).map_err(|e| Error::Internal(e.to_string()))?;
+        let metadata = a
+            .metadata
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| Error::Internal(e.to_string()))?;
+        let status = a.status.to_string();
+        let failed = a.failed_login_count as i32;
+        let now = Utc::now();
+        execute(&self.pool,"UPDATE accounts SET email=@P2,username=@P3,password_hash=@P4,status=@P5,roles=@P6,email_verified=@P7,email_verified_at=@P8,last_login_at=@P9,locked_at=@P10,locked_reason=@P11,disabled_at=@P12,disabled_reason=@P13,expires_at=@P14,password_changed_at=@P15,failed_login_count=@P16,metadata=@P17,updated_at=@P18 WHERE id=@P1",&[&a.id.as_str(),&a.email,&a.username,&a.password_hash,&status,&roles,&a.email_verified,&a.email_verified_at,&a.last_login_at,&a.locked_at,&a.locked_reason,&a.disabled_at,&a.disabled_reason,&a.expires_at,&a.password_changed_at,&failed,&metadata,&now]).await?;
+        Ok(())
+    }
+    async fn update_status(
+        &self,
+        id: &str,
+        status: AccountStatus,
+        reason: Option<&str>,
+    ) -> Result<(), Error> {
+        let now = Utc::now();
+        let value = status.to_string();
+        let sql=match status{AccountStatus::Disabled=>"UPDATE accounts SET status=@P2,disabled_at=@P3,disabled_reason=@P4,updated_at=@P3 WHERE id=@P1",AccountStatus::Locked=>"UPDATE accounts SET status=@P2,locked_at=@P3,locked_reason=@P4,updated_at=@P3 WHERE id=@P1",AccountStatus::Active=>"UPDATE accounts SET status=@P2,locked_at=NULL,locked_reason=NULL,disabled_at=NULL,disabled_reason=NULL,updated_at=@P3 WHERE id=@P1",_=>"UPDATE accounts SET status=@P2,updated_at=@P3 WHERE id=@P1"};
+        execute(&self.pool, sql, &[&id, &value, &now, &reason]).await?;
+        Ok(())
+    }
+    async fn list(
+        &self,
+        status: Option<AccountStatus>,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<Account>, Error> {
+        let limit = limit as i64;
+        let offset = offset as i64;
+        let rows = if let Some(status) = status {
+            let value = status.to_string();
+            query(&self.pool,"SELECT * FROM accounts WHERE status=@P1 ORDER BY created_at DESC OFFSET @P2 ROWS FETCH NEXT @P3 ROWS ONLY",&[&value,&offset,&limit]).await?
+        } else {
+            query(&self.pool,"SELECT * FROM accounts ORDER BY created_at DESC OFFSET @P1 ROWS FETCH NEXT @P2 ROWS ONLY",&[&offset,&limit]).await?
+        };
+        rows.iter().map(decode).collect()
+    }
+    async fn count(&self, status: Option<AccountStatus>) -> Result<u64, Error> {
+        let rows = if let Some(status) = status {
+            let value = status.to_string();
+            query(
+                &self.pool,
+                "SELECT COUNT_BIG(*) AS count FROM accounts WHERE status=@P1",
+                &[&value],
+            )
+            .await?
+        } else {
+            query(
+                &self.pool,
+                "SELECT COUNT_BIG(*) AS count FROM accounts",
+                &[],
+            )
+            .await?
+        };
+        Ok(rows
+            .first()
+            .and_then(|r| r.get::<i64, _>("count"))
+            .unwrap_or(0) as u64)
+    }
+    async fn delete(&self, id: &str) -> Result<bool, Error> {
+        Ok(execute(&self.pool, "DELETE FROM accounts WHERE id=@P1", &[&id]).await? > 0)
+    }
+    async fn record_login(&self, id: &str) -> Result<(), Error> {
+        execute(&self.pool,"UPDATE accounts SET last_login_at=SYSDATETIMEOFFSET(),failed_login_count=0,updated_at=SYSDATETIMEOFFSET() WHERE id=@P1",&[&id]).await?;
+        Ok(())
+    }
+    async fn find_expired(&self, limit: usize) -> Result<Vec<Account>, Error> {
+        let limit = limit as i64;
+        query(&self.pool,"SELECT TOP (@P1) * FROM accounts WHERE expires_at<SYSDATETIMEOFFSET() AND status<>'expired' ORDER BY expires_at",&[&limit]).await?.iter().map(decode).collect()
+    }
+    async fn find_inactive(
+        &self,
+        cutoff: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Account>, Error> {
+        let limit = limit as i64;
+        query(&self.pool,"SELECT TOP (@P2) * FROM accounts WHERE status='active' AND (last_login_at IS NULL OR last_login_at<@P1) ORDER BY CASE WHEN last_login_at IS NULL THEN 0 ELSE 1 END,last_login_at",&[&cutoff,&limit]).await?.iter().map(decode).collect()
+    }
+}

--- a/acton-service/src/agents/messages.rs
+++ b/acton-service/src/agents/messages.rs
@@ -88,6 +88,20 @@ pub(crate) struct DatabasePoolConnectionFailed {
     pub error: String,
 }
 
+/// Internal message sent when the SQL Server pool connects successfully.
+#[cfg(feature = "mssql")]
+#[derive(Clone, Debug)]
+pub(crate) struct MssqlPoolConnected {
+    pub pool: crate::mssql::MssqlPool,
+}
+
+/// Internal message sent when the SQL Server pool connection fails.
+#[cfg(feature = "mssql")]
+#[derive(Clone, Debug, Default)]
+pub(crate) struct MssqlPoolConnectionFailed {
+    pub error: String,
+}
+
 /// Internal message sent when a Redis pool connects successfully
 #[cfg(feature = "cache")]
 #[derive(Clone, Debug)]

--- a/acton-service/src/agents/mod.rs
+++ b/acton-service/src/agents/mod.rs
@@ -45,6 +45,9 @@ pub use messages::{
 #[cfg(feature = "database")]
 pub(crate) use pool::{DatabasePoolAgent, SharedDbPool};
 
+#[cfg(feature = "mssql")]
+pub(crate) use pool::{MssqlPoolAgent, SharedMssqlPool};
+
 #[cfg(feature = "cache")]
 pub(crate) use pool::{RedisPoolAgent, SharedRedisPool};
 

--- a/acton-service/src/agents/pool.rs
+++ b/acton-service/src/agents/pool.rs
@@ -43,7 +43,8 @@
     feature = "events",
     feature = "turso",
     feature = "surrealdb",
-    feature = "clickhouse"
+    feature = "clickhouse",
+    feature = "mssql"
 ))]
 use super::messages::{GetPoolHealth, WaitForPoolReady};
 
@@ -58,7 +59,8 @@ use super::messages::{GetPoolHealth, WaitForPoolReady};
     feature = "events",
     feature = "turso",
     feature = "surrealdb",
-    feature = "clickhouse"
+    feature = "clickhouse",
+    feature = "mssql"
 ))]
 fn pool_health(
     name: &str,
@@ -83,6 +85,133 @@ fn pool_health(
         name: name.to_string(),
         status,
         message,
+    }
+}
+
+// ============================================================================
+// Microsoft SQL Server Pool Agent
+// ============================================================================
+
+#[cfg(feature = "mssql")]
+use super::messages::{MssqlPoolConnected, MssqlPoolConnectionFailed};
+#[cfg(all(feature = "mssql", not(feature = "database")))]
+use acton_reactive::prelude::*;
+#[cfg(all(feature = "mssql", not(feature = "database")))]
+use std::sync::Arc;
+#[cfg(all(feature = "mssql", not(feature = "database")))]
+use tokio::sync::RwLock;
+#[cfg(all(feature = "mssql", not(feature = "database")))]
+use tokio_util::sync::CancellationToken;
+
+#[cfg(feature = "mssql")]
+pub type SharedMssqlPool = Arc<RwLock<Option<crate::mssql::MssqlPool>>>;
+
+#[cfg(feature = "mssql")]
+#[derive(Debug, Default)]
+pub struct MssqlPoolState {
+    pub pool: Option<crate::mssql::MssqlPool>,
+    pub config: Option<crate::config::DatabaseConfig>,
+    pub connecting: bool,
+    pub shared_pool: Option<SharedMssqlPool>,
+    pub last_error: Option<String>,
+    pub(crate) ready_waiters: Vec<OutboundEnvelope>,
+    pub cancel_token: Option<CancellationToken>,
+}
+
+/// Agent-managed Microsoft SQL Server pool lifecycle.
+#[cfg(feature = "mssql")]
+pub struct MssqlPoolAgent;
+
+#[cfg(feature = "mssql")]
+impl MssqlPoolAgent {
+    pub async fn spawn(
+        runtime: &mut ActorRuntime,
+        config: crate::config::DatabaseConfig,
+        shared_pool: Option<SharedMssqlPool>,
+    ) -> anyhow::Result<ActorHandle> {
+        let mut agent = runtime.new_actor::<MssqlPoolState>();
+        agent.model.config = Some(config);
+        agent.model.connecting = true;
+        agent.model.shared_pool = shared_pool;
+        agent.model.cancel_token = Some(CancellationToken::new());
+        agent.mutate_on::<MssqlPoolConnected>(|agent, envelope| {
+            let pool = envelope.message().pool.clone();
+            agent.model.pool = Some(pool.clone());
+            agent.model.connecting = false;
+            agent.model.last_error = None;
+            let shared = agent.model.shared_pool.clone();
+            let waiters = std::mem::take(&mut agent.model.ready_waiters);
+            let health = pool_health("mssql", true, false, None);
+            Reply::pending(async move {
+                if let Some(shared) = shared {
+                    *shared.write().await = Some(pool);
+                }
+                for waiter in waiters {
+                    waiter.send(health.clone()).await;
+                }
+            })
+        });
+        agent.mutate_on::<MssqlPoolConnectionFailed>(|agent, envelope| {
+            agent.model.connecting = false;
+            agent.model.last_error = Some(envelope.message().error.clone());
+            let waiters = std::mem::take(&mut agent.model.ready_waiters);
+            let health = pool_health("mssql", false, false, agent.model.last_error.as_deref());
+            Reply::pending(async move {
+                for waiter in waiters {
+                    waiter.send(health.clone()).await;
+                }
+            })
+        });
+        agent.mutate_on::<WaitForPoolReady>(|agent, envelope| {
+            let reply = envelope.reply_envelope();
+            if agent.model.connecting {
+                agent.model.ready_waiters.push(reply);
+                return Reply::ready();
+            }
+            let health = pool_health(
+                "mssql",
+                agent.model.pool.is_some(),
+                false,
+                agent.model.last_error.as_deref(),
+            );
+            Reply::pending(async move {
+                reply.send(health).await;
+            })
+        });
+        agent.act_on::<GetPoolHealth>(|agent, envelope| {
+            let reply = envelope.reply_envelope();
+            let health = pool_health(
+                "mssql",
+                agent.model.pool.is_some(),
+                agent.model.connecting,
+                agent.model.last_error.as_deref(),
+            );
+            Reply::pending(async move {
+                reply.send(health).await;
+            })
+        });
+        agent.after_start(|agent| {
+            let config = agent.model.config.clone();
+            let token = agent.model.cancel_token.clone();
+            let handle = agent.handle().clone();
+            if let Some(config) = config { tokio::spawn(async move {
+                tokio::select! {
+                    () = async { if let Some(token) = token { token.cancelled().await } } => handle.send(MssqlPoolConnectionFailed { error: "connection cancelled during shutdown".to_string() }).await,
+                    result = crate::mssql::create_pool(&config) => match result {
+                        Ok(pool) => handle.send(MssqlPoolConnected { pool }).await,
+                        Err(error) => handle.send(MssqlPoolConnectionFailed { error: error.to_string() }).await,
+                    }
+                }
+            }); }
+            Reply::ready()
+        });
+        agent.before_stop(|agent| {
+            if let Some(token) = &agent.model.cancel_token {
+                token.cancel();
+            }
+            Reply::ready()
+        });
+        Ok(agent.start().await)
     }
 }
 

--- a/acton-service/src/audit/storage/mod.rs
+++ b/acton-service/src/audit/storage/mod.rs
@@ -20,12 +20,16 @@ use crate::error::Error;
     feature = "database",
     feature = "turso",
     feature = "surrealdb",
-    feature = "clickhouse"
+    feature = "clickhouse",
+    feature = "mssql"
 ))]
 pub(crate) mod lazy;
 
 #[cfg(feature = "database")]
 pub mod pg;
+
+#[cfg(feature = "mssql")]
+pub mod mssql;
 
 #[cfg(feature = "turso")]
 pub mod turso;
@@ -46,7 +50,8 @@ pub mod clickhouse_impl;
     feature = "database",
     feature = "turso",
     feature = "surrealdb",
-    feature = "clickhouse"
+    feature = "clickhouse",
+    feature = "mssql"
 ))]
 pub(crate) fn looks_like_framework_kind(s: &str) -> bool {
     s.starts_with("auth.")
@@ -67,7 +72,8 @@ pub(crate) fn looks_like_framework_kind(s: &str) -> bool {
     feature = "database",
     feature = "turso",
     feature = "surrealdb",
-    feature = "clickhouse"
+    feature = "clickhouse",
+    feature = "mssql"
 ))]
 pub(crate) fn parse_custom_kind(s: &str) -> String {
     if looks_like_framework_kind(s) {

--- a/acton-service/src/audit/storage/mssql.rs
+++ b/acton-service/src/audit/storage/mssql.rs
@@ -1,0 +1,181 @@
+//! Append-only Microsoft SQL Server audit storage.
+use super::lazy::InitializableStorage;
+use super::AuditStorage;
+use crate::{
+    audit::event::{AuditEvent, AuditEventKind, AuditSeverity, AuditSource},
+    error::Error,
+    mssql::{execute, query, MssqlPool},
+};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+/// SQL Server-backed append-only audit storage.
+pub struct MssqlAuditStorage {
+    pool: MssqlPool,
+}
+impl MssqlAuditStorage {
+    pub fn new(pool: MssqlPool) -> Self {
+        Self { pool }
+    }
+    pub async fn initialize(&self) -> Result<(), Error> {
+        execute(&self.pool,"IF OBJECT_ID(N'audit_events',N'U') IS NULL CREATE TABLE audit_events(id UNIQUEIDENTIFIER PRIMARY KEY,[timestamp] DATETIMEOFFSET NOT NULL,kind NVARCHAR(255) NOT NULL,severity SMALLINT NOT NULL,source_ip NVARCHAR(255) NULL,source_user_agent NVARCHAR(MAX) NULL,source_subject NVARCHAR(255) NULL,source_request_id NVARCHAR(255) NULL,method NVARCHAR(32) NULL,path NVARCHAR(MAX) NULL,status_code SMALLINT NULL,duration_ms BIGINT NULL,service_name NVARCHAR(255) NOT NULL,metadata NVARCHAR(MAX) NULL,[hash] NVARCHAR(255) NOT NULL,previous_hash NVARCHAR(255) NULL,sequence BIGINT NOT NULL UNIQUE)",&[]).await?;
+        execute(&self.pool,"IF OBJECT_ID(N'audit_no_update',N'TR') IS NULL EXEC('CREATE TRIGGER audit_no_update ON audit_events INSTEAD OF UPDATE AS THROW 51000, ''audit events are immutable'', 1')",&[]).await?;
+        execute(&self.pool,"IF OBJECT_ID(N'audit_no_delete',N'TR') IS NULL EXEC('CREATE TRIGGER audit_no_delete ON audit_events INSTEAD OF DELETE AS THROW 51000, ''audit events are immutable'', 1')",&[]).await?;
+        Ok(())
+    }
+}
+fn req(row: &tiberius::Row, name: &str) -> Result<String, Error> {
+    row.get::<&str, _>(name)
+        .map(str::to_owned)
+        .ok_or_else(|| Error::Internal(format!("missing {name}")))
+}
+fn kind(value: &str) -> AuditEventKind {
+    match value {
+        "auth.login.success" => AuditEventKind::AuthLoginSuccess,
+        "auth.login.failed" => AuditEventKind::AuthLoginFailed,
+        "auth.token.missing" => AuditEventKind::AuthTokenMissing,
+        "auth.token.invalid" => AuditEventKind::AuthTokenInvalid,
+        "auth.logout" => AuditEventKind::AuthLogout,
+        "auth.token.refresh" => AuditEventKind::AuthTokenRefresh,
+        "auth.token.revoked" => AuditEventKind::AuthTokenRevoked,
+        "auth.password.changed" => AuditEventKind::AuthPasswordChanged,
+        "auth.apikey.created" => AuditEventKind::AuthApiKeyCreated,
+        "auth.apikey.revoked" => AuditEventKind::AuthApiKeyRevoked,
+        "auth.oauth.callback" => AuditEventKind::AuthOAuthCallback,
+        "auth.permission.denied" => AuditEventKind::AuthPermissionDenied,
+        "auth.key.rotated" => AuditEventKind::AuthKeyRotated,
+        "auth.key.retired" => AuditEventKind::AuthKeyRetired,
+        "auth.key.rotation_failed" => AuditEventKind::AuthKeyRotationFailed,
+        "config.loaded" => AuditEventKind::ConfigLoaded,
+        "config.drift_detected" => AuditEventKind::ConfigDriftDetected,
+        "http.request" => AuditEventKind::HttpRequest,
+        "http.request.denied" => AuditEventKind::HttpRequestDenied,
+        other => AuditEventKind::Custom(super::parse_custom_kind(other)),
+    }
+}
+fn decode(row: &tiberius::Row) -> Result<AuditEvent, Error> {
+    let severity = match row.get::<i16, _>("severity").unwrap_or(6) {
+        0 => AuditSeverity::Emergency,
+        1 => AuditSeverity::Alert,
+        2 => AuditSeverity::Critical,
+        3 => AuditSeverity::Error,
+        4 => AuditSeverity::Warning,
+        5 => AuditSeverity::Notice,
+        7 => AuditSeverity::Debug,
+        _ => AuditSeverity::Informational,
+    };
+    Ok(AuditEvent {
+        id: row
+            .get("id")
+            .ok_or_else(|| Error::Internal("missing id".to_string()))?,
+        timestamp: row
+            .get("timestamp")
+            .ok_or_else(|| Error::Internal("missing timestamp".to_string()))?,
+        kind: kind(&req(row, "kind")?),
+        severity,
+        source: AuditSource {
+            ip: row.get::<&str, _>("source_ip").map(str::to_owned),
+            user_agent: row.get::<&str, _>("source_user_agent").map(str::to_owned),
+            subject: row.get::<&str, _>("source_subject").map(str::to_owned),
+            request_id: row.get::<&str, _>("source_request_id").map(str::to_owned),
+        },
+        method: row.get::<&str, _>("method").map(str::to_owned),
+        path: row.get::<&str, _>("path").map(str::to_owned),
+        status_code: row.get::<i16, _>("status_code").map(|v| v as u16),
+        duration_ms: row.get::<i64, _>("duration_ms").map(|v| v as u64),
+        service_name: req(row, "service_name")?,
+        metadata: row
+            .get::<&str, _>("metadata")
+            .and_then(|v| serde_json::from_str(v).ok()),
+        hash: row.get::<&str, _>("hash").map(str::to_owned),
+        previous_hash: row.get::<&str, _>("previous_hash").map(str::to_owned),
+        sequence: row.get::<i64, _>("sequence").unwrap_or(0) as u64,
+    })
+}
+#[async_trait]
+impl AuditStorage for MssqlAuditStorage {
+    async fn append(&self, e: &AuditEvent) -> Result<(), Error> {
+        let id = e.id;
+        let kind = e.kind.to_string();
+        let severity = e.severity.as_syslog_severity() as i16;
+        let status = e.status_code.map(|v| v as i16);
+        let duration = e.duration_ms.map(|v| v as i64);
+        let metadata = e
+            .metadata
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|x| Error::Internal(x.to_string()))?;
+        let sequence = e.sequence as i64;
+        execute(&self.pool,"INSERT INTO audit_events(id,[timestamp],kind,severity,source_ip,source_user_agent,source_subject,source_request_id,method,path,status_code,duration_ms,service_name,metadata,[hash],previous_hash,sequence) VALUES(@P1,@P2,@P3,@P4,@P5,@P6,@P7,@P8,@P9,@P10,@P11,@P12,@P13,@P14,@P15,@P16,@P17)",&[&id,&e.timestamp,&kind,&severity,&e.source.ip,&e.source.user_agent,&e.source.subject,&e.source.request_id,&e.method,&e.path,&status,&duration,&e.service_name,&metadata,&e.hash,&e.previous_hash,&sequence]).await?;
+        Ok(())
+    }
+    async fn latest(&self) -> Result<Option<AuditEvent>, Error> {
+        query(
+            &self.pool,
+            "SELECT TOP (1) * FROM audit_events ORDER BY sequence DESC",
+            &[],
+        )
+        .await?
+        .first()
+        .map(decode)
+        .transpose()
+    }
+    async fn query_range(
+        &self,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<AuditEvent>, Error> {
+        let limit = limit as i64;
+        query(&self.pool,"SELECT TOP (@P3) * FROM audit_events WHERE [timestamp]>=@P1 AND [timestamp]<=@P2 ORDER BY sequence",&[&from,&to,&limit]).await?.iter().map(decode).collect()
+    }
+    async fn query_before(
+        &self,
+        cutoff: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<AuditEvent>, Error> {
+        let limit = limit as i64;
+        query(
+            &self.pool,
+            "SELECT TOP (@P2) * FROM audit_events WHERE [timestamp]<@P1 ORDER BY sequence",
+            &[&cutoff, &limit],
+        )
+        .await?
+        .iter()
+        .map(decode)
+        .collect()
+    }
+    async fn purge_before(&self, cutoff: DateTime<Utc>) -> Result<u64, Error> {
+        execute(&self.pool,"SET XACT_ABORT ON; BEGIN TRANSACTION; DISABLE TRIGGER audit_no_delete ON audit_events; DELETE FROM audit_events WHERE [timestamp]<@P1; ENABLE TRIGGER audit_no_delete ON audit_events; COMMIT TRANSACTION",&[&cutoff]).await
+    }
+    async fn verify_chain(&self, from: u64) -> Result<Option<u64>, Error> {
+        let from = from as i64;
+        let events: Vec<_> = query(
+            &self.pool,
+            "SELECT * FROM audit_events WHERE sequence>=@P1 ORDER BY sequence",
+            &[&from],
+        )
+        .await?
+        .iter()
+        .map(decode)
+        .collect::<Result<_, _>>()?;
+        Ok(crate::audit::chain::verify_chain(&events)
+            .err()
+            .map(|e| e.sequence))
+    }
+}
+
+#[async_trait]
+impl InitializableStorage for MssqlAuditStorage {
+    type Conn = MssqlPool;
+    fn from_conn(conn: Self::Conn) -> Self {
+        Self::new(conn)
+    }
+    async fn init_schema(&self) -> Result<(), Error> {
+        self.initialize().await
+    }
+    fn backend_name() -> &'static str {
+        "Microsoft SQL Server"
+    }
+}

--- a/acton-service/src/audit/wiring.rs
+++ b/acton-service/src/audit/wiring.rs
@@ -19,6 +19,8 @@ use super::storage::AuditStorage;
 pub(crate) struct AuditStorageHandles {
     #[cfg(feature = "database")]
     pub db_pool: Option<crate::agents::SharedDbPool>,
+    #[cfg(feature = "mssql")]
+    pub mssql_pool: Option<crate::agents::SharedMssqlPool>,
     #[cfg(feature = "turso")]
     pub turso_db: Option<crate::agents::SharedTursoDb>,
     #[cfg(feature = "surrealdb")]
@@ -45,6 +47,15 @@ pub(crate) fn select_audit_storage(handles: &AuditStorageHandles) -> Option<Arc<
                 super::storage::pg::PgAuditStorage,
             >::new(shared.clone())));
             tracing::debug!("Audit persistence will use PostgreSQL storage");
+        }
+    }
+
+    #[cfg(feature = "mssql")]
+    if storage.is_none() {
+        if let Some(ref shared) = handles.mssql_pool {
+            storage = Some(Arc::new(super::storage::lazy::LazyAuditStorage::<
+                super::storage::mssql::MssqlAuditStorage,
+            >::new(shared.clone())));
         }
     }
 

--- a/acton-service/src/auth/api_keys/mod.rs
+++ b/acton-service/src/auth/api_keys/mod.rs
@@ -694,6 +694,123 @@ pub mod pg_storage {
 #[cfg(feature = "database")]
 pub use pg_storage::PgApiKeyStorage;
 
+/// Microsoft SQL Server API-key storage.
+#[cfg(feature = "mssql")]
+pub mod mssql_storage {
+    use super::*;
+    use crate::mssql::{execute, query, MssqlPool};
+
+    #[derive(Clone)]
+    pub struct MssqlApiKeyStorage {
+        pool: MssqlPool,
+        generator: ApiKeyGenerator,
+    }
+    impl MssqlApiKeyStorage {
+        pub async fn new(pool: MssqlPool, prefix: impl Into<String>) -> Result<Self, Error> {
+            execute(&pool,"IF OBJECT_ID(N'api_keys',N'U') IS NULL CREATE TABLE api_keys(id NVARCHAR(255) PRIMARY KEY,user_id NVARCHAR(255) NOT NULL,name NVARCHAR(255) NOT NULL,key_prefix NVARCHAR(255) NOT NULL UNIQUE,key_hash NVARCHAR(MAX) NOT NULL,scopes NVARCHAR(MAX) NOT NULL,rate_limit INT NULL,is_revoked BIT NOT NULL,last_used_at DATETIMEOFFSET NULL,expires_at DATETIMEOFFSET NULL,created_at DATETIMEOFFSET NOT NULL)",&[]).await?;
+            Ok(Self {
+                pool,
+                generator: ApiKeyGenerator::new(prefix),
+            })
+        }
+    }
+    fn required(row: &tiberius::Row, name: &str) -> Result<String, Error> {
+        row.get::<&str, _>(name)
+            .map(str::to_owned)
+            .ok_or_else(|| Error::Internal(format!("missing {name}")))
+    }
+    fn decode(row: &tiberius::Row) -> Result<ApiKey, Error> {
+        Ok(ApiKey {
+            id: required(row, "id")?,
+            user_id: required(row, "user_id")?,
+            name: required(row, "name")?,
+            prefix: required(row, "key_prefix")?,
+            key_hash: required(row, "key_hash")?,
+            scopes: serde_json::from_str(required(row, "scopes")?.as_str()).unwrap_or_default(),
+            rate_limit: row.get::<i32, _>("rate_limit").map(|v| v as u32),
+            is_revoked: row.get("is_revoked").unwrap_or(false),
+            last_used_at: row.get("last_used_at"),
+            expires_at: row.get("expires_at"),
+            created_at: row
+                .get("created_at")
+                .ok_or_else(|| Error::Internal("missing created_at".to_string()))?,
+        })
+    }
+    #[async_trait]
+    impl ApiKeyStorage for MssqlApiKeyStorage {
+        async fn get_by_key(&self, key: &str) -> Result<Option<ApiKey>, Error> {
+            let prefix = ApiKeyGenerator::key_prefix_for_lookup(key)
+                .ok_or_else(|| Error::ValidationError("Invalid API key format".to_string()))?;
+            Ok(self.get_by_prefix(&prefix).await?.filter(|stored| {
+                self.generator
+                    .verify(key, &stored.key_hash)
+                    .unwrap_or(false)
+            }))
+        }
+        async fn get_by_prefix(&self, prefix: &str) -> Result<Option<ApiKey>, Error> {
+            query(
+                &self.pool,
+                "SELECT * FROM api_keys WHERE key_prefix=@P1",
+                &[&prefix],
+            )
+            .await?
+            .first()
+            .map(decode)
+            .transpose()
+        }
+        async fn get_by_id(&self, id: &str) -> Result<Option<ApiKey>, Error> {
+            query(&self.pool, "SELECT * FROM api_keys WHERE id=@P1", &[&id])
+                .await?
+                .first()
+                .map(decode)
+                .transpose()
+        }
+        async fn create(&self, key: &ApiKey) -> Result<(), Error> {
+            let scopes = serde_json::to_string(&key.scopes)
+                .map_err(|error| Error::Internal(error.to_string()))?;
+            let rate = key.rate_limit.map(|v| v as i32);
+            execute(&self.pool,"INSERT INTO api_keys(id,user_id,name,key_prefix,key_hash,scopes,rate_limit,is_revoked,last_used_at,expires_at,created_at) VALUES(@P1,@P2,@P3,@P4,@P5,@P6,@P7,@P8,@P9,@P10,@P11)",&[&key.id,&key.user_id,&key.name,&key.prefix,&key.key_hash,&scopes,&rate,&key.is_revoked,&key.last_used_at,&key.expires_at,&key.created_at]).await?;
+            Ok(())
+        }
+        async fn update_last_used(&self, id: &str) -> Result<(), Error> {
+            execute(
+                &self.pool,
+                "UPDATE api_keys SET last_used_at=SYSDATETIMEOFFSET() WHERE id=@P1",
+                &[&id],
+            )
+            .await?;
+            Ok(())
+        }
+        async fn revoke(&self, id: &str) -> Result<(), Error> {
+            execute(
+                &self.pool,
+                "UPDATE api_keys SET is_revoked=1 WHERE id=@P1",
+                &[&id],
+            )
+            .await?;
+            Ok(())
+        }
+        async fn list_by_user(&self, user_id: &str) -> Result<Vec<ApiKey>, Error> {
+            query(
+                &self.pool,
+                "SELECT * FROM api_keys WHERE user_id=@P1 ORDER BY created_at DESC",
+                &[&user_id],
+            )
+            .await?
+            .iter()
+            .map(decode)
+            .collect()
+        }
+        async fn delete(&self, id: &str) -> Result<(), Error> {
+            execute(&self.pool, "DELETE FROM api_keys WHERE id=@P1", &[&id]).await?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(feature = "mssql")]
+pub use mssql_storage::MssqlApiKeyStorage;
+
 /// Turso/libsql-based API key storage
 #[cfg(feature = "turso")]
 pub mod turso_storage {

--- a/acton-service/src/auth/key_rotation/mod.rs
+++ b/acton-service/src/auth/key_rotation/mod.rs
@@ -38,6 +38,8 @@ pub use key_metadata::{
 pub use manager::{CachedKey, KeyManager};
 pub use storage::KeyRotationStorage;
 
+#[cfg(feature = "mssql")]
+pub use storage::mssql::MssqlKeyRotationStorage;
 #[cfg(feature = "database")]
 pub use storage::pg::PgKeyRotationStorage;
 

--- a/acton-service/src/auth/key_rotation/storage/mod.rs
+++ b/acton-service/src/auth/key_rotation/storage/mod.rs
@@ -20,6 +20,9 @@ use crate::error::Error;
 #[cfg(feature = "database")]
 pub mod pg;
 
+#[cfg(feature = "mssql")]
+pub mod mssql;
+
 #[cfg(feature = "turso")]
 pub mod turso;
 

--- a/acton-service/src/auth/key_rotation/storage/mssql.rs
+++ b/acton-service/src/auth/key_rotation/storage/mssql.rs
@@ -1,0 +1,108 @@
+//! Microsoft SQL Server signing-key storage.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use super::KeyRotationStorage;
+use crate::{
+    auth::key_rotation::key_metadata::{KeyFormat, KeyStatus, SigningKeyMetadata},
+    error::Error,
+    mssql::{execute, query, MssqlPool},
+};
+
+/// SQL Server-backed signing-key storage.
+pub struct MssqlKeyRotationStorage {
+    pool: MssqlPool,
+}
+
+impl MssqlKeyRotationStorage {
+    /// Creates storage backed by the supplied pool.
+    pub fn new(pool: MssqlPool) -> Self {
+        Self { pool }
+    }
+}
+
+fn text(row: &tiberius::Row, name: &str) -> Result<String, Error> {
+    row.get::<&str, _>(name)
+        .map(str::to_owned)
+        .ok_or_else(|| Error::Internal(format!("SQL Server returned NULL for {name}")))
+}
+
+fn decode(row: &tiberius::Row) -> Result<SigningKeyMetadata, Error> {
+    let format = text(row, "format")?
+        .parse::<KeyFormat>()
+        .map_err(|error| Error::Internal(error.to_string()))?;
+    let status = text(row, "status")?
+        .parse::<KeyStatus>()
+        .map_err(|error| Error::Internal(error.to_string()))?;
+    Ok(SigningKeyMetadata {
+        kid: text(row, "kid")?,
+        format,
+        key_material: text(row, "key_material")?,
+        status,
+        created_at: row
+            .get("created_at")
+            .ok_or_else(|| Error::Internal("missing created_at".to_string()))?,
+        activated_at: row.get("activated_at"),
+        draining_since: row.get("draining_since"),
+        retired_at: row.get("retired_at"),
+        drain_expires_at: row.get("drain_expires_at"),
+        service_name: text(row, "service_name")?,
+        key_hash: text(row, "key_hash")?,
+    })
+}
+
+#[async_trait]
+impl KeyRotationStorage for MssqlKeyRotationStorage {
+    async fn initialize(&self) -> Result<(), Error> {
+        execute(&self.pool, "IF OBJECT_ID(N'signing_keys', N'U') IS NULL CREATE TABLE signing_keys (kid NVARCHAR(255) PRIMARY KEY, format NVARCHAR(32) NOT NULL, key_material NVARCHAR(MAX) NOT NULL, status NVARCHAR(16) NOT NULL CONSTRAINT CK_signing_keys_status CHECK (status IN ('active','draining','retired')), created_at DATETIMEOFFSET NOT NULL, activated_at DATETIMEOFFSET NULL, draining_since DATETIMEOFFSET NULL, retired_at DATETIMEOFFSET NULL, drain_expires_at DATETIMEOFFSET NULL, service_name NVARCHAR(255) NOT NULL, key_hash NVARCHAR(255) NOT NULL)", &[]).await?;
+        execute(&self.pool, "IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name='idx_signing_keys_status') CREATE INDEX idx_signing_keys_status ON signing_keys(status)", &[]).await?;
+        Ok(())
+    }
+    async fn store_key(&self, key: &SigningKeyMetadata) -> Result<(), Error> {
+        let format = key.format.to_string();
+        let status = key.status.to_string();
+        execute(&self.pool, "INSERT INTO signing_keys (kid,format,key_material,status,created_at,activated_at,draining_since,retired_at,drain_expires_at,service_name,key_hash) VALUES (@P1,@P2,@P3,@P4,@P5,@P6,@P7,@P8,@P9,@P10,@P11)", &[&key.kid,&format,&key.key_material,&status,&key.created_at,&key.activated_at,&key.draining_since,&key.retired_at,&key.drain_expires_at,&key.service_name,&key.key_hash]).await?;
+        Ok(())
+    }
+    async fn get_active_key(
+        &self,
+        service_name: &str,
+    ) -> Result<Option<SigningKeyMetadata>, Error> {
+        query(&self.pool, "SELECT TOP (1) * FROM signing_keys WHERE service_name=@P1 AND status='active' ORDER BY created_at DESC", &[&service_name]).await?.first().map(decode).transpose()
+    }
+    async fn get_key_by_kid(&self, kid: &str) -> Result<Option<SigningKeyMetadata>, Error> {
+        query(
+            &self.pool,
+            "SELECT * FROM signing_keys WHERE kid=@P1",
+            &[&kid],
+        )
+        .await?
+        .first()
+        .map(decode)
+        .transpose()
+    }
+    async fn get_verification_keys(
+        &self,
+        service_name: &str,
+    ) -> Result<Vec<SigningKeyMetadata>, Error> {
+        query(&self.pool, "SELECT * FROM signing_keys WHERE service_name=@P1 AND status IN ('active','draining') ORDER BY created_at DESC", &[&service_name]).await?.iter().map(decode).collect()
+    }
+    async fn update_key_status(
+        &self,
+        kid: &str,
+        status: KeyStatus,
+        timestamp: DateTime<Utc>,
+    ) -> Result<(), Error> {
+        let (sql, expected) = match status { KeyStatus::Active => ("UPDATE signing_keys SET status='active',activated_at=@P1 WHERE kid=@P2", None), KeyStatus::Draining => ("UPDATE signing_keys SET status='draining',draining_since=@P1 WHERE kid=@P2 AND status='active'", Some("active")), KeyStatus::Retired => ("UPDATE signing_keys SET status='retired',retired_at=@P1 WHERE kid=@P2 AND status='draining'", Some("draining")) };
+        if execute(&self.pool, sql, &[&timestamp, &kid]).await? == 0 {
+            return Err(Error::Conflict(format!(
+                "key {kid} was not in expected state {expected:?}"
+            )));
+        }
+        Ok(())
+    }
+    async fn retire_expired_draining_keys(&self, now: DateTime<Utc>) -> Result<u64, Error> {
+        execute(&self.pool, "UPDATE signing_keys SET status='retired',retired_at=@P1 WHERE status='draining' AND drain_expires_at<=@P1", &[&now]).await
+    }
+}

--- a/acton-service/src/auth/mod.rs
+++ b/acton-service/src/auth/mod.rs
@@ -65,6 +65,8 @@ pub use tokens::{TokenGenerator, TokenPair};
 #[cfg(feature = "cache")]
 pub use tokens::refresh::RedisRefreshStorage;
 
+#[cfg(feature = "mssql")]
+pub use tokens::refresh::MssqlRefreshStorage;
 #[cfg(feature = "database")]
 pub use tokens::refresh::PgRefreshStorage;
 
@@ -83,6 +85,8 @@ pub use api_keys::{ApiKey, ApiKeyGenerator, ApiKeyStorage};
 #[cfg(feature = "cache")]
 pub use api_keys::RedisApiKeyStorage;
 
+#[cfg(feature = "mssql")]
+pub use api_keys::MssqlApiKeyStorage;
 #[cfg(feature = "database")]
 pub use api_keys::PgApiKeyStorage;
 
@@ -108,6 +112,8 @@ pub use key_rotation::{
     SigningKeyMetadata,
 };
 
+#[cfg(feature = "mssql")]
+pub use key_rotation::MssqlKeyRotationStorage;
 #[cfg(feature = "database")]
 pub use key_rotation::PgKeyRotationStorage;
 

--- a/acton-service/src/auth/tokens/refresh.rs
+++ b/acton-service/src/auth/tokens/refresh.rs
@@ -517,6 +517,118 @@ pub mod pg_storage {
 #[cfg(feature = "database")]
 pub use pg_storage::PgRefreshStorage;
 
+/// Microsoft SQL Server refresh-token storage.
+#[cfg(feature = "mssql")]
+pub mod mssql_storage {
+    use super::*;
+    use crate::mssql::{execute, query, MssqlPool};
+
+    /// SQL Server-backed refresh-token storage.
+    #[derive(Clone)]
+    pub struct MssqlRefreshStorage {
+        pool: MssqlPool,
+    }
+
+    impl MssqlRefreshStorage {
+        /// Creates the storage and its schema.
+        pub async fn new(pool: MssqlPool) -> Result<Self, Error> {
+            execute(&pool, "IF OBJECT_ID(N'refresh_tokens',N'U') IS NULL CREATE TABLE refresh_tokens (id NVARCHAR(255) PRIMARY KEY,user_id NVARCHAR(255) NOT NULL,family_id NVARCHAR(255) NOT NULL,expires_at DATETIMEOFFSET NOT NULL,metadata NVARCHAR(MAX) NOT NULL,is_revoked BIT NOT NULL CONSTRAINT DF_refresh_revoked DEFAULT 0,created_at DATETIMEOFFSET NOT NULL CONSTRAINT DF_refresh_created DEFAULT SYSDATETIMEOFFSET())", &[]).await?;
+            Ok(Self { pool })
+        }
+    }
+
+    #[async_trait]
+    impl RefreshTokenStorage for MssqlRefreshStorage {
+        async fn store(
+            &self,
+            token_id: &str,
+            user_id: &str,
+            family_id: &str,
+            expires_at: DateTime<Utc>,
+            metadata: &RefreshTokenMetadata,
+        ) -> Result<(), Error> {
+            let metadata = serde_json::to_string(metadata)
+                .map_err(|error| Error::Internal(error.to_string()))?;
+            execute(&self.pool,"INSERT INTO refresh_tokens(id,user_id,family_id,expires_at,metadata,is_revoked) VALUES(@P1,@P2,@P3,@P4,@P5,0)",&[&token_id,&user_id,&family_id,&expires_at,&metadata]).await?;
+            Ok(())
+        }
+        async fn get(&self, token_id: &str) -> Result<Option<RefreshTokenData>, Error> {
+            let rows=query(&self.pool,"SELECT id,user_id,family_id,is_revoked,expires_at,metadata FROM refresh_tokens WHERE id=@P1 AND expires_at>SYSDATETIMEOFFSET()",&[&token_id]).await?;
+            rows.first()
+                .map(|row| {
+                    let required = |name| {
+                        row.get::<&str, _>(name)
+                            .map(str::to_owned)
+                            .ok_or_else(|| Error::Internal(format!("missing {name}")))
+                    };
+                    let metadata = serde_json::from_str(required("metadata")?.as_str())
+                        .map_err(|error| Error::Internal(error.to_string()))?;
+                    Ok(RefreshTokenData {
+                        token_id: required("id")?,
+                        user_id: required("user_id")?,
+                        family_id: required("family_id")?,
+                        is_revoked: row.get("is_revoked").unwrap_or(false),
+                        expires_at: row
+                            .get("expires_at")
+                            .ok_or_else(|| Error::Internal("missing expires_at".to_string()))?,
+                        metadata,
+                    })
+                })
+                .transpose()
+        }
+        async fn revoke(&self, token_id: &str) -> Result<(), Error> {
+            execute(
+                &self.pool,
+                "UPDATE refresh_tokens SET is_revoked=1 WHERE id=@P1",
+                &[&token_id],
+            )
+            .await?;
+            Ok(())
+        }
+        async fn revoke_family(&self, family_id: &str) -> Result<u64, Error> {
+            execute(
+                &self.pool,
+                "UPDATE refresh_tokens SET is_revoked=1 WHERE family_id=@P1",
+                &[&family_id],
+            )
+            .await
+        }
+        async fn revoke_all_for_user(&self, user_id: &str) -> Result<u64, Error> {
+            execute(
+                &self.pool,
+                "UPDATE refresh_tokens SET is_revoked=1 WHERE user_id=@P1",
+                &[&user_id],
+            )
+            .await
+        }
+        async fn rotate(
+            &self,
+            old_token_id: &str,
+            new_token_id: &str,
+            user_id: &str,
+            family_id: &str,
+            expires_at: DateTime<Utc>,
+            metadata: &RefreshTokenMetadata,
+        ) -> Result<(), Error> {
+            let metadata = serde_json::to_string(metadata)
+                .map_err(|error| Error::Internal(error.to_string()))?;
+            execute(&self.pool,"SET XACT_ABORT ON; BEGIN TRANSACTION; UPDATE refresh_tokens SET is_revoked=1 WHERE id=@P1; INSERT INTO refresh_tokens(id,user_id,family_id,expires_at,metadata,is_revoked) VALUES(@P2,@P3,@P4,@P5,@P6,0); COMMIT TRANSACTION",&[&old_token_id,&new_token_id,&user_id,&family_id,&expires_at,&metadata]).await?;
+            Ok(())
+        }
+        async fn cleanup_expired(&self) -> Result<u64, Error> {
+            execute(
+                &self.pool,
+                "DELETE FROM refresh_tokens WHERE expires_at<SYSDATETIMEOFFSET()",
+                &[],
+            )
+            .await
+        }
+    }
+}
+
+#[cfg(feature = "mssql")]
+pub use mssql_storage::MssqlRefreshStorage;
+
 /// Turso/libsql-based refresh token storage
 #[cfg(feature = "turso")]
 pub mod turso_storage {

--- a/acton-service/src/error.rs
+++ b/acton-service/src/error.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 
 /// Database operation being performed when the error occurred
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+#[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
 pub enum DatabaseOperation {
     /// Establishing a database connection
     Connect,
@@ -37,7 +37,7 @@ pub enum DatabaseOperation {
     PoolAcquire,
 }
 
-#[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+#[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
 impl fmt::Display for DatabaseOperation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -56,7 +56,7 @@ impl fmt::Display for DatabaseOperation {
 
 /// Category of database error
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+#[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
 pub enum DatabaseErrorKind {
     /// Failed to establish connection
     ConnectionFailed,
@@ -84,7 +84,7 @@ pub enum DatabaseErrorKind {
     Other,
 }
 
-#[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+#[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
 impl fmt::Display for DatabaseErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -106,7 +106,7 @@ impl fmt::Display for DatabaseErrorKind {
 
 /// Structured database error with operation context
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+#[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
 pub struct DatabaseError {
     /// The operation being performed when the error occurred
     pub operation: DatabaseOperation,
@@ -118,7 +118,7 @@ pub struct DatabaseError {
     pub context: Option<String>,
 }
 
-#[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+#[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
 impl DatabaseError {
     /// Create a new database error
     pub fn new(
@@ -227,7 +227,7 @@ impl DatabaseError {
     }
 }
 
-#[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+#[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
 impl fmt::Display for DatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -242,11 +242,11 @@ impl fmt::Display for DatabaseError {
     }
 }
 
-#[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+#[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
 impl std::error::Error for DatabaseError {}
 
 /// Sanitize a database URL by removing credentials
-#[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+#[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
 pub fn sanitize_url(url: &str) -> String {
     // Handle standard database URLs like postgres://user:pass@host/db
     if let Some(at_pos) = url.find('@') {
@@ -282,7 +282,7 @@ pub enum Error {
     Config(Box<figment::Error>),
 
     /// Structured database error with operation context
-    #[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+    #[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
     #[error("{0}")]
     Database(DatabaseError),
 
@@ -451,7 +451,7 @@ impl IntoResponse for Error {
                 ),
             ),
 
-            #[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+            #[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
             Error::Database(ref e) => {
                 // Log with structured context
                 tracing::error!(
@@ -814,8 +814,20 @@ impl From<sqlx::Error> for Error {
     }
 }
 
+#[cfg(feature = "mssql")]
+impl From<tiberius::error::Error> for DatabaseError {
+    fn from(err: tiberius::error::Error) -> Self {
+        Self::new(DatabaseOperation::Query, DatabaseErrorKind::QueryFailed, err.to_string())
+    }
+}
+
+#[cfg(feature = "mssql")]
+impl From<tiberius::error::Error> for Error {
+    fn from(err: tiberius::error::Error) -> Self { Error::Database(DatabaseError::from(err)) }
+}
+
 // Conversion from DatabaseError to Error
-#[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+#[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
 impl From<DatabaseError> for Error {
     fn from(err: DatabaseError) -> Self {
         Error::Database(err)
@@ -953,7 +965,7 @@ impl From<axum::http::Error> for Error {
 // Conversion from DatabaseError to RepositoryError
 #[cfg(all(
     feature = "repository",
-    any(feature = "database", feature = "turso", feature = "surrealdb")
+    any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb")
 ))]
 impl From<DatabaseError> for crate::repository::RepositoryError {
     fn from(err: DatabaseError) -> Self {
@@ -1014,7 +1026,7 @@ mod tests {
     // DatabaseError Tests
     // =========================================================================
 
-    #[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+    #[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
     mod database_error_tests {
         use super::*;
 

--- a/acton-service/src/grpc/health.rs
+++ b/acton-service/src/grpc/health.rs
@@ -63,6 +63,34 @@ impl HealthService {
                 }
             }
         }
+        #[cfg(feature = "mssql")]
+        if self.state.config().database.is_some() {
+            match self.state.mssql().await {
+                Some(pool) if crate::mssql::health_check(&pool).await.is_err() => {
+                    if !self
+                        .state
+                        .config()
+                        .database
+                        .as_ref()
+                        .is_some_and(|config| config.optional)
+                    {
+                        all_healthy = false;
+                    }
+                }
+                None => {
+                    if !self
+                        .state
+                        .config()
+                        .database
+                        .as_ref()
+                        .is_some_and(|config| config.optional)
+                    {
+                        all_healthy = false;
+                    }
+                }
+                Some(_) => {}
+            }
+        }
 
         // Check Redis connection
         #[cfg(feature = "cache")]

--- a/acton-service/src/health.rs
+++ b/acton-service/src/health.rs
@@ -158,6 +158,55 @@ where
         }
     }
 
+    #[cfg(feature = "mssql")]
+    if state.config().database.is_some() {
+        match state.mssql().await {
+            Some(pool) => match crate::mssql::health_check(&pool).await {
+                Ok(()) => dependencies.insert(
+                    "mssql".to_string(),
+                    DependencyStatus {
+                        healthy: true,
+                        message: Some("Connected".to_string()),
+                    },
+                ),
+                Err(error) => {
+                    if !state
+                        .config()
+                        .database
+                        .as_ref()
+                        .is_some_and(|config| config.optional)
+                    {
+                        all_ready = false;
+                    }
+                    dependencies.insert(
+                        "mssql".to_string(),
+                        DependencyStatus {
+                            healthy: false,
+                            message: Some(error.to_string()),
+                        },
+                    )
+                }
+            },
+            None => {
+                if !state
+                    .config()
+                    .database
+                    .as_ref()
+                    .is_some_and(|config| config.optional)
+                {
+                    all_ready = false;
+                }
+                dependencies.insert(
+                    "mssql".to_string(),
+                    DependencyStatus {
+                        healthy: false,
+                        message: Some("Not connected".to_string()),
+                    },
+                )
+            }
+        };
+    }
+
     // Check Redis connection
     #[cfg(feature = "cache")]
     if state.config().redis.is_some() {

--- a/acton-service/src/lib.rs
+++ b/acton-service/src/lib.rs
@@ -57,6 +57,17 @@ compile_error!(
      Enable only one database backend."
 );
 
+#[cfg(all(feature = "database", feature = "mssql"))]
+compile_error!(
+    "Features `database`/`postgres` and `mssql` are mutually exclusive. Enable only one primary database backend."
+);
+
+#[cfg(all(feature = "mssql", feature = "turso"))]
+compile_error!("Features `mssql` and `turso` are mutually exclusive.");
+
+#[cfg(all(feature = "mssql", feature = "surrealdb"))]
+compile_error!("Features `mssql` and `surrealdb` are mutually exclusive.");
+
 #[cfg(all(feature = "database", feature = "surrealdb"))]
 compile_error!(
     "Features `database` (PostgreSQL) and `surrealdb` are mutually exclusive. \
@@ -98,6 +109,9 @@ pub mod versioning;
 
 #[cfg(feature = "database")]
 pub mod database;
+
+#[cfg(feature = "mssql")]
+pub mod mssql;
 
 #[cfg(feature = "turso")]
 pub mod turso;
@@ -204,7 +218,7 @@ pub mod prelude {
 
     pub use crate::error::{Error, Result};
 
-    #[cfg(any(feature = "database", feature = "turso", feature = "surrealdb"))]
+    #[cfg(any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb"))]
     pub use crate::error::{DatabaseError, DatabaseErrorKind, DatabaseOperation};
 
     pub use crate::checks::CheckOutcome;
@@ -214,6 +228,8 @@ pub mod prelude {
 
     #[cfg(feature = "database")]
     pub use crate::pool_health::DatabasePoolHealth;
+    #[cfg(feature = "mssql")]
+    pub use crate::pool_health::MssqlPoolHealth;
 
     #[cfg(feature = "turso")]
     pub use crate::pool_health::TursoDbHealth;
@@ -321,7 +337,7 @@ pub mod prelude {
     // Key rotation storage trait (requires auth + a database backend)
     #[cfg(all(
         feature = "auth",
-        any(feature = "database", feature = "turso", feature = "surrealdb")
+        any(feature = "database", feature = "mssql", feature = "turso", feature = "surrealdb")
     ))]
     pub use crate::auth::KeyRotationStorage;
 

--- a/acton-service/src/mssql.rs
+++ b/acton-service/src/mssql.rs
@@ -1,0 +1,100 @@
+//! Microsoft SQL Server connection pooling and query primitives.
+
+use std::time::Duration;
+
+use bb8::Pool;
+use bb8_tiberius::ConnectionManager;
+
+use crate::{
+    config::DatabaseConfig,
+    error::{Error, Result},
+};
+
+/// A cloneable Microsoft SQL Server connection pool.
+pub type MssqlPool = Pool<ConnectionManager>;
+
+/// Creates a SQL Server pool using the common database retry policy.
+pub async fn create_pool(config: &DatabaseConfig) -> Result<MssqlPool> {
+    let mut attempt = 0_u32;
+    let base_delay = Duration::from_secs(config.retry_delay_secs);
+
+    loop {
+        match try_create_pool(config).await {
+            Ok(pool) => return Ok(pool),
+            Err(error) if attempt >= config.max_retries => return Err(error),
+            Err(error) => {
+                attempt += 1;
+                let multiplier = 2_u32.saturating_pow(attempt.saturating_sub(1));
+                let delay = base_delay.saturating_mul(multiplier);
+                tracing::warn!(attempt, %error, ?delay, "SQL Server connection failed; retrying");
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+}
+
+async fn try_create_pool(config: &DatabaseConfig) -> Result<MssqlPool> {
+    let manager = ConnectionManager::build(config.url.as_str()).map_err(|error| {
+        Error::Internal(format!(
+            "invalid SQL Server connection configuration: {error}"
+        ))
+    })?;
+    Pool::builder()
+        .max_size(config.max_connections)
+        .min_idle(Some(config.min_connections))
+        .connection_timeout(Duration::from_secs(config.connection_timeout_secs))
+        .build(manager)
+        .await
+        .map_err(|error| Error::Internal(format!("failed to connect to SQL Server: {error}")))
+}
+
+/// Checks that SQL Server accepts and executes a query on a pooled connection.
+pub async fn health_check(pool: &MssqlPool) -> Result<()> {
+    let mut connection = pool.get().await.map_err(|error| {
+        Error::Internal(format!("failed to acquire SQL Server connection: {error}"))
+    })?;
+    connection
+        .simple_query("SELECT 1")
+        .await
+        .map_err(|error| Error::Internal(format!("SQL Server health query failed: {error}")))?;
+    Ok(())
+}
+
+/// Executes a SQL Server statement and returns the affected-row count.
+pub(crate) async fn execute(
+    pool: &MssqlPool,
+    sql: &str,
+    params: &[&dyn tiberius::ToSql],
+) -> Result<u64> {
+    let mut connection = pool.get().await.map_err(pool_error)?;
+    connection
+        .execute(sql, params)
+        .await
+        .map(|result| result.total())
+        .map_err(query_error)
+}
+
+/// Executes a SQL Server query and materializes its first result set.
+pub(crate) async fn query(
+    pool: &MssqlPool,
+    sql: &str,
+    params: &[&dyn tiberius::ToSql],
+) -> Result<Vec<tiberius::Row>> {
+    let mut connection = pool.get().await.map_err(pool_error)?;
+    let rows = connection
+        .query(sql, params)
+        .await
+        .map_err(query_error)?
+        .into_first_result()
+        .await
+        .map_err(query_error)?;
+    Ok(rows)
+}
+
+fn pool_error(error: bb8::RunError<bb8_tiberius::Error>) -> Error {
+    Error::Internal(format!("failed to acquire SQL Server connection: {error}"))
+}
+
+fn query_error(error: tiberius::error::Error) -> Error {
+    Error::Internal(format!("SQL Server operation failed: {error}"))
+}

--- a/acton-service/src/pool_health.rs
+++ b/acton-service/src/pool_health.rs
@@ -54,6 +54,40 @@ impl DatabasePoolHealth {
     }
 }
 
+/// Microsoft SQL Server connection-pool health metrics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg(feature = "mssql")]
+pub struct MssqlPoolHealth {
+    pub size: u32,
+    pub idle: u32,
+    pub max_size: u32,
+    pub min_size: u32,
+    pub healthy: bool,
+    pub utilization_percent: f32,
+}
+#[cfg(feature = "mssql")]
+impl MssqlPoolHealth {
+    pub fn from_pool(
+        pool: &crate::mssql::MssqlPool,
+        config: &crate::config::DatabaseConfig,
+    ) -> Self {
+        let state = pool.state();
+        let utilization_percent = if config.max_connections == 0 {
+            0.0
+        } else {
+            (state.connections as f32 / config.max_connections as f32 * 100.0).min(100.0)
+        };
+        Self {
+            size: state.connections,
+            idle: state.idle_connections,
+            max_size: config.max_connections,
+            min_size: config.min_connections,
+            healthy: state.connections < config.max_connections,
+            utilization_percent,
+        }
+    }
+}
+
 /// Redis connection pool health metrics
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg(feature = "cache")]
@@ -207,6 +241,9 @@ pub struct PoolHealthSummary {
     #[cfg(feature = "database")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database: Option<DatabasePoolHealth>,
+    #[cfg(feature = "mssql")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mssql: Option<MssqlPoolHealth>,
 
     /// Redis pool health
     #[cfg(feature = "cache")]
@@ -243,6 +280,8 @@ impl PoolHealthSummary {
         Self {
             #[cfg(feature = "database")]
             database: None,
+            #[cfg(feature = "mssql")]
+            mssql: None,
             #[cfg(feature = "cache")]
             redis: None,
             #[cfg(feature = "events")]
@@ -269,6 +308,8 @@ impl PoolHealthSummary {
                 true
             }
         };
+        #[cfg(feature = "mssql")]
+        let database_healthy = database_healthy && self.mssql.as_ref().is_none_or(|db| db.healthy);
 
         let cache_healthy = {
             #[cfg(feature = "cache")]

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -644,6 +644,8 @@ where
         // Determine if we need to spawn pool agents
         #[cfg(feature = "database")]
         let needs_db_agent = config.database.is_some();
+        #[cfg(feature = "mssql")]
+        let needs_mssql_agent = config.database.is_some();
 
         #[cfg(feature = "cache")]
         let needs_redis_agent = config.redis.is_some();
@@ -666,13 +668,18 @@ where
             feature = "events",
             feature = "turso",
             feature = "surrealdb",
-            feature = "clickhouse"
+            feature = "clickhouse",
+            feature = "mssql"
         ))]
         let needs_agents = {
             #[cfg(feature = "database")]
             let db = needs_db_agent;
             #[cfg(not(feature = "database"))]
             let db = false;
+            #[cfg(feature = "mssql")]
+            let mssql = needs_mssql_agent;
+            #[cfg(not(feature = "mssql"))]
+            let mssql = false;
 
             #[cfg(feature = "cache")]
             let redis = needs_redis_agent;
@@ -699,12 +706,18 @@ where
             #[cfg(not(feature = "clickhouse"))]
             let clickhouse = false;
 
-            db || redis || nats || turso || surrealdb || clickhouse
+            db || mssql || redis || nats || turso || surrealdb || clickhouse
         };
 
         // Initialize agent runtime and spawn pool agents if needed
         #[cfg(feature = "database")]
         let shared_db_pool: Option<crate::agents::SharedDbPool> = if needs_db_agent {
+            Some(std::sync::Arc::new(tokio::sync::RwLock::new(None)))
+        } else {
+            None
+        };
+        #[cfg(feature = "mssql")]
+        let shared_mssql_pool: Option<crate::agents::SharedMssqlPool> = if needs_mssql_agent {
             Some(std::sync::Arc::new(tokio::sync::RwLock::new(None)))
         } else {
             None
@@ -750,6 +763,8 @@ where
         // Agent handles for AppState
         #[cfg(feature = "database")]
         let mut db_agent_handle: Option<acton_reactive::prelude::ActorHandle> = None;
+        #[cfg(feature = "mssql")]
+        let mut mssql_agent_handle: Option<acton_reactive::prelude::ActorHandle> = None;
         #[cfg(feature = "cache")]
         let mut redis_agent_handle: Option<acton_reactive::prelude::ActorHandle> = None;
         #[cfg(feature = "events")]
@@ -767,7 +782,8 @@ where
             feature = "events",
             feature = "turso",
             feature = "surrealdb",
-            feature = "clickhouse"
+            feature = "clickhouse",
+            feature = "mssql"
         ))]
         let mut broker_handle = if needs_agents {
             // Use block_in_place to run async code in sync context
@@ -797,6 +813,22 @@ where
                                 }
                                 Err(e) => {
                                     tracing::warn!("Failed to spawn database pool agent: {}", e);
+                                }
+                            }
+                        }
+
+                        #[cfg(feature = "mssql")]
+                        if let Some(ref db_config) = config.database {
+                            match crate::agents::MssqlPoolAgent::spawn(
+                                runtime,
+                                db_config.clone(),
+                                shared_mssql_pool.clone(),
+                            )
+                            .await
+                            {
+                                Ok(handle) => mssql_agent_handle = Some(handle),
+                                Err(error) => {
+                                    tracing::warn!(%error, "failed to spawn SQL Server pool agent")
                                 }
                             }
                         }
@@ -936,6 +968,8 @@ where
                         &crate::audit::wiring::AuditStorageHandles {
                             #[cfg(feature = "database")]
                             db_pool: shared_db_pool.clone(),
+                            #[cfg(feature = "mssql")]
+                            mssql_pool: shared_mssql_pool.clone(),
                             #[cfg(feature = "turso")]
                             turso_db: shared_turso_db.clone(),
                             #[cfg(feature = "surrealdb")]
@@ -1073,6 +1107,8 @@ where
                     &config,
                     #[cfg(feature = "database")]
                     &shared_db_pool,
+                    #[cfg(feature = "mssql")]
+                    &shared_mssql_pool,
                     #[cfg(feature = "turso")]
                     &shared_turso_db,
                     #[cfg(feature = "surrealdb")]
@@ -1208,7 +1244,8 @@ where
             feature = "events",
             feature = "turso",
             feature = "surrealdb",
-            feature = "clickhouse"
+            feature = "clickhouse",
+            feature = "mssql"
         )))]
         let broker_handle: Option<acton_reactive::prelude::ActorHandle> = self.broker();
 
@@ -1221,7 +1258,8 @@ where
             feature = "events",
             feature = "turso",
             feature = "surrealdb",
-            feature = "clickhouse"
+            feature = "clickhouse",
+            feature = "mssql"
         ))]
         if broker_handle.is_none() {
             broker_handle = self.broker();
@@ -1244,6 +1282,10 @@ where
             #[cfg(feature = "database")]
             if let Some(pool) = shared_db_pool {
                 state.set_db_pool_storage(pool);
+            }
+            #[cfg(feature = "mssql")]
+            if let Some(pool) = shared_mssql_pool {
+                state.set_mssql_pool_storage(pool);
             }
 
             #[cfg(feature = "cache")]
@@ -2174,6 +2216,7 @@ where
         builder: &mut Self,
         config: &Config<T>,
         #[cfg(feature = "database")] shared_db_pool: &Option<crate::agents::SharedDbPool>,
+        #[cfg(feature = "mssql")] shared_mssql_pool: &Option<crate::agents::SharedMssqlPool>,
         #[cfg(feature = "turso")] shared_turso_db: &Option<crate::agents::SharedTursoDb>,
         #[cfg(feature = "surrealdb")] shared_surrealdb_client: &Option<
             crate::agents::SharedSurrealDb,
@@ -2232,6 +2275,21 @@ where
                                 crate::auth::key_rotation::PgKeyRotationStorage::new(pool.clone()),
                             ));
                             tracing::debug!("Key rotation using PostgreSQL storage");
+                        }
+                    }
+                }
+            }
+
+            #[cfg(feature = "mssql")]
+            if s.is_none() {
+                if let Some(ref pool_lock) = shared_mssql_pool {
+                    if let Ok(guard) = pool_lock.try_read() {
+                        if let Some(ref pool) = *guard {
+                            s = Some(std::sync::Arc::new(
+                                crate::auth::key_rotation::MssqlKeyRotationStorage::new(
+                                    pool.clone(),
+                                ),
+                            ));
                         }
                     }
                 }

--- a/acton-service/src/state.rs
+++ b/acton-service/src/state.rs
@@ -26,12 +26,16 @@ use std::sync::Arc;
     feature = "events",
     feature = "turso",
     feature = "surrealdb",
-    feature = "clickhouse"
+    feature = "clickhouse",
+    feature = "mssql"
 ))]
 use tokio::sync::RwLock;
 
 #[cfg(feature = "database")]
 use sqlx::PgPool;
+
+#[cfg(feature = "mssql")]
+use crate::mssql::MssqlPool;
 
 #[cfg(feature = "cache")]
 use deadpool_redis::Pool as RedisPool;
@@ -73,6 +77,9 @@ where
     // Traditional pool storage (used when agents are not configured)
     #[cfg(feature = "database")]
     db_pool: Arc<RwLock<Option<PgPool>>>,
+
+    #[cfg(feature = "mssql")]
+    mssql_pool: Arc<RwLock<Option<MssqlPool>>>,
 
     #[cfg(feature = "turso")]
     turso_db: Arc<RwLock<Option<Arc<libsql::Database>>>>,
@@ -127,6 +134,8 @@ where
             config: Arc::new(Config::<T>::default()),
             #[cfg(feature = "database")]
             db_pool: Arc::new(RwLock::new(None)),
+            #[cfg(feature = "mssql")]
+            mssql_pool: Arc::new(RwLock::new(None)),
             #[cfg(feature = "turso")]
             turso_db: Arc::new(RwLock::new(None)),
             #[cfg(feature = "cache")]
@@ -166,6 +175,8 @@ where
             config: Arc::new(config),
             #[cfg(feature = "database")]
             db_pool: Arc::new(RwLock::new(None)),
+            #[cfg(feature = "mssql")]
+            mssql_pool: Arc::new(RwLock::new(None)),
             #[cfg(feature = "turso")]
             turso_db: Arc::new(RwLock::new(None)),
             #[cfg(feature = "cache")]
@@ -240,6 +251,23 @@ where
     #[cfg(feature = "database")]
     pub(crate) fn set_db_pool_storage(&mut self, storage: Arc<RwLock<Option<PgPool>>>) {
         self.db_pool = storage;
+    }
+
+    /// Gets the Microsoft SQL Server pool, if it is connected.
+    #[cfg(feature = "mssql")]
+    pub async fn mssql(&self) -> Option<MssqlPool> {
+        self.mssql_pool.read().await.clone()
+    }
+
+    /// Gets the shared SQL Server pool storage.
+    #[cfg(feature = "mssql")]
+    pub fn mssql_lock(&self) -> &Arc<RwLock<Option<MssqlPool>>> {
+        &self.mssql_pool
+    }
+
+    #[cfg(feature = "mssql")]
+    pub(crate) fn set_mssql_pool_storage(&mut self, storage: Arc<RwLock<Option<MssqlPool>>>) {
+        self.mssql_pool = storage;
     }
 
     /// Get the Turso database
@@ -542,6 +570,12 @@ where
                     &pool, db_config,
                 ));
             }
+        }
+        #[cfg(feature = "mssql")]
+        if let (Some(pool), Some(config)) = (self.mssql().await, self.config.database.as_ref()) {
+            summary.mssql = Some(crate::pool_health::MssqlPoolHealth::from_pool(
+                &pool, config,
+            ));
         }
 
         #[cfg(feature = "cache")]
@@ -857,10 +891,39 @@ where
             Arc::new(RwLock::new(None))
         };
 
+        #[cfg(feature = "mssql")]
+        let mssql_pool = if let Some(database_config) = &config.database {
+            if database_config.lazy_init {
+                let storage = Arc::new(RwLock::new(None));
+                let target = storage.clone();
+                let database_config = database_config.clone();
+                tokio::spawn(async move {
+                    match crate::mssql::create_pool(&database_config).await {
+                        Ok(pool) => *target.write().await = Some(pool),
+                        Err(error) => tracing::error!(%error, "lazy SQL Server connection failed"),
+                    }
+                });
+                storage
+            } else {
+                match crate::mssql::create_pool(database_config).await {
+                    Ok(pool) => Arc::new(RwLock::new(Some(pool))),
+                    Err(error) if database_config.optional => {
+                        tracing::warn!(%error, "optional SQL Server connection failed");
+                        Arc::new(RwLock::new(None))
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+        } else {
+            Arc::new(RwLock::new(None))
+        };
+
         Ok(AppState {
             config: Arc::new(config),
             #[cfg(feature = "database")]
             db_pool,
+            #[cfg(feature = "mssql")]
+            mssql_pool,
             #[cfg(feature = "turso")]
             turso_db: Arc::new(RwLock::new(None)), // Turso uses agents, not builder
             #[cfg(feature = "surrealdb")]

--- a/acton-service/tests/mssql_integration.rs
+++ b/acton-service/tests/mssql_integration.rs
@@ -1,0 +1,34 @@
+#![cfg(all(feature = "mssql", feature = "accounts", feature = "auth", feature = "audit"))]
+
+use acton_service::{accounts::{storage::{mssql::MssqlAccountStorage,AccountStorage},types::{Account,AccountId,AccountStatus}},audit::storage::mssql::MssqlAuditStorage,auth::{ApiKey,ApiKeyStorage,KeyRotationStorage,MssqlApiKeyStorage,MssqlKeyRotationStorage,MssqlRefreshStorage,RefreshTokenMetadata,RefreshTokenStorage},config::DatabaseConfig,mssql};
+use chrono::{Duration,Utc};
+use testcontainers_modules::{mssql_server::MssqlServer,testcontainers::runners::AsyncRunner};
+
+#[tokio::test]
+async fn mssql_backends_initialize_and_accounts_round_trip(){
+ let container=MssqlServer::default().with_accept_eula().start().await.expect("start SQL Server container");
+ let host=container.get_host().await.expect("container host");
+ let port=container.get_host_port_ipv4(1433).await.expect("container port");
+ let config=DatabaseConfig{url:format!("Server=tcp:{host},{port};Database=master;User Id=sa;Password={};TrustServerCertificate=True;",MssqlServer::DEFAULT_SA_PASSWORD),max_connections:5,min_connections:1,connection_timeout_secs:30,max_retries:10,retry_delay_secs:2,optional:false,lazy_init:false};
+ let pool=mssql::create_pool(&config).await.expect("SQL Server pool");
+ mssql::health_check(&pool).await.expect("health query");
+ let accounts=MssqlAccountStorage::new(pool.clone()).await.expect("accounts schema");
+ let api_keys=MssqlApiKeyStorage::new(pool.clone(),"test").await.expect("api key schema");
+ let refresh=MssqlRefreshStorage::new(pool.clone()).await.expect("refresh schema");
+ MssqlKeyRotationStorage::new(pool.clone()).initialize().await.expect("key rotation schema");
+ MssqlAuditStorage::new(pool.clone()).initialize().await.expect("audit schema");
+ let now=Utc::now();
+ let account:Account=serde_json::from_value(serde_json::json!({"id":AccountId::new().to_string(),"email":format!("{}@example.test",uuid::Uuid::new_v4()),"username":null,"password_hash":null,"status":AccountStatus::Active,"roles":["user"],"email_verified":true,"email_verified_at":now,"last_login_at":null,"locked_at":null,"locked_reason":null,"disabled_at":null,"disabled_reason":null,"expires_at":null,"password_changed_at":null,"failed_login_count":0,"metadata":{"backend":"mssql"},"created_at":now,"updated_at":now})).expect("account fixture");
+ accounts.create(&account).await.expect("create account");
+ let loaded=accounts.get_by_id(account.id.as_str()).await.expect("load account").expect("account exists");
+ assert_eq!(loaded.email,account.email);
+ assert_eq!(loaded.roles,account.roles);
+ let key=ApiKey{id:uuid::Uuid::new_v4().to_string(),user_id:account.id.to_string(),name:"integration".to_string(),prefix:format!("test_{}",uuid::Uuid::new_v4()),key_hash:"not-used-for-id-lookup".to_string(),scopes:vec!["read".to_string()],rate_limit:Some(100),is_revoked:false,last_used_at:None,expires_at:None,created_at:now};
+ api_keys.create(&key).await.expect("create API key");
+ assert_eq!(api_keys.get_by_id(&key.id).await.expect("load API key").expect("API key exists").scopes,key.scopes);
+ let token_id=uuid::Uuid::new_v4().to_string();
+ let metadata=RefreshTokenMetadata::default();
+ refresh.store(&token_id,account.id.as_str(),"family",now+Duration::hours(1),&metadata).await.expect("store refresh token");
+ assert_eq!(refresh.get(&token_id).await.expect("load refresh token").expect("refresh token exists").user_id,account.id.as_str());
+ assert!(accounts.delete(account.id.as_str()).await.expect("delete account"));
+}


### PR DESCRIPTION
## Summary
- add first-class Microsoft SQL Server pooling, lifecycle, readiness, and telemetry
- add MSSQL storage parity for accounts, API keys, refresh tokens, signing-key rotation, and audit events
- add SQL Server 2022 Testcontainers integration coverage and CI
- add a descriptive postgres feature alias while preserving database

## Validation
- MSSQL clippy with warnings denied
- MSSQL nextest suite: 368 passed
- full feature cargo check and clippy
- full feature nextest suite: 900 passed
- cargo audit
- cargo deny advisories