### PR TITLE
feat(auth): add Windows integrated authentication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,6 +216,8 @@ jobs:
         run: cargo check -p acton-service --all-targets --features full
       - name: Check Microsoft SQL Server feature set
         run: cargo check -p acton-service --all-targets --no-default-features --features "mssql,http,grpc,auth,accounts,audit,observability,crypto-aws-lc-rs"
+      - name: Check trusted-proxy Windows authentication
+        run: cargo check -p acton-service --all-targets --no-default-features --features "http,tls,windows-auth,crypto-aws-lc-rs"
 
   # The `full` legs above cover audit with the PostgreSQL storage backend
   # (`database` is in `full`). The optional backends are mutually exclusive
@@ -260,7 +262,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libkrb5-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -311,6 +313,10 @@ jobs:
           # workspace asked for it. So this leg runs the tests too.
           - combo: tls-no-grpc
             features: "http,tls,crypto-aws-lc-rs"
+            test: true
+          # Windows identities asserted by an mTLS-authenticated proxy.
+          - combo: windows-auth
+            features: "http,tls,windows-auth,crypto-aws-lc-rs"
             test: true
           # The mirror image: gRPC transport with no TLS material.
           - combo: grpc-no-tls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **auth(windows)**: Added trusted-proxy Windows/Active Directory authentication
+  over allowlisted mutual TLS, including validated principals, group-to-role
+  mappings, unified claims, and defensive removal of forwarded identity headers.
+- **database(mssql)**: Added SSPI integrated authentication on Windows and
+  Kerberos/GSSAPI integrated authentication on Unix for SQL Server pools.
+
 - **database(mssql)**: Added first-class Microsoft SQL Server support through
   Tiberius and bb8, including agent-managed pooling, retries, readiness and
   gRPC health checks, pool telemetry, accounts, API keys, refresh tokens,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
  "acton-service",
  "anyhow",
  "chrono",
- "clap",
+ "clap 4.6.1",
  "clap_complete",
  "colored",
  "dialoguer",
@@ -207,7 +207,7 @@ dependencies = [
  "crossbeam",
  "libc",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.5",
  "thiserror 2.0.18",
  "tokio",
  "winapi",
@@ -271,6 +271,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -831,6 +840,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,7 +1052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "457d7ed3f888dfd2c7af56d4975cade43c622f74bdcddfed6d4352f57acc6310"
 dependencies = [
  "futures-util",
- "parking_lot",
+ "parking_lot 0.12.5",
  "portable-atomic",
  "tokio",
 ]
@@ -1090,6 +1110,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
 dependencies = [
  "virtue",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "clap 2.34.0",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "which",
 ]
 
 [[package]]
@@ -1607,6 +1650,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width 0.1.14",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
@@ -1624,7 +1682,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
  "terminal_size",
  "unicase",
  "unicode-width 0.2.2",
@@ -1636,7 +1694,7 @@ version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
- "clap",
+ "clap 4.6.1",
 ]
 
 [[package]]
@@ -2069,7 +2127,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -2082,7 +2140,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -2119,7 +2177,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
 ]
 
 [[package]]
@@ -2571,6 +2629,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,7 +2925,7 @@ dependencies = [
  "fred-macros",
  "futures",
  "log",
- "parking_lot",
+ "parking_lot 0.12.5",
  "rand 0.8.6",
  "redis-protocol",
  "semver",
@@ -2945,7 +3016,7 @@ checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -3188,7 +3259,7 @@ dependencies = [
  "getrandom 0.3.4",
  "hashbrown 0.16.1",
  "nonzero_ext",
- "parking_lot",
+ "parking_lot 0.12.5",
  "portable-atomic",
  "quanta",
  "rand 0.9.4",
@@ -3429,6 +3500,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -3961,6 +4041,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4206,6 +4295,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libgssapi"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "724dbcd1f871da9c67983537a47ac510c278656f6392418ad67c7a52720e54b2"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytes",
+ "lazy_static",
+ "libgssapi-sys",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
+name = "libgssapi-sys"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd7d65e409c889f6c9d81ff079371d0d8fd88d7dca702ff187ef96fb0450fb7"
+dependencies = [
+ "bindgen 0.59.2",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4257,7 +4368,7 @@ dependencies = [
  "libsql-sqlite3-parser",
  "libsql-sys",
  "libsql_replication",
- "parking_lot",
+ "parking_lot 0.12.5",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4279,7 +4390,7 @@ version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0be1da6f123ceb2cd23f469883415cab9ee963286a85d61e22afb8b12e15e681"
 dependencies = [
- "bindgen",
+ "bindgen 0.66.1",
  "cc",
  "cmake",
  "glob",
@@ -4356,7 +4467,7 @@ dependencies = [
  "cbc",
  "libsql-rusqlite",
  "libsql-sys",
- "parking_lot",
+ "parking_lot 0.12.5",
  "prost 0.12.6",
  "serde",
  "thiserror 1.0.69",
@@ -4974,7 +5085,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
@@ -5047,7 +5158,7 @@ dependencies = [
  "http 1.4.0",
  "humantime",
  "itertools 0.14.0",
- "parking_lot",
+ "parking_lot 0.12.5",
  "percent-encoding",
  "thiserror 2.0.18",
  "tokio",
@@ -5375,12 +5486,37 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -5753,7 +5889,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -5891,7 +6027,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot",
+ "parking_lot 0.12.5",
  "protobuf",
  "thiserror 2.0.18",
 ]
@@ -6072,7 +6208,7 @@ dependencies = [
  "ahash 0.8.12",
  "equivalent",
  "hashbrown 0.16.1",
- "parking_lot",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -6389,6 +6525,15 @@ dependencies = [
  "crc16",
  "log",
  "nom 7.1.3",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -7868,7 +8013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.12.5",
  "phf_shared 0.11.3",
  "precomputed-hash",
 ]
@@ -7880,7 +8025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.12.5",
  "phf_shared 0.13.1",
  "precomputed-hash",
 ]
@@ -7907,6 +8052,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -8048,7 +8199,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "object_store",
- "parking_lot",
+ "parking_lot 0.12.5",
  "path-clean",
  "pbkdf2",
  "phf 0.13.1",
@@ -8071,7 +8222,7 @@ dependencies = [
  "sha1",
  "sha2",
  "storekey",
- "strsim",
+ "strsim 0.11.1",
  "subtle",
  "surrealdb-protocol",
  "surrealdb-types",
@@ -8167,7 +8318,7 @@ dependencies = [
  "crossbeam-skiplist",
  "lz4",
  "papaya",
- "parking_lot",
+ "parking_lot 0.12.5",
  "serde",
  "smallvec",
  "thiserror 2.0.18",
@@ -8281,6 +8432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8328,6 +8488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5985fde5befe4ffa77a052e035e16c2da86e8bae301baa9f9904ad3c494d357"
 dependencies = [
  "testcontainers",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -8395,6 +8564,7 @@ dependencies = [
  "encoding_rs",
  "enumflags2",
  "futures-util",
+ "libgssapi",
  "num-traits",
  "once_cell",
  "pin-project-lite",
@@ -8472,7 +8642,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",
@@ -8880,7 +9050,7 @@ dependencies = [
  "cookie",
  "futures-util",
  "http 1.4.0",
- "parking_lot",
+ "parking_lot 0.12.5",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -9009,7 +9179,7 @@ dependencies = [
  "base64 0.22.1",
  "futures",
  "http 1.4.0",
- "parking_lot",
+ "parking_lot 0.12.5",
  "rand 0.8.6",
  "serde",
  "serde_json",
@@ -9531,6 +9701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9708,7 +9884,7 @@ checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot",
+ "parking_lot 0.12.5",
  "pin-utils",
  "wasm-bindgen",
 ]

--- a/README.md
+++ b/README.md
@@ -430,6 +430,52 @@ Choose exactly one primary database backend (enforced at compile time), and opti
 - **Turso / libsql** (`turso`) - Edge-replicated SQLite ([guide](https://govcraft.github.io/acton-service/docs/turso))
 - **SurrealDB** (`surrealdb`) - Multi-model database
 - **ClickHouse** (`clickhouse`) - Analytical database, composable with any primary backend ([guide](https://govcraft.github.io/acton-service/docs/clickhouse))
+
+SQL Server can authenticate as the service process instead of storing a SQL
+password in the connection string:
+
+```toml
+[dependencies]
+acton-service = { version = "0.37", features = ["mssql"] }
+
+[database]
+url = "server=tcp:sql.internal,1433;database=service;TrustServerCertificate=false"
+mssql_auth = "integrated"
+```
+
+On Windows this uses SSPI. On Unix it uses the process's Kerberos credentials
+through GSSAPI and therefore requires the host's realm, SPN, and keytab to be
+configured.
+
+For intranet user authentication, terminate Negotiate/Kerberos at a dedicated
+proxy and forward identity only over an allowlisted mTLS connection:
+
+```toml
+[dependencies]
+acton-service = { version = "0.37", features = ["windows-auth"] }
+
+[caller_auth]
+mode = "mtls-or-bearer"
+allowlist = ["windows-auth-gateway.internal"]
+
+[caller_auth.windows]
+trusted_proxies = ["windows-auth-gateway.internal"]
+identity_header = "x-windows-user"
+groups_header = "x-windows-groups"
+
+[caller_auth.windows.group_roles]
+"CONTOSO\\Platform Admins" = "admin"
+"CONTOSO\\Service Readers" = "reader"
+```
+
+The proxy is responsible for completing Negotiate authentication and must not
+forward an identity until it has validated the Kerberos or NTLM exchange. The
+identity headers are ignored unless the request carries a verified client
+certificate whose SAN is present in both allowlists. A trusted proxy that omits
+or supplies an invalid identity is rejected. Acton-service removes the forwarded
+headers after parsing them and exposes `WindowsIdentity` plus unified `Claims`
+to handlers and authorization middleware. Group names are matched exactly and
+the groups header is a comma-separated list with a maximum of 256 entries.
 - **Redis** (`cache`) - Connection pooling via deadpool ([guide](https://govcraft.github.io/acton-service/docs/cache))
 - **NATS JetStream** (`events`) - Event streaming ([guide](https://govcraft.github.io/acton-service/docs/events))
 
@@ -545,6 +591,7 @@ acton-service = { version = "0.37", features = ["grpc", "database", "cache"] }
 |---|---|
 | `jwt` | JWT validation middleware |
 | `auth` | Argon2 password hashing, token generation, API keys, key rotation |
+| `windows-auth` | Trusted-proxy Windows/AD identity over mutually authenticated TLS (implies `http` and `tls`) |
 | `oauth` | OAuth 2.0 / OIDC providers (implies `auth`) |
 | `auth-full` | Everything: auth + oauth + jwt + cache + database + lockout + accounts |
 | `cedar-authz` | AWS Cedar policy-based authorization |

--- a/acton-service/Cargo.toml
+++ b/acton-service/Cargo.toml
@@ -141,7 +141,7 @@ hyper-util = { version = "0.1.20", features = ["tokio"], optional = true }
 x509-parser = { version = "0.18.1", optional = true }
 bb8 = { version = "0.9.1", optional = true }
 bb8-tiberius = { version = "0.16.0", optional = true }
-tiberius = { version = "0.12.3", features = ["chrono"], optional = true }
+tiberius = { version = "0.12.3", features = ["chrono", "integrated-auth-gssapi"], optional = true }
 
 [features]
 default = ["http", "observability", "crypto-aws-lc-rs"]
@@ -172,6 +172,7 @@ grpc = ["dep:tonic", "dep:prost", "dep:tonic-prost", "dep:tonic-prost-build", "d
 database = ["dep:sqlx"]
 postgres = ["database"]
 mssql = ["dep:bb8", "dep:bb8-tiberius", "dep:tiberius"]
+windows-auth = ["http", "tls"]
 turso = ["dep:libsql"]
 surrealdb = ["dep:surrealdb"]
 cache = ["dep:redis", "dep:deadpool-redis"]

--- a/acton-service/src/config.rs
+++ b/acton-service/src/config.rs
@@ -453,6 +453,26 @@ pub struct DatabaseConfig {
     /// Whether to initialize connection lazily (in background)
     #[serde(default = "default_lazy_init")]
     pub lazy_init: bool,
+
+    /// Microsoft SQL Server authentication mode.
+    ///
+    /// Ignored by non-MSSQL backends. `integrated` authenticates as the
+    /// process identity through SSPI on Windows or GSSAPI/Kerberos on Unix.
+    #[cfg(feature = "mssql")]
+    #[serde(default)]
+    pub mssql_auth: MssqlAuthMode,
+}
+
+/// Authentication used by the Microsoft SQL Server connection pool.
+#[cfg(feature = "mssql")]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MssqlAuthMode {
+    /// Use the credentials encoded in the ADO connection string.
+    #[default]
+    ConnectionString,
+    /// Authenticate as the service process using SSPI or Kerberos/GSSAPI.
+    Integrated,
 }
 
 /// Turso/libsql connection mode
@@ -1050,6 +1070,12 @@ pub struct TlsConfig {
 /// treated as a URI SAN, anything else as a DNS SAN; there is no wildcard or
 /// suffix matching.
 ///
+/// With the `windows-auth` feature, an optional nested
+/// `[caller_auth.windows]` section can name mTLS-authenticated proxies that
+/// have already completed Negotiate authentication and may assert a Windows
+/// principal and Active Directory groups. This requires `mtls-or-bearer`;
+/// each trusted proxy must also appear in this section's `allowlist`.
+///
 /// Combinations that would look like protection without being it are refused
 /// at startup rather than accepted: a certificate mode with no
 /// `client_ca_path` on the listener it guards, an allowlist under
@@ -1079,6 +1105,15 @@ pub struct CallerAuthConfig {
     /// `/api-docs` on HTTP; the gRPC health and reflection services on gRPC).
     #[serde(default)]
     pub public_paths: Vec<String>,
+
+    /// Windows identity asserted by selected allowlisted mTLS proxies.
+    ///
+    /// The proxy, rather than acton-service, completes the Kerberos or NTLM
+    /// exchange. Forwarded identity headers are accepted only from a proxy in
+    /// both allowlists and are removed before application handlers run.
+    #[cfg(feature = "windows-auth")]
+    #[serde(default)]
+    pub windows: Option<crate::windows_auth::WindowsAuthConfig>,
 }
 
 #[cfg(feature = "tls")]
@@ -2393,6 +2428,8 @@ port = 9091
             mode: crate::caller_auth::CallerAuthMode::Bearer,
             allowlist: vec!["reporter.internal".to_string()],
             public_paths: Vec::new(),
+            #[cfg(feature = "windows-auth")]
+            windows: None,
         };
         assert_eq!(
             dead_allowlist
@@ -2405,6 +2442,8 @@ port = 9091
             mode: crate::caller_auth::CallerAuthMode::Mtls,
             allowlist: Vec::new(),
             public_paths: Vec::new(),
+            #[cfg(feature = "windows-auth")]
+            windows: None,
         };
         assert_eq!(
             empty_allowlist

--- a/acton-service/src/lib.rs
+++ b/acton-service/src/lib.rs
@@ -177,6 +177,9 @@ pub mod client_tls;
 #[cfg(feature = "tls")]
 pub mod caller_auth;
 
+#[cfg(feature = "windows-auth")]
+pub mod windows_auth;
+
 #[cfg(feature = "login-lockout")]
 pub mod lockout;
 
@@ -230,6 +233,9 @@ pub mod prelude {
     pub use crate::pool_health::DatabasePoolHealth;
     #[cfg(feature = "mssql")]
     pub use crate::pool_health::MssqlPoolHealth;
+
+    #[cfg(feature = "mssql")]
+    pub use crate::config::MssqlAuthMode;
 
     #[cfg(feature = "turso")]
     pub use crate::pool_health::TursoDbHealth;
@@ -297,6 +303,11 @@ pub mod prelude {
 
     #[cfg(feature = "tls")]
     pub use crate::config::CallerAuthConfig;
+
+    #[cfg(feature = "windows-auth")]
+    pub use crate::windows_auth::{
+        WindowsAuthConfig, WindowsAuthLayer, WindowsGroup, WindowsIdentity, WindowsPrincipal,
+    };
 
     #[cfg(all(feature = "cedar-authz", feature = "cache"))]
     pub use crate::middleware::{PolicyCache, RedisPolicyCache};

--- a/acton-service/src/mssql.rs
+++ b/acton-service/src/mssql.rs
@@ -34,7 +34,8 @@ pub async fn create_pool(config: &DatabaseConfig) -> Result<MssqlPool> {
 }
 
 async fn try_create_pool(config: &DatabaseConfig) -> Result<MssqlPool> {
-    let manager = ConnectionManager::build(config.url.as_str()).map_err(|error| {
+    let connection_config = connection_config(config)?;
+    let manager = ConnectionManager::build(connection_config).map_err(|error| {
         Error::Internal(format!(
             "invalid SQL Server connection configuration: {error}"
         ))
@@ -46,6 +47,27 @@ async fn try_create_pool(config: &DatabaseConfig) -> Result<MssqlPool> {
         .build(manager)
         .await
         .map_err(|error| Error::Internal(format!("failed to connect to SQL Server: {error}")))
+}
+
+fn connection_config(config: &DatabaseConfig) -> Result<tiberius::Config> {
+    let mut connection = tiberius::Config::from_ado_string(&config.url).map_err(|error| {
+        Error::Internal(format!(
+            "invalid SQL Server connection configuration: {error}"
+        ))
+    })?;
+
+    if let Some(auth) = auth_method(config.mssql_auth) {
+        connection.authentication(auth);
+    }
+
+    Ok(connection)
+}
+
+fn auth_method(mode: crate::config::MssqlAuthMode) -> Option<tiberius::AuthMethod> {
+    match mode {
+        crate::config::MssqlAuthMode::ConnectionString => None,
+        crate::config::MssqlAuthMode::Integrated => Some(tiberius::AuthMethod::Integrated),
+    }
 }
 
 /// Checks that SQL Server accepts and executes a query on a pooled connection.
@@ -97,4 +119,39 @@ fn pool_error(error: bb8::RunError<bb8_tiberius::Error>) -> Error {
 
 fn query_error(error: tiberius::error::Error) -> Error {
     Error::Internal(format!("SQL Server operation failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::MssqlAuthMode;
+
+    fn config(auth: MssqlAuthMode) -> DatabaseConfig {
+        DatabaseConfig {
+            url: "server=tcp:sql.internal,1433;database=app;user=sa;password=secret;TrustServerCertificate=true".to_string(),
+            max_connections: 5,
+            min_connections: 1,
+            connection_timeout_secs: 5,
+            max_retries: 0,
+            retry_delay_secs: 1,
+            optional: false,
+            lazy_init: false,
+            mssql_auth: auth,
+        }
+    }
+
+    #[test]
+    fn integrated_auth_overrides_connection_string_credentials() {
+        assert!(connection_config(&config(MssqlAuthMode::Integrated)).is_ok());
+        assert!(matches!(
+            auth_method(MssqlAuthMode::Integrated),
+            Some(tiberius::AuthMethod::Integrated)
+        ));
+    }
+
+    #[test]
+    fn connection_string_auth_is_preserved() {
+        assert!(connection_config(&config(MssqlAuthMode::ConnectionString)).is_ok());
+        assert!(auth_method(MssqlAuthMode::ConnectionString).is_none());
+    }
 }

--- a/acton-service/src/service_builder.rs
+++ b/acton-service/src/service_builder.rs
@@ -1765,6 +1765,41 @@ where
             None => None,
         };
 
+        // Applied in this source position so execution order is caller-auth,
+        // Windows identity, then bearer-token authentication.
+        #[cfg(feature = "windows-auth")]
+        if let Some(windows_auth_config) = config
+            .caller_auth
+            .as_ref()
+            .and_then(|caller_auth| caller_auth.windows.as_ref())
+        {
+            let windows_auth = windows_auth_config.to_layer().and_then(|layer| {
+                let policy = caller_auth_policy
+                    .as_ref()
+                    .ok_or(crate::windows_auth::WindowsAuthConfigError::RequiresMtlsOrBearer)?;
+                layer.validate_caller_policy(policy)?;
+                Ok(layer)
+            });
+
+            match windows_auth {
+                Ok(layer) => {
+                    tracing::debug!("Auto-applying trusted-proxy Windows authentication");
+                    app = app.layer(axum::middleware::from_fn_with_state(
+                        layer,
+                        crate::windows_auth::WindowsAuthLayer::middleware,
+                    ));
+                }
+                Err(error) => {
+                    let error = crate::error::Error::Internal(format!(
+                        "[caller_auth.windows] is invalid; refusing to start without Windows identity \
+                         verification: {error}"
+                    ));
+                    tracing::error!("{error}");
+                    record_startup_error(&mut startup_error, error);
+                }
+            }
+        }
+
         #[cfg(feature = "tls")]
         if let Some(ref policy) = caller_auth_policy {
             if policy.requires_client_ca() {
@@ -3282,6 +3317,8 @@ mod tests {
                     mode: crate::caller_auth::CallerAuthMode::Mtls,
                     allowlist: vec!["reporter.internal".to_string()],
                     public_paths: Vec::new(),
+                    #[cfg(feature = "windows-auth")]
+                    windows: None,
                 }),
                 ..Default::default()
             })
@@ -3314,6 +3351,8 @@ mod tests {
                     mode: crate::caller_auth::CallerAuthMode::MtlsOrBearer,
                     allowlist: vec!["reporter.internal".to_string()],
                     public_paths: Vec::new(),
+                    #[cfg(feature = "windows-auth")]
+                    windows: None,
                 }),
                 ..Default::default()
             })
@@ -3341,6 +3380,8 @@ mod tests {
                     mode: crate::caller_auth::CallerAuthMode::Bearer,
                     allowlist: vec!["reporter.internal".to_string()],
                     public_paths: Vec::new(),
+                    #[cfg(feature = "windows-auth")]
+                    windows: None,
                 }),
                 ..Default::default()
             })
@@ -3376,6 +3417,8 @@ mod tests {
                     mode: crate::caller_auth::CallerAuthMode::Mtls,
                     allowlist: vec!["reporter.internal".to_string()],
                     public_paths: Vec::new(),
+                    #[cfg(feature = "windows-auth")]
+                    windows: None,
                 }),
                 ..Default::default()
             })

--- a/acton-service/src/windows_auth.rs
+++ b/acton-service/src/windows_auth.rs
@@ -1,0 +1,574 @@
+//! Windows/Active Directory identity forwarded by a mutually authenticated proxy.
+//!
+//! This module does not trust identity headers on their own. A request must
+//! first carry a [`crate::caller_auth::CallerIdentity`] created
+//! from a verified, allowlisted client certificate, and that certificate must
+//! identify one of the explicitly configured Windows-auth proxies.
+//! The proxy is responsible for completing and validating the Negotiate
+//! exchange before asserting a principal.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt;
+
+use axum::extract::{Request, State};
+use axum::http::header::HeaderName;
+use axum::middleware::Next;
+use axum::response::Response;
+use serde::{Deserialize, Serialize};
+
+use crate::caller_auth::{CallerAllowlist, CallerIdentity};
+use crate::error::{Error, Result};
+use crate::middleware::token::Claims;
+
+const DEFAULT_IDENTITY_HEADER: &str = "x-windows-user";
+const DEFAULT_GROUPS_HEADER: &str = "x-windows-groups";
+const MAX_PRINCIPAL_LEN: usize = 512;
+const MAX_GROUP_LEN: usize = 512;
+const MAX_GROUPS: usize = 256;
+
+/// Configuration for Windows identities forwarded by an mTLS proxy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsAuthConfig {
+    /// Certificate SANs of proxies allowed to assert Windows identities.
+    pub trusted_proxies: Vec<String>,
+    /// Header containing `DOMAIN\user`, `user@domain`, or a local username.
+    #[serde(default = "default_identity_header")]
+    pub identity_header: String,
+    /// Optional comma-separated Active Directory group header.
+    #[serde(default = "default_groups_header")]
+    pub groups_header: String,
+    /// Exact AD-group-to-application-role mappings.
+    #[serde(default)]
+    pub group_roles: BTreeMap<String, String>,
+}
+
+impl WindowsAuthConfig {
+    /// Validate the configuration and build middleware state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an empty/invalid proxy allowlist, invalid header
+    /// names, or malformed group-to-role mappings.
+    pub fn to_layer(&self) -> std::result::Result<WindowsAuthLayer, WindowsAuthConfigError> {
+        let trusted_proxies = CallerAllowlist::from_entries(&self.trusted_proxies)
+            .map_err(|error| WindowsAuthConfigError::TrustedProxy(error.to_string()))?;
+        let identity_header = parse_header_name("identity_header", &self.identity_header)?;
+        let groups_header = parse_header_name("groups_header", &self.groups_header)?;
+
+        for (group, role) in &self.group_roles {
+            WindowsGroup::new(group.clone())
+                .map_err(|error| WindowsAuthConfigError::InvalidGroupMapping(error.to_string()))?;
+            validate_role(role)?;
+        }
+
+        Ok(WindowsAuthLayer {
+            trusted_proxies,
+            identity_header,
+            groups_header,
+            group_roles: self.group_roles.clone(),
+        })
+    }
+}
+
+fn default_identity_header() -> String {
+    DEFAULT_IDENTITY_HEADER.to_owned()
+}
+
+fn default_groups_header() -> String {
+    DEFAULT_GROUPS_HEADER.to_owned()
+}
+
+fn parse_header_name(
+    field: &'static str,
+    value: &str,
+) -> std::result::Result<HeaderName, WindowsAuthConfigError> {
+    value
+        .parse()
+        .map_err(|_| WindowsAuthConfigError::InvalidHeader {
+            field,
+            value: value.to_owned(),
+        })
+}
+
+fn validate_role(role: &str) -> std::result::Result<(), WindowsAuthConfigError> {
+    if role.is_empty() || role.chars().any(char::is_whitespace) {
+        return Err(WindowsAuthConfigError::InvalidRole(role.to_owned()));
+    }
+    Ok(())
+}
+
+/// Invalid trusted-proxy Windows authentication configuration.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum WindowsAuthConfigError {
+    /// The trusted proxy allowlist is invalid.
+    #[error("invalid Windows-auth trusted proxy allowlist: {0}")]
+    TrustedProxy(String),
+    /// A configured header name is invalid.
+    #[error("[caller_auth.windows].{field} '{value}' is not a valid HTTP header name")]
+    InvalidHeader {
+        /// Configuration field.
+        field: &'static str,
+        /// Invalid value.
+        value: String,
+    },
+    /// A group mapping contains an invalid group.
+    #[error("invalid Windows-auth group mapping: {0}")]
+    InvalidGroupMapping(String),
+    /// A role is empty or contains whitespace.
+    #[error("Windows-auth role '{0}' must be non-empty and contain no whitespace")]
+    InvalidRole(String),
+    /// The outer mode cannot safely replace bearer auth with a proxy identity.
+    #[error("[caller_auth.windows] requires [caller_auth].mode = 'mtls-or-bearer'")]
+    RequiresMtlsOrBearer,
+    /// A trusted proxy is absent from the outer certificate allowlist.
+    #[error("Windows-auth proxy '{0}' is not present in [caller_auth].allowlist")]
+    ProxyNotAllowed(String),
+}
+
+/// A validated Windows principal name.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WindowsPrincipal(String);
+
+impl WindowsPrincipal {
+    /// Validate a Windows principal.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, overlong, surrounding-whitespace, control-character,
+    /// comma, and path-like values.
+    pub fn new(value: impl Into<String>) -> std::result::Result<Self, WindowsIdentityError> {
+        let value = value.into();
+        validate_identity_value("principal", &value, MAX_PRINCIPAL_LEN)?;
+        if value.contains(',') || value.contains('/') || value == "." || value == ".." {
+            return Err(WindowsIdentityError::InvalidPrincipal(value));
+        }
+        let valid_qualified_form = if value.contains('\\') {
+            let mut parts = value.split('\\');
+            matches!((parts.next(), parts.next(), parts.next()), (Some(domain), Some(user), None) if !domain.is_empty() && !user.is_empty())
+        } else if value.contains('@') {
+            let mut parts = value.split('@');
+            matches!((parts.next(), parts.next(), parts.next()), (Some(user), Some(domain), None) if !user.is_empty() && !domain.is_empty())
+        } else {
+            true
+        };
+        if !valid_qualified_form {
+            return Err(WindowsIdentityError::InvalidPrincipal(value));
+        }
+        Ok(Self(value))
+    }
+
+    /// The exact principal asserted by the trusted proxy.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for WindowsPrincipal {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// A validated Active Directory group name.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WindowsGroup(String);
+
+impl WindowsGroup {
+    /// Validate an Active Directory group name.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, overlong, surrounding-whitespace, control-character,
+    /// and comma-containing values.
+    pub fn new(value: impl Into<String>) -> std::result::Result<Self, WindowsIdentityError> {
+        let value = value.into();
+        validate_identity_value("group", &value, MAX_GROUP_LEN)?;
+        if value.contains(',') {
+            return Err(WindowsIdentityError::InvalidGroup(value));
+        }
+        Ok(Self(value))
+    }
+
+    /// The exact group name asserted by the trusted proxy.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for WindowsGroup {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+fn validate_identity_value(
+    kind: &'static str,
+    value: &str,
+    maximum: usize,
+) -> std::result::Result<(), WindowsIdentityError> {
+    if value.is_empty() {
+        return Err(WindowsIdentityError::Empty(kind));
+    }
+    if value.len() > maximum {
+        return Err(WindowsIdentityError::TooLong {
+            kind,
+            length: value.len(),
+            maximum,
+        });
+    }
+    if value.trim() != value || value.chars().any(char::is_control) {
+        return Err(WindowsIdentityError::IllegalCharacter(kind));
+    }
+    Ok(())
+}
+
+/// A Windows identity established by a trusted proxy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowsIdentity {
+    principal: WindowsPrincipal,
+    groups: Vec<WindowsGroup>,
+}
+
+impl WindowsIdentity {
+    /// The authenticated domain principal.
+    #[must_use]
+    pub fn principal(&self) -> &WindowsPrincipal {
+        &self.principal
+    }
+
+    /// Active Directory groups asserted for the principal.
+    #[must_use]
+    pub fn groups(&self) -> &[WindowsGroup] {
+        &self.groups
+    }
+}
+
+/// Invalid identity data received from a trusted proxy.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum WindowsIdentityError {
+    /// A required value was empty.
+    #[error("Windows {0} is empty")]
+    Empty(&'static str),
+    /// A value exceeded its defensive size limit.
+    #[error("Windows {kind} is {length} bytes, over the {maximum}-byte limit")]
+    TooLong {
+        /// Kind of identity value.
+        kind: &'static str,
+        /// Actual length.
+        length: usize,
+        /// Maximum accepted length.
+        maximum: usize,
+    },
+    /// A value contains surrounding whitespace or control characters.
+    #[error("Windows {0} contains illegal whitespace or control characters")]
+    IllegalCharacter(&'static str),
+    /// A principal has an ambiguous or unsafe shape.
+    #[error("Windows principal '{0}' has an invalid form")]
+    InvalidPrincipal(String),
+    /// A group contains the configured delimiter.
+    #[error("Windows group '{0}' contains a comma")]
+    InvalidGroup(String),
+    /// Too many groups were forwarded.
+    #[error("Windows identity has {count} groups, over the {maximum}-group limit")]
+    TooManyGroups {
+        /// Actual group count.
+        count: usize,
+        /// Maximum accepted count.
+        maximum: usize,
+    },
+}
+
+/// Middleware state for trusted-proxy Windows authentication.
+#[derive(Debug, Clone)]
+pub struct WindowsAuthLayer {
+    trusted_proxies: CallerAllowlist,
+    identity_header: HeaderName,
+    groups_header: HeaderName,
+    group_roles: BTreeMap<String, String>,
+}
+
+impl WindowsAuthLayer {
+    /// Check that this layer is safely nested inside the caller-auth policy.
+    ///
+    /// # Errors
+    ///
+    /// Windows proxy authentication requires `mtls-or-bearer`, and every
+    /// trusted proxy must also occur in the outer certificate allowlist.
+    pub fn validate_caller_policy(
+        &self,
+        policy: &crate::caller_auth::CallerAuthPolicy,
+    ) -> std::result::Result<(), WindowsAuthConfigError> {
+        if policy.mode() != crate::caller_auth::CallerAuthMode::MtlsOrBearer {
+            return Err(WindowsAuthConfigError::RequiresMtlsOrBearer);
+        }
+        let Some(outer) = policy.allowlist() else {
+            return Err(WindowsAuthConfigError::RequiresMtlsOrBearer);
+        };
+        for proxy in &self.trusted_proxies {
+            if !outer.iter().any(|allowed| allowed == proxy) {
+                return Err(WindowsAuthConfigError::ProxyNotAllowed(proxy.to_string()));
+            }
+        }
+        Ok(())
+    }
+
+    /// Authenticate a forwarded Windows identity when the request came from a
+    /// configured, mutually authenticated proxy.
+    pub async fn middleware(
+        State(auth): State<Self>,
+        mut request: Request,
+        next: Next,
+    ) -> Result<Response> {
+        let trusted = request
+            .extensions()
+            .get::<CallerIdentity>()
+            .is_some_and(|caller| auth.trusted_proxies.iter().any(|san| san == caller.san()));
+
+        if !trusted {
+            // Never let application code accidentally consume an unverified
+            // identity assertion, even on a valid bearer-authenticated request.
+            auth.strip_identity_headers(request.headers_mut());
+            return Ok(next.run(request).await);
+        }
+
+        let identity = auth.identity_from_headers(request.headers())?;
+        let claims = auth.claims(&identity);
+
+        auth.strip_identity_headers(request.headers_mut());
+        request.extensions_mut().insert(claims);
+        request.extensions_mut().insert(identity);
+
+        Ok(next.run(request).await)
+    }
+
+    fn identity_from_headers(
+        &self,
+        headers: &http::HeaderMap,
+    ) -> std::result::Result<WindowsIdentity, Error> {
+        let principal = headers
+            .get(&self.identity_header)
+            .ok_or_else(|| {
+                Error::Unauthorized(
+                    "trusted Windows-auth proxy omitted the identity header".to_owned(),
+                )
+            })?
+            .to_str()
+            .map_err(|_| {
+                Error::Unauthorized("Windows identity header is not valid text".to_owned())
+            })?;
+        let principal = WindowsPrincipal::new(principal.to_owned())
+            .map_err(|error| Error::Unauthorized(error.to_string()))?;
+
+        let groups = match headers.get(&self.groups_header) {
+            None => Vec::new(),
+            Some(value) => {
+                let value = value.to_str().map_err(|_| {
+                    Error::Unauthorized("Windows groups header is not valid text".to_owned())
+                })?;
+                parse_groups(value).map_err(|error| Error::Unauthorized(error.to_string()))?
+            }
+        };
+
+        Ok(WindowsIdentity { principal, groups })
+    }
+
+    fn claims(&self, identity: &WindowsIdentity) -> Claims {
+        let roles: BTreeSet<String> = identity
+            .groups
+            .iter()
+            .filter_map(|group| self.group_roles.get(group.as_str()).cloned())
+            .collect();
+        let group_names: Vec<&str> = identity.groups.iter().map(WindowsGroup::as_str).collect();
+        let mut custom = HashMap::new();
+        custom.insert(
+            "authentication_method".to_owned(),
+            serde_json::Value::String("windows".to_owned()),
+        );
+        custom.insert("windows_groups".to_owned(), serde_json::json!(group_names));
+
+        Claims {
+            sub: format!("windows:{}", identity.principal),
+            email: identity
+                .principal
+                .as_str()
+                .contains('@')
+                .then(|| identity.principal.to_string()),
+            username: Some(identity.principal.to_string()),
+            roles: roles.into_iter().collect(),
+            perms: Vec::new(),
+            exp: i64::MAX,
+            iat: Some(chrono::Utc::now().timestamp()),
+            jti: None,
+            iss: Some("windows-auth-proxy".to_owned()),
+            aud: None,
+            custom,
+        }
+    }
+
+    fn strip_identity_headers(&self, headers: &mut http::HeaderMap) {
+        headers.remove(&self.identity_header);
+        headers.remove(&self.groups_header);
+    }
+}
+
+fn parse_groups(value: &str) -> std::result::Result<Vec<WindowsGroup>, WindowsIdentityError> {
+    if value.is_empty() {
+        return Ok(Vec::new());
+    }
+    let entries: Vec<&str> = value.split(',').collect();
+    if entries.len() > MAX_GROUPS {
+        return Err(WindowsIdentityError::TooManyGroups {
+            count: entries.len(),
+            maximum: MAX_GROUPS,
+        });
+    }
+
+    entries
+        .into_iter()
+        .map(|entry| WindowsGroup::new(entry.trim().to_owned()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn principal_accepts_domain_and_upn_forms() {
+        assert!(WindowsPrincipal::new("CONTOSO\\alice").is_ok());
+        assert!(WindowsPrincipal::new("alice@contoso.example").is_ok());
+    }
+
+    #[test]
+    fn principal_rejects_ambiguous_values() {
+        assert!(WindowsPrincipal::new(" alice").is_err());
+        assert!(WindowsPrincipal::new("alice,bob").is_err());
+        assert!(WindowsPrincipal::new("../alice").is_err());
+        assert!(WindowsPrincipal::new("CONTOSO\\").is_err());
+        assert!(WindowsPrincipal::new("alice@@contoso.example").is_err());
+    }
+
+    #[test]
+    fn groups_are_trimmed_and_deduplicated_by_role_mapping() {
+        let groups = parse_groups("CONTOSO\\Admins, CONTOSO\\Readers");
+        assert_eq!(groups.map(|items| items.len()), Ok(2));
+    }
+
+    #[test]
+    fn config_rejects_invalid_header_names() {
+        let config = WindowsAuthConfig {
+            trusted_proxies: vec!["proxy.internal".to_owned()],
+            identity_header: "not a header".to_owned(),
+            groups_header: default_groups_header(),
+            group_roles: BTreeMap::new(),
+        };
+        assert!(matches!(
+            config.to_layer(),
+            Err(WindowsAuthConfigError::InvalidHeader { .. })
+        ));
+    }
+
+    #[test]
+    fn proxy_must_be_in_outer_mtls_or_bearer_allowlist() {
+        let config = WindowsAuthConfig {
+            trusted_proxies: vec!["proxy.internal".to_owned()],
+            identity_header: default_identity_header(),
+            groups_header: default_groups_header(),
+            group_roles: BTreeMap::new(),
+        };
+        let layer = config.to_layer().expect("valid Windows auth config");
+        let allowed =
+            CallerAllowlist::from_entries(["proxy.internal"]).expect("valid outer allowlist");
+        assert!(layer
+            .validate_caller_policy(&crate::caller_auth::CallerAuthPolicy::mtls_or_bearer(
+                allowed
+            ))
+            .is_ok());
+
+        let other =
+            CallerAllowlist::from_entries(["other.internal"]).expect("valid outer allowlist");
+        assert!(matches!(
+            layer.validate_caller_policy(&crate::caller_auth::CallerAuthPolicy::mtls_or_bearer(
+                other
+            )),
+            Err(WindowsAuthConfigError::ProxyNotAllowed(_))
+        ));
+    }
+
+    #[test]
+    fn windows_groups_map_to_unified_claim_roles() {
+        let mut group_roles = BTreeMap::new();
+        group_roles.insert("CONTOSO\\Platform Admins".to_owned(), "admin".to_owned());
+        group_roles.insert("CONTOSO\\Readers".to_owned(), "reader".to_owned());
+        let layer = WindowsAuthConfig {
+            trusted_proxies: vec!["proxy.internal".to_owned()],
+            identity_header: default_identity_header(),
+            groups_header: default_groups_header(),
+            group_roles,
+        }
+        .to_layer()
+        .expect("valid Windows auth config");
+        let identity = WindowsIdentity {
+            principal: WindowsPrincipal::new("alice@contoso.example").expect("valid principal"),
+            groups: parse_groups("CONTOSO\\Readers,CONTOSO\\Platform Admins,CONTOSO\\Other")
+                .expect("valid groups"),
+        };
+
+        let claims = layer.claims(&identity);
+        assert_eq!(claims.sub, "windows:alice@contoso.example");
+        assert_eq!(claims.email.as_deref(), Some("alice@contoso.example"));
+        assert_eq!(claims.roles, ["admin", "reader"]);
+        assert_eq!(
+            claims
+                .custom_claim("authentication_method")
+                .and_then(serde_json::Value::as_str),
+            Some("windows")
+        );
+    }
+
+    #[test]
+    fn missing_identity_from_a_trusted_proxy_fails_closed() {
+        let layer = WindowsAuthConfig {
+            trusted_proxies: vec!["proxy.internal".to_owned()],
+            identity_header: default_identity_header(),
+            groups_header: default_groups_header(),
+            group_roles: BTreeMap::new(),
+        }
+        .to_layer()
+        .expect("valid Windows auth config");
+
+        assert!(matches!(
+            layer.identity_from_headers(&http::HeaderMap::new()),
+            Err(Error::Unauthorized(_))
+        ));
+    }
+
+    #[test]
+    fn forwarded_identity_headers_are_removed_before_application_code() {
+        let layer = WindowsAuthConfig {
+            trusted_proxies: vec!["proxy.internal".to_owned()],
+            identity_header: default_identity_header(),
+            groups_header: default_groups_header(),
+            group_roles: BTreeMap::new(),
+        }
+        .to_layer()
+        .expect("valid Windows auth config");
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            DEFAULT_IDENTITY_HEADER,
+            "CONTOSO\\alice".parse().expect("header"),
+        );
+        headers.insert(
+            DEFAULT_GROUPS_HEADER,
+            "CONTOSO\\Readers".parse().expect("header"),
+        );
+
+        layer.strip_identity_headers(&mut headers);
+
+        assert!(!headers.contains_key(DEFAULT_IDENTITY_HEADER));
+        assert!(!headers.contains_key(DEFAULT_GROUPS_HEADER));
+    }
+}

--- a/acton-service/tests/mssql_integration.rs
+++ b/acton-service/tests/mssql_integration.rs
@@ -9,7 +9,7 @@ async fn mssql_backends_initialize_and_accounts_round_trip(){
  let container=MssqlServer::default().with_accept_eula().start().await.expect("start SQL Server container");
  let host=container.get_host().await.expect("container host");
  let port=container.get_host_port_ipv4(1433).await.expect("container port");
- let config=DatabaseConfig{url:format!("Server=tcp:{host},{port};Database=master;User Id=sa;Password={};TrustServerCertificate=True;",MssqlServer::DEFAULT_SA_PASSWORD),max_connections:5,min_connections:1,connection_timeout_secs:30,max_retries:10,retry_delay_secs:2,optional:false,lazy_init:false};
+    let config=DatabaseConfig{url:format!("Server=tcp:{host},{port};Database=master;User Id=sa;Password={};TrustServerCertificate=True;",MssqlServer::DEFAULT_SA_PASSWORD),max_connections:5,min_connections:1,connection_timeout_secs:30,max_retries:10,retry_delay_secs:2,optional:false,lazy_init:false,mssql_auth:acton_service::config::MssqlAuthMode::ConnectionString};
  let pool=mssql::create_pool(&config).await.expect("SQL Server pool");
  mssql::health_check(&pool).await.expect("health query");
  let accounts=MssqlAccountStorage::new(pool.clone()).await.expect("accounts schema");


### PR DESCRIPTION
## Summary

- add SQL Server Integrated Authentication through SSPI on Windows and Kerberos/GSSAPI on Unix
- add trusted-proxy Windows/AD application identity over allowlisted mutual TLS
- map validated AD groups into unified application claims and roles
- document deployment requirements and add Windows/Linux CI coverage

## Validation

- `cargo clippy -p acton-service --all-targets --no-default-features --features "mssql,http,grpc,auth,accounts,audit,observability,tls,windows-auth,crypto-aws-lc-rs" -- -D warnings`
- `cargo nextest run -p acton-service --no-default-features --features "mssql,http,grpc,auth,accounts,audit,observability,tls,windows-auth,crypto-aws-lc-rs"` (545 passed)
- `cargo nextest run -p acton-service --no-default-features --features "http,tls,windows-auth,crypto-aws-lc-rs" -E "test(/windows_auth/)"` (8 passed)
- SQL Server 2022 Testcontainers integration test
- `cargo audit` and `cargo deny --all-features check advisories`