### PR TITLE
chore(release): prepare 0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [acton-service-v0.38.0] - 2026-08-25
+
+This release adds native Windows portability, first-class Microsoft SQL Server
+storage parity, SQL Server Integrated Authentication, and trusted-proxy
+Windows/Active Directory application identities over mutual TLS.
+
 ### Added
 
 - **auth(windows)**: Added trusted-proxy Windows/Active Directory authentication

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "acton-cli"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "acton-service",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["acton-service", "acton-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 authors = ["roland@govcraft.ai"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -436,8 +436,12 @@ password in the connection string:
 
 ```toml
 [dependencies]
-acton-service = { version = "0.37", features = ["mssql"] }
+acton-service = { version = "0.38", features = ["mssql"] }
+```
 
+Then select integrated authentication in the service configuration:
+
+```toml
 [database]
 url = "server=tcp:sql.internal,1433;database=service;TrustServerCertificate=false"
 mssql_auth = "integrated"
@@ -452,8 +456,13 @@ proxy and forward identity only over an allowlisted mTLS connection:
 
 ```toml
 [dependencies]
-acton-service = { version = "0.37", features = ["windows-auth"] }
+acton-service = { version = "0.38", features = ["windows-auth"] }
+```
 
+Configure the trusted proxy and its exact group-to-role mappings in the service
+configuration:
+
+```toml
 [caller_auth]
 mode = "mtls-or-bearer"
 allowlist = ["windows-auth-gateway.internal"]
@@ -553,7 +562,7 @@ Defaults: `http`, `observability`, `crypto-aws-lc-rs`. Enable only what you need
 
 ```toml
 [dependencies]
-acton-service = { version = "0.37", features = ["grpc", "database", "cache"] }
+acton-service = { version = "0.38", features = ["grpc", "database", "cache"] }
 ```
 
 **Transports & protocols**
@@ -629,7 +638,7 @@ Or use `full` to enable everything (with PostgreSQL as the database backend):
 
 ```toml
 [dependencies]
-acton-service = { version = "0.37", features = ["full"] }
+acton-service = { version = "0.38", features = ["full"] }
 ```
 
 See the [Feature Flags guide](https://govcraft.github.io/acton-service/docs/feature-flags) for a decision tree.
@@ -646,7 +655,7 @@ that `aws-lc-rs` requires at build time:
 
 ```toml
 [dependencies]
-acton-service = { version = "0.37", default-features = false, features = [
+acton-service = { version = "0.38", default-features = false, features = [
     "http",
     "observability",
     "crypto-ring",

--- a/acton-cli/Cargo.toml
+++ b/acton-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-acton-service = { path = "../acton-service", version = "0.37.0" }
+acton-service = { path = "../acton-service", version = "0.38.0" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/acton-docs/src/lib/version.ts
+++ b/acton-docs/src/lib/version.ts
@@ -2,4 +2,4 @@
  * Version information for acton-service
  * This should match the version in the root Cargo.toml workspace.package.version
  */
-export const VERSION = '0.37.0'
+export const VERSION = '0.38.0'

--- a/acton-docs/src/markdoc/config.js
+++ b/acton-docs/src/markdoc/config.js
@@ -4,7 +4,7 @@ import { siteConfig } from '../lib/config'
 
 // Extract version from workspace Cargo.toml
 // This should be kept in sync with the workspace version
-const ACTON_VERSION = '0.37.0'
+const ACTON_VERSION = '0.38.0'
 
 // Single source of truth mapping camelCase aliases to the real Cargo feature
 // lists. Used by both the `dep()` function and the `$dep.*` variables so a

--- a/acton-docs/src/markdoc/functions.js
+++ b/acton-docs/src/markdoc/functions.js
@@ -1,5 +1,5 @@
 // Markdoc functions for version management
-const ACTON_VERSION = '0.37.0'
+const ACTON_VERSION = '0.38.0'
 
 export const version = {
   transform() {


### PR DESCRIPTION
## Summary

- bump the workspace and acton-cli dependency to 0.38.0
- date the changelog for the Windows, MSSQL, and Windows-auth release
- synchronize README and documentation version references

## Validation

- `cargo nextest run --workspace` (168 passed)
- release package verification will run from the clean committed tree